### PR TITLE
fix: security audit remediation

### DIFF
--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
@@ -30,10 +30,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.Comparator;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -563,7 +560,7 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
         StringBuilder keyBuilder = new StringBuilder(uri.toString());
 
         // Filter first, then sort for consistent cache keys
-        var filteredEntries = new java.util.ArrayList<Map.Entry<String, String>>();
+        var filteredEntries = new ArrayList<Map.Entry<String, String>>();
         for (Map.Entry<String, String> entry : headers.entrySet()) {
             if (filter.includeInCacheKey(entry.getKey())) {
                 filteredEntries.add(entry);

--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java
@@ -139,7 +139,8 @@ public final class HttpHandler {
         this.connectionTimeoutSeconds = connectionTimeoutSeconds;
         this.readTimeoutSeconds = readTimeoutSeconds;
 
-        // Create the HttpClient for HTTPS
+        // JDK 11+ HttpClient enables hostname verification by default.
+        // We intentionally omit explicit SSLParameters to preserve caller flexibility.
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(connectionTimeoutSeconds))
                 .sslContext(sslContext)

--- a/cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java
@@ -18,10 +18,10 @@ package de.cuioss.http.security.data;
 import de.cuioss.http.security.config.SecurityConfiguration;
 import de.cuioss.http.security.core.ValidationType;
 import de.cuioss.http.security.validation.CharacterValidationStage;
+import de.cuioss.tools.string.Splitter;
 import org.jspecify.annotations.Nullable;
 
-import de.cuioss.tools.string.Splitter;
-
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -319,7 +319,7 @@ String attributes) {
         if (!hasAttributes()) {
             return List.of();
         }
-        var result = new java.util.ArrayList<String>();
+        var result = new ArrayList<String>();
         for (String attr : Splitter.on(';').trimResults().omitEmptyStrings().splitToList(attributes)) {
             int equalIndex = attr.indexOf('=');
             result.add(equalIndex > 0 ? attr.substring(0, equalIndex).trim() : attr);

--- a/cui-http-core/src/main/java/de/cuioss/http/security/exceptions/UrlSecurityException.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/exceptions/UrlSecurityException.java
@@ -189,7 +189,7 @@ public class UrlSecurityException extends RuntimeException {
                 ", validationType=" + validationType +
                 ", originalInput='" + truncateForLogging(originalInput) + '\'' +
                 ", sanitizedInput='" + (sanitizedInput != null ? truncateForLogging(sanitizedInput) : null) + '\'' +
-                ", detail='" + detail + '\'' +
+                ", detail='" + (detail != null ? truncateForLogging(detail) : null) + '\'' +
                 ", cause=" + getCause() +
                 '}';
     }

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
@@ -163,9 +163,13 @@ public final class CharacterValidationStage implements HttpSecurityValidator {
         while (i < value.length()) {
             char ch = value.charAt(i);
 
-            // Check for null byte FIRST (highest priority security check)
+            // Check for null byte FIRST (highest priority security check).
+            // Self-contained: skip remaining loop body so future reordering
+            // cannot inadvertently process a null byte through other checks.
             if (ch == '\0') {
                 handleNullByte(value, i);
+                i++;
+                continue;
             }
 
             // Handle percent encoding

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
@@ -158,6 +158,7 @@ public final class CharacterValidationStage implements HttpSecurityValidator {
      * @param value The string to validate
      * @throws UrlSecurityException if any character validation fails
      */
+    @SuppressWarnings("java:S135")
     private void validateCharacters(String value) throws UrlSecurityException {
         int i = 0;
         while (i < value.length()) {


### PR DESCRIPTION
- Apply truncateForLogging() to detail field in UrlSecurityException.toString() for log injection defense\n- Self-contained null byte handling with continue in CharacterValidationStage\n- Document JDK 11+ default hostname verification in HttpHandler, remove explicit SSLParameters to preserve caller flexibility