### PR TITLE
docs: fix source paths, class names, and API examples

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,7 +59,7 @@ Test artifact:
 
 xref:doc/security-readme.adoc[Security Validation Framework]:
 
-* Validation pipelines for paths, parameters, headers, bodies
+* Validation pipelines for paths, parameters, headers
 * Attack pattern detection (path traversal, parameter injection, protocol violations)
 * Configuration via `SecurityConfigurationBuilder`
 

--- a/doc/LogMessages.adoc
+++ b/doc/LogMessages.adoc
@@ -77,6 +77,48 @@ LogMessages Classes:
 |SSL
 |Provided SSL context uses insecure protocol: %s. Creating a secure context instead.
 |Logged when a provided SSL context uses an insecure protocol and is replaced with a secure one. Parameters: insecure protocol name (e.g., TLSv1.0, TLSv1.1, SSLv3).
+
+|HTTP-110
+|Retry
+|Skipping retry for non-idempotent method: %s (idempotentOnly=true)
+|Logged when retry is skipped because the HTTP method is not idempotent and idempotentOnly is enabled. Parameters: HTTP method name.
+
+|HTTP-111
+|Handler
+|%s request failed after %s attempts
+|Logged when all retry attempts are exhausted. Parameters: HTTP method, maximum attempts.
+
+|HTTP-112
+|Handler
+|%s request failed on attempt %s, retrying after %sms
+|Logged when a request fails and a retry is scheduled with backoff. Parameters: HTTP method, failed attempt number, delay in milliseconds.
+
+|HTTP-113
+|Handler
+|Response conversion failed for status %s
+|Logged when converting HTTP response content fails. Parameters: HTTP status code.
+
+|HTTP-114
+|Handler
+|Network error during %s request: %s
+|Logged when a network error occurs during an HTTP request. Parameters: HTTP method, error message.
+|===
+
+== ERROR Level (200-299)
+
+[cols="1,2,3,3", options="header"]
+|===
+|ID |Component |Message |Description
+
+|HTTP-200
+|Handler
+|Configuration error during %s request: %s
+|Logged when a configuration error prevents an HTTP request from being executed. Parameters: HTTP method, error message.
+
+|HTTP-201
+|Handler
+|Failed to build HTTP request for %s: %s
+|Logged when building an HTTP request fails. Parameters: URL, error message.
 |===
 
 == Notes

--- a/doc/client-handlers-readme.adoc
+++ b/doc/client-handlers-readme.adoc
@@ -25,7 +25,7 @@ HTTP client utilities for request execution, SSL/TLS context management, and HTT
 
 === Core HTTP Handlers
 
-==== xref:../src/main/java/de/cuioss/http/client/handler/HttpHandler.java[HttpHandler]
+==== xref:../cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java[HttpHandler]
 
 Builder-based HTTP client wrapper with automatic SSL context creation for HTTPS.
 
@@ -34,7 +34,7 @@ Builder-based HTTP client wrapper with automatic SSL context creation for HTTPS.
 * Configurable connection and read timeouts (default: 10 seconds)
 * Thread-safe after construction
 
-==== xref:../src/main/java/de/cuioss/http/client/adapter/package-info.java[HTTP Adapters (New Architecture)]
+===== xref:../cui-http-core/src/main/java/de/cuioss/http/client/adapter/package-info.java[HTTP Adapters (New Architecture)]
 
 Async-first HTTP client adapters with composable retry and caching.
 
@@ -45,23 +45,23 @@ Async-first HTTP client adapters with composable retry and caching.
 * Thread-safe async execution with CompletableFuture
 * Error categorization and idempotency-aware retry
 
-See xref:../src/main/java/de/cuioss/http/client/adapter/package-info.java[package documentation] for complete usage examples.
+See xref:../cui-http-core/src/main/java/de/cuioss/http/client/adapter/package-info.java[package documentation] for complete usage examples.
 
 === SSL/TLS Support
 
-==== xref:../src/main/java/de/cuioss/http/client/handler/SecureSSLContextProvider.java[SecureSSLContextProvider]
+==== xref:../cui-http-core/src/main/java/de/cuioss/http/client/handler/SecureSSLContextProvider.java[SecureSSLContextProvider]
 
 Utility for creating TLS 1.2+ SSL contexts.
 
 === HTTP Status Classification
 
-==== xref:../src/main/java/de/cuioss/http/client/handler/HttpStatusFamily.java[HttpStatusFamily]
+==== xref:../cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpStatusFamily.java[HttpStatusFamily]
 
 Enum for RFC 7231 HTTP status code classification with static helper methods.
 
 === Content Conversion
 
-==== xref:../src/main/java/de/cuioss/http/client/converter/HttpContentConverter.java[HttpContentConverter]
+==== xref:../cui-http-core/src/main/java/de/cuioss/http/client/converter/HttpResponseConverter.java[HttpResponseConverter]
 
 Interface for converting HTTP response bodies to domain objects.
 
@@ -69,7 +69,7 @@ Interface for converting HTTP response bodies to domain objects.
 * Configurable body handlers
 * Empty value support for null/empty responses
 
-==== xref:../src/main/java/de/cuioss/http/client/converter/StringContentConverter.java[StringContentConverter]
+==== xref:../cui-http-core/src/main/java/de/cuioss/http/client/converter/StringContentConverter.java[StringContentConverter]
 
 Built-in content converter for String responses.
 
@@ -79,7 +79,7 @@ Built-in content converter for String responses.
 
 === Result Handling
 
-==== xref:../src/main/java/de/cuioss/http/client/result/HttpResult.java[HttpResult]
+==== xref:../cui-http-core/src/main/java/de/cuioss/http/client/result/HttpResult.java[HttpResult]
 
 Sealed interface for HTTP operation results with type-safe pattern matching.
 
@@ -89,7 +89,7 @@ Sealed interface for HTTP operation results with type-safe pattern matching.
 * Error categorization via HttpErrorCategory
 * Factory methods for common scenarios
 
-==== xref:../src/main/java/de/cuioss/http/client/result/HttpErrorCategory.java[HttpErrorCategory]
+==== xref:../cui-http-core/src/main/java/de/cuioss/http/client/result/HttpErrorCategory.java[HttpErrorCategory]
 
 Error categorization for HTTP operations.
 
@@ -99,13 +99,13 @@ Error categorization for HTTP operations.
 * `INVALID_CONTENT` - Content conversion failures
 * Retry eligibility determination
 
-==== xref:../src/main/java/de/cuioss/http/client/result/HttpResultState.java[HttpResultState]
+==== xref:../cui-http-core/src/main/java/de/cuioss/http/client/result/HttpResultState.java[HttpResultState]
 
 HTTP-specific result states extending CUI result framework.
 
 === Logging
 
-==== xref:../src/main/java/de/cuioss/http/client/HttpLogMessages.java[HttpLogMessages]
+==== xref:../cui-http-core/src/main/java/de/cuioss/http/client/HttpLogMessages.java[HttpLogMessages]
 
 Centralized log messages for HTTP operations.
 

--- a/doc/http-result-pattern.adoc
+++ b/doc/http-result-pattern.adoc
@@ -192,55 +192,26 @@ CompletableFuture<HttpResult<T>> future = adapter.get(headers);
 // - 304 Not Modified: Return cached content
 // - Network/server errors: Retry with exponential backoff
 future.thenAccept(result -> {
-    result.ifSuccess(content -> {
-        // Use content
-    }).ifFailure(error -> {
-                case int code when code >= 500 -> {
-                    // Server error with fallback
-                    yield HttpResult.failureWithFallback(
-                        "Server error: " + code,
-                        null,
-                        cachedContent,
-                        HttpErrorCategory.SERVER_ERROR,
-                        cachedEtag,
-                        code
-                    );
-                }
+    if (result.isSuccess()) {
+        result.getContent().ifPresent(content -> {
+            // Use content
+        });
+    } else {
+        result.getErrorMessage().ifPresent(logger::error);
+        result.getCause().ifPresent(cause ->
+            logger.error("Underlying cause", cause));
 
-                default -> {
-                    // Client error without fallback
-                    yield HttpResult.failure(
-                        "Unexpected status: " + response.statusCode(),
-                        null,
-                        HttpErrorCategory.CLIENT_ERROR
-                    );
-                }
-            };
-
-        } catch (IOException e) {
-            return handleNetworkError(e);
+        // Check if retryable
+        if (result.isRetryable()) {
+            logger.warn("Error is retryable, scheduling retry");
+            scheduleRetry();
         }
-    }
 
-    private HttpResult<T> handleNetworkError(IOException e) {
-        if (cachedContent != null) {
-            return HttpResult.failureWithFallback(
-                "Network error: " + e.getMessage(),
-                e,
-                cachedContent,
-                HttpErrorCategory.NETWORK_ERROR,
-                cachedEtag,
-                null
-            );
-        } else {
-            return HttpResult.failure(
-                "Network error with no cache: " + e.getMessage(),
-                e,
-                HttpErrorCategory.NETWORK_ERROR
-            );
-        }
+        // Use fallback if available
+        result.getContent().ifPresent(fallback ->
+            logger.warn("Using cached fallback content"));
     }
-}
+});
 ----
 
 === Factory Method Reference

--- a/doc/http-security/analysis/cookie-chaos-analysis.adoc
+++ b/doc/http-security/analysis/cookie-chaos-analysis.adoc
@@ -77,11 +77,11 @@ Result: __Host- cookie with forbidden Domain attribute
 
 **Implementation:**
 
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - ASCII-only validation, whitespace rejection
-* link:../../../src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage] - RFC 6265bis prefix validation
-* link:../../../src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie.hostPrefix() / securePrefix()] - Factory methods
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - ASCII-only validation, whitespace rejection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage] - RFC 6265bis prefix validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie.hostPrefix() / securePrefix()] - Factory methods
 
-**Tests:** link:../../../src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java[CookiePrefixValidationStageTest] (36 tests), link:../../../src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java[CookieChaosAttackTest] (50 tests)
+**Tests:** link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java[CookiePrefixValidationStageTest] (36 tests), link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java[CookieChaosAttackTest] (50 tests)
 
 === 2. Legacy Parsing Exploitation
 
@@ -118,7 +118,7 @@ Legacy parser behavior:
 
 **Scope:** Library validates outgoing cookies; server-side parsing is framework responsibility. Configure Tomcat (`STRICT_SERVLET_COMPLIANCE=true`) or Jetty (`CookieCompliance.RFC6265`) to disable legacy RFC 2109 parsing.
 
-**Tests:** link:../../../src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java[CookieChaosAttackTest] (20 tests with link:../../../src/test/java/de/cuioss/http/security/generators/cookie/CookieNameLegacyParsingGenerator.java[CookieNameLegacyParsingGenerator])
+**Tests:** link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java[CookieChaosAttackTest] (20 tests with link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/CookieNameLegacyParsingGenerator.java[CookieNameLegacyParsingGenerator])
 
 === 3. Server-Side Cookie Name Normalization
 
@@ -148,12 +148,12 @@ Result: __Host- cookie with forbidden Domain attribute bypasses validation
 
 **Implementation:**
 
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - ASCII-only validation
-* link:../../../src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage] - Whitespace rejection before prefix validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - ASCII-only validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage] - Whitespace rejection before prefix validation
 
 **Tests:**
 
-link:../../../src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java[CookiePrefixValidationStageTest], link:../../../src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java[CookieChaosAttackTest] (40 tests with link:../../../src/test/java/de/cuioss/http/security/generators/cookie/CookieNameAsciiWhitespaceGenerator.java[CookieNameAsciiWhitespaceGenerator])
+link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java[CookiePrefixValidationStageTest], link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java[CookieChaosAttackTest] (40 tests with link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/CookieNameAsciiWhitespaceGenerator.java[CookieNameAsciiWhitespaceGenerator])
 
 === 4. Domain Attribute Validation
 
@@ -177,11 +177,11 @@ Result: __Host- cookie with forbidden Domain attribute accepted by server
 
 **Implementation:**
 
-* link:../../../src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie] - Data structure with getDomain(), getPath(), isSecure()
-* link:../../../src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage] - Validates `__Host-` has no Domain, Path=/, Secure; `__Secure-` has Secure
-* link:../../../src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie.hostPrefix() / securePrefix()] - Factory methods
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie] - Data structure with getDomain(), getPath(), isSecure()
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage] - Validates `__Host-` has no Domain, Path=/, Secure; `__Secure-` has Secure
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie.hostPrefix() / securePrefix()] - Factory methods
 
-**Tests:** link:../../../src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java[CookiePrefixValidationStageTest] (36 tests), link:../../../src/test/java/de/cuioss/http/security/data/CookieTest.java[CookieTest] (factory method tests)
+**Tests:** link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java[CookiePrefixValidationStageTest] (36 tests), link:../../../cui-http-core/src/test/java/de/cuioss/http/security/data/CookieTest.java[CookieTest] (factory method tests)
 
 === 5. Path Attribute Validation
 
@@ -205,9 +205,9 @@ Result: __Host- cookie with restricted path accepted by server
 
 **Implementation:**
 
-* link:../../../src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage] - Validates `__Host-` cookies have Path=/
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage] - Validates `__Host-` cookies have Path=/
 
-**Tests:** link:../../../src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java[CookiePrefixValidationStageTest]
+**Tests:** link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java[CookiePrefixValidationStageTest]
 
 == Attack Pattern Database
 
@@ -284,7 +284,7 @@ Cookie: "$Version=1,__Secure-session=attack;"
 
 The cui-http library now provides comprehensive cookie prefix validation and secure cookie creation:
 
-1. ✓ Cookie prefix validation fully implemented (link:../../../src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage])
+1. ✓ Cookie prefix validation fully implemented (link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage])
 2. ✓ `__Host-` prefix requirements enforced (no Domain, Path=/, Secure)
 3. ✓ `__Secure-` prefix requirements enforced (Secure attribute)
 4. ✓ Factory methods for creating RFC-compliant cookies
@@ -295,22 +295,22 @@ The cui-http library now provides comprehensive cookie prefix validation and sec
 
 ==== Completed Library Enhancements ✓
 
-1. **Cookie Prefix Validator:** link:../../../src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage] - RFC 6265bis validation for `__Host-` and `__Secure-` prefixes
+1. **Cookie Prefix Validator:** link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage] - RFC 6265bis validation for `__Host-` and `__Secure-` prefixes
 
-2. **Enhanced Character Validation:** link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - ASCII-only enforcement, whitespace rejection
+2. **Enhanced Character Validation:** link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - ASCII-only enforcement, whitespace rejection
 
-3. **Cookie Factory Methods:** link:../../../src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie.hostPrefix()] and link:../../../src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie.securePrefix()] - Create RFC-compliant cookies
+3. **Cookie Factory Methods:** link:../../../cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie.hostPrefix()] and link:../../../cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie.securePrefix()] - Create RFC-compliant cookies
 
 4. **Test Coverage:** 246 tests total
-   * link:../../../src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java[CookiePrefixValidationStageTest] (36 tests)
-   * link:../../../src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java[CookieChaosAttackTest] (213 tests)
-   * link:../../../src/test/java/de/cuioss/http/security/data/CookieTest.java[CookieTest] (factory method tests)
+   * link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java[CookiePrefixValidationStageTest] (36 tests)
+   * link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java[CookieChaosAttackTest] (213 tests)
+   * link:../../../cui-http-core/src/test/java/de/cuioss/http/security/data/CookieTest.java[CookieTest] (factory method tests)
 
 ==== Usage Guide for Library Users
 
-1. **Cookie Prefix Validation:** See link:../../../src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage] - Use `validateCookie(cookie)` or `validate(cookieName)` methods
+1. **Cookie Prefix Validation:** See link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage] - Use `validateCookie(cookie)` or `validate(cookieName)` methods
 
-2. **Creating Secure Cookies:** See link:../../../src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie.hostPrefix()] and link:../../../src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie.securePrefix()] - Factory methods that automatically apply RFC 6265bis compliant attributes
+2. **Creating Secure Cookies:** See link:../../../cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie.hostPrefix()] and link:../../../cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie.securePrefix()] - Factory methods that automatically apply RFC 6265bis compliant attributes
 
 3. **Server Framework Configuration:**
    * Tomcat: Set `STRICT_SERVLET_COMPLIANCE=true`
@@ -323,16 +323,16 @@ The cui-http library now provides comprehensive cookie prefix validation and sec
 
 All recommended test cases have been implemented using parameterized tests with generators:
 
-**Test Class:** link:../../../src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java[CookieChaosAttackTest]
+**Test Class:** link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java[CookieChaosAttackTest]
 
 **Test Generators:**
 
-* link:../../../src/test/java/de/cuioss/http/security/generators/cookie/CookieNameUnicodeWhitespaceGenerator.java[CookieNameUnicodeWhitespaceGenerator] - 13 Unicode whitespace types
-* link:../../../src/test/java/de/cuioss/http/security/generators/cookie/CookieNameZeroWidthGenerator.java[CookieNameZeroWidthGenerator] - 4 zero-width character types
-* link:../../../src/test/java/de/cuioss/http/security/generators/cookie/CookieNameAsciiWhitespaceGenerator.java[CookieNameAsciiWhitespaceGenerator] - ASCII whitespace patterns
-* link:../../../src/test/java/de/cuioss/http/security/generators/cookie/CookieNameLegacyParsingGenerator.java[CookieNameLegacyParsingGenerator] - Legacy parsing triggers
-* link:../../../src/test/java/de/cuioss/http/security/generators/cookie/ValidCookieGenerator.java[ValidCookieGenerator] - Valid cookie patterns
-* link:../../../src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGenerator.java[AttackCookieGenerator] - General attack patterns
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/CookieNameUnicodeWhitespaceGenerator.java[CookieNameUnicodeWhitespaceGenerator] - 13 Unicode whitespace types
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/CookieNameZeroWidthGenerator.java[CookieNameZeroWidthGenerator] - 4 zero-width character types
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/CookieNameAsciiWhitespaceGenerator.java[CookieNameAsciiWhitespaceGenerator] - ASCII whitespace patterns
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/CookieNameLegacyParsingGenerator.java[CookieNameLegacyParsingGenerator] - Legacy parsing triggers
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/ValidCookieGenerator.java[ValidCookieGenerator] - Valid cookie patterns
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGenerator.java[AttackCookieGenerator] - General attack patterns
 
 **Test Coverage (213 total test cases):**
 
@@ -383,16 +383,16 @@ All recommended test cases have been implemented using parameterized tests with 
 
 **Core Implementation:**
 
-* link:../../../src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie] - Data structure with attribute parsing
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - ASCII-only, whitespace rejection
-* link:../../../src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage] - RFC 6265bis prefix validation
-* link:../../../src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie.hostPrefix() / securePrefix()] - Factory methods
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie] - Data structure with attribute parsing
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - ASCII-only, whitespace rejection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java[CookiePrefixValidationStage] - RFC 6265bis prefix validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie.hostPrefix() / securePrefix()] - Factory methods
 
 **Test Coverage (246 total):**
 
-* link:../../../src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java[CookiePrefixValidationStageTest] - 36 prefix validation tests
-* link:../../../src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java[CookieChaosAttackTest] - 213 attack pattern tests
-* link:../../../src/test/java/de/cuioss/http/security/data/CookieTest.java[CookieTest] - Factory method validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java[CookiePrefixValidationStageTest] - 36 prefix validation tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java[CookieChaosAttackTest] - 213 attack pattern tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/data/CookieTest.java[CookieTest] - Factory method validation
 
 === Architectural Notes
 

--- a/doc/http-security/analysis/cve-analysis.adoc
+++ b/doc/http-security/analysis/cve-analysis.adoc
@@ -240,41 +240,39 @@ File tempDir = Files.createTempDir();
 [source,java]
 ----
 @Test
-public void testCVE_2021_29425_Pattern() {
+void shouldDetectApacheCommonsIOPattern() {
     // Apache Commons IO vulnerability pattern
-    assertThrows(SecurityException.class, () -> 
-        validatePath("//../sensitive/file"));
+    URLPathValidationPipeline pipeline = new URLPathValidationPipeline(
+        SecurityConfiguration.defaults(), new SecurityEventCounter());
+    assertThrows(UrlSecurityException.class, () ->
+        pipeline.validate("//../sensitive/file"));
 }
 
 @Test
-public void testCVE_2023_32235_Encoding() {
+void shouldDetectGhostCMSEncoding() {
     // Ghost CMS URL encoding pattern
-    assertThrows(SecurityException.class, () -> 
-        validatePath("assets/built%2F..%2F..%2F/config"));
+    URLPathValidationPipeline pipeline = new URLPathValidationPipeline(
+        SecurityConfiguration.defaults(), new SecurityEventCounter());
+    assertThrows(UrlSecurityException.class, () ->
+        pipeline.validate("assets/built%2F..%2F..%2F/config"));
 }
 
 @Test
-public void testCVE_2023_50164_FileUpload() {
+void shouldDetectApacheStrutsUpload() {
     // Apache Struts upload traversal
-    String filename = "../../webapps/shell.jsp";
-    assertThrows(SecurityException.class, () -> 
-        validateUploadPath(filename));
+    URLPathValidationPipeline pipeline = new URLPathValidationPipeline(
+        SecurityConfiguration.defaults(), new SecurityEventCounter());
+    assertThrows(UrlSecurityException.class, () ->
+        pipeline.validate("../../webapps/shell.jsp"));
 }
 
 @Test
-public void testHttpHeaderInjection() {
-    // HTTP header injection pattern
-    String header = "X-Original-URL: /../../admin";
-    assertThrows(SecurityException.class, () -> 
-        validateHttpHeader(header));
-}
-
-@Test
-public void testDoubleEncoding() {
+void shouldDetectDoubleEncoding() {
     // Spring Framework double encoding
-    String input = "%252e%252e%252f%252e%252e%252f";
-    assertThrows(SecurityException.class, () -> 
-        validateAfterDecoding(input));
+    URLPathValidationPipeline pipeline = new URLPathValidationPipeline(
+        SecurityConfiguration.defaults(), new SecurityEventCounter());
+    assertThrows(UrlSecurityException.class, () ->
+        pipeline.validate("%252e%252e%252f%252e%252e%252f"));
 }
 ----
 

--- a/doc/http-security/analysis/http1-vulnerabilities-analysis.adoc
+++ b/doc/http-security/analysis/http1-vulnerabilities-analysis.adoc
@@ -60,9 +60,9 @@ G
 
 **Application-Layer Protection:**
 
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - Detects CRLF injection patterns (`%0d%0a`)
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] - Validates header values
-* link:../../../src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest] - Comprehensive CL.TE test coverage (200+ tests)
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - Detects CRLF injection patterns (`%0d%0a`)
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] - Validates header values
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest] - Comprehensive CL.TE test coverage (200+ tests)
 
 **Infrastructure-Layer Responsibility:**
 
@@ -70,7 +70,7 @@ G
 * Content-Length vs Transfer-Encoding conflict resolution
 * Request boundary determination
 
-**Tests:** link:../../../src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest] (25 CL.TE-specific tests using link:../../../src/test/java/de/cuioss/http/security/generators/injection/HttpRequestSmugglingAttackGenerator.java[HttpRequestSmugglingAttackGenerator])
+**Tests:** link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest] (25 CL.TE-specific tests using link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/HttpRequestSmugglingAttackGenerator.java[HttpRequestSmugglingAttackGenerator])
 
 === 2. TE.CL Request Smuggling
 
@@ -107,8 +107,8 @@ Host: vulnerable.com
 
 **Application-Layer Protection:**
 
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - CRLF and control character detection
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] - Header value validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - CRLF and control character detection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] - Header value validation
 
 **Infrastructure-Layer Responsibility:**
 
@@ -116,7 +116,7 @@ Host: vulnerable.com
 * Transfer-Encoding vs Content-Length priority determination
 * Connection reuse security
 
-**Tests:** link:../../../src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest] (25 TE.CL-specific tests)
+**Tests:** link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest] (25 TE.CL-specific tests)
 
 === 3. CL.0 Request Smuggling
 
@@ -149,7 +149,7 @@ Host: vulnerable.com
 
 **Application-Layer Protection:**
 
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - Detects embedded HTTP verbs and CRLF patterns
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - Detects embedded HTTP verbs and CRLF patterns
 * Existing smuggling tests cover embedded request patterns
 
 **Infrastructure-Layer Responsibility:**
@@ -158,7 +158,7 @@ Host: vulnerable.com
 * Request body handling
 * Connection state management
 
-**Tests:** Covered by general smuggling tests in link:../../../src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest]
+**Tests:** Covered by general smuggling tests in link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest]
 
 === 4. Expect Header Desync Attacks
 
@@ -258,9 +258,9 @@ Front-end ignores obfuscated Transfer-Encoding, back-end processes it.
 
 **Application-Layer Protection:**
 
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - Whitespace and control character validation
-* link:../../../src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest] - TE.TE smuggling tests cover Transfer-Encoding obfuscation (30 tests)
-* link:../../../src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest] - Header injection and CRLF detection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - Whitespace and control character validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest] - TE.TE smuggling tests cover Transfer-Encoding obfuscation (30 tests)
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest] - Header injection and CRLF detection
 
 **Infrastructure-Layer Responsibility:**
 
@@ -270,8 +270,8 @@ Front-end ignores obfuscated Transfer-Encoding, back-end processes it.
 
 **Tests:**
 
-* link:../../../src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest] - TE.TE and CL.CL variants
-* link:../../../src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest] - Header manipulation patterns
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest] - TE.TE and CL.CL variants
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest] - Header manipulation patterns
 
 === 6. Upstream Connection Reuse Vulnerabilities
 
@@ -342,20 +342,20 @@ The cui-http library provides HTTP **component** validation (headers, paths, par
 
 ==== Completed Library Enhancements ✓
 
-1. **HTTP Header Validation:** link:../../../src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] - RFC 7230 header validation
+1. **HTTP Header Validation:** link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] - RFC 7230 header validation
 
-2. **Character Validation:** link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - CRLF, control character detection
+2. **Character Validation:** link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - CRLF, control character detection
 
-3. **Pattern Matching:** link:../../../src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage] - Attack pattern detection
+3. **Pattern Matching:** link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage] - Attack pattern detection
 
 4. **Test Coverage:** 395+ tests total
-   * link:../../../src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest] (200 tests)
-   * link:../../../src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest] (195 tests)
+   * link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest] (200 tests)
+   * link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest] (195 tests)
    * Generator-based testing with reproducible patterns
 
 ==== Usage Guide for Library Users
 
-1. **Header Validation:** Use link:../../../src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] for validating HTTP header values
+1. **Header Validation:** Use link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] for validating HTTP header values
 
 2. **Infrastructure Configuration (Critical):**
    * **Disable upstream connection reuse** for security-critical applications
@@ -478,9 +478,9 @@ Transfer-Encoding: identity
 
 All request smuggling patterns are tested using parameterized tests with generators:
 
-**Test Class:** link:../../../src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest]
+**Test Class:** link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest]
 
-**Test Generator:** link:../../../src/test/java/de/cuioss/http/security/generators/injection/HttpRequestSmugglingAttackGenerator.java[HttpRequestSmugglingAttackGenerator]
+**Test Generator:** link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/HttpRequestSmugglingAttackGenerator.java[HttpRequestSmugglingAttackGenerator]
 
 **Test Coverage (200 total test cases):**
 
@@ -575,9 +575,9 @@ All request smuggling patterns are tested using parameterized tests with generat
 
 **Library-Level Protection (Application Layer):**
 
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] - Header component validation
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - CRLF and control character detection
-* link:../../../src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage] - Attack pattern detection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] - Header component validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - CRLF and control character detection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage] - Attack pattern detection
 * Comprehensive test coverage (395+ tests)
 
 **Infrastructure-Level Protection (Required):**

--- a/doc/http-security/analysis/owasp-best-practices.adoc
+++ b/doc/http-security/analysis/owasp-best-practices.adoc
@@ -61,15 +61,15 @@ When user input cannot be avoided, implement multiple layers of defense:
 === Input Validation Techniques
 
 ==== Character Validation
-Implemented in: link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage]
+Implemented in: link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage]
 
 * Whitelist validation for allowed characters
-* Pattern matching against link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java[CharacterValidationConstants]
+* Pattern matching against link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java[CharacterValidationConstants]
 
 === Path Canonicalization and Validation
 
 ==== Normalization Implementation
-Implemented in: link:../../../src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage]
+Implemented in: link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage]
 
 * Path normalization and canonicalization
 * Unicode normalization (NFC, NFD, NFKC, NFKD)
@@ -106,7 +106,7 @@ Implemented in: link:../../../src/main/java/de/cuioss/http/security/validation/N
 |===
 
 ==== Decoding Implementation
-Implemented in: link:../../../src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage]
+Implemented in: link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage]
 
 * URL decoding with double-encoding detection
 * UTF-8 overlong encoding prevention
@@ -171,15 +171,15 @@ C:\inetpub\wwwroot\..\..\Windows\win.ini
 === Secure Validation Patterns
 
 ==== Path Validation Pipeline
-Implemented in: link:../../../src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]
+Implemented in: link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]
 
 * Sequential validation stages
 * Pattern matching for known attacks
-* Configurable security levels via link:../../../src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java[SecurityConfiguration]
+* Configurable security levels via link:../../../cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java[SecurityConfiguration]
 
 === HTTP Header Validation
 
-Implemented in: link:../../../src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline]
+Implemented in: link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline]
 
 * Header injection prevention
 * CRLF attack detection
@@ -188,7 +188,7 @@ Implemented in: link:../../../src/main/java/de/cuioss/http/security/pipeline/HTT
 == Real-World Attack Pattern Detection
 
 === Pattern Matching Implementation
-Implemented in: link:../../../src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage]
+Implemented in: link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage]
 
 * Path traversal pattern detection
 * CVE-based attack patterns
@@ -198,26 +198,26 @@ Implemented in: link:../../../src/main/java/de/cuioss/http/security/validation/P
 == Monitoring and Detection
 
 === Security Event Monitoring
-Implemented in: link:../../../src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]
+Implemented in: link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]
 
 * Attack attempt counting by type
 * Failure type categorization
 * Metrics collection for security monitoring
 
 === Logging Implementation
-Implemented in: link:../../../src/main/java/de/cuioss/http/security/monitoring/URLSecurityLogMessages.java[URLSecurityLogMessages]
+Implemented in: link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]
 
-* Structured security event logging
-* CuiLogger integration
-* Attack pattern logging
+* Security event counting and tracking
+* Failure type categorization
+* Attack pattern monitoring
 
 
 == Key Implementation Points
 
-* Use link:../../../src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java[PipelineFactory] to select appropriate validation pipeline
-* Configure via link:../../../src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java[SecurityConfiguration] with sensible defaults
-* Monitor security events with link:../../../src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]
-* All validators implement link:../../../src/main/java/de/cuioss/http/security/core/HttpSecurityValidator.java[HttpSecurityValidator] interface
+* Use link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java[PipelineFactory] to select appropriate validation pipeline
+* Configure via link:../../../cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java[SecurityConfiguration] with sensible defaults
+* Monitor security events with link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]
+* All validators implement link:../../../cui-http-core/src/main/java/de/cuioss/http/security/core/HttpSecurityValidator.java[HttpSecurityValidator] interface
 
 == HTTP/URL Standards and Validation
 
@@ -241,14 +241,14 @@ Implemented in: link:../../../src/main/java/de/cuioss/http/security/monitoring/U
 
 ==== URL Query Parameter Validation
 
-Implemented in: link:../../../src/main/java/de/cuioss/http/security/pipeline/URLParameterValidationPipeline.java[URLParameterValidationPipeline]
+Implemented in: link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLParameterValidationPipeline.java[URLParameterValidationPipeline]
 
 * RFC 3986 compliant validation
 * Parameter name and value validation
 * Length limits enforcement
 * Null byte detection
 
-Parameter data structure: link:../../../src/main/java/de/cuioss/http/security/data/URLParameter.java[URLParameter]
+Parameter data structure: link:../../../cui-http-core/src/main/java/de/cuioss/http/security/data/URLParameter.java[URLParameter]
 
 ==== HTTP Body Validation
 
@@ -263,8 +263,8 @@ Note: Body validation pipeline has been eliminated from the architecture. Body c
 
 ==== Cookie Validation
 
-Cookie data structure: link:../../../src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie]
-Attribute parsing: link:../../../src/main/java/de/cuioss/http/security/data/AttributeParser.java[AttributeParser]
+Cookie data structure: link:../../../cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie]
+Attribute parsing: link:../../../cui-http-core/src/main/java/de/cuioss/http/security/data/AttributeParser.java[AttributeParser]
 
 ==== Common Parameter Attack Patterns
 

--- a/doc/http-security/functional-requirements.adoc
+++ b/doc/http-security/functional-requirements.adoc
@@ -259,31 +259,31 @@ The following classes implement the functional requirements:
 
 === Core Implementation Classes
 
-* link:../../src/main/java/de/cuioss/http/security/core/HttpSecurityValidator.java[HttpSecurityValidator] - Core validation interface (HTTP-1, HTTP-3)
-* link:../../src/main/java/de/cuioss/http/security/core/ValidationType.java[ValidationType] - Validation type enumeration (HTTP-1, HTTP-14)
-* link:../../src/main/java/de/cuioss/http/security/exceptions/UrlSecurityException.java[UrlSecurityException] - Security exception handling (HTTP-15)
-* link:../../src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter] - Event tracking (HTTP-16)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/core/HttpSecurityValidator.java[HttpSecurityValidator] - Core validation interface (HTTP-1, HTTP-3)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/core/ValidationType.java[ValidationType] - Validation type enumeration (HTTP-1, HTTP-14)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/exceptions/UrlSecurityException.java[UrlSecurityException] - Security exception handling (HTTP-15)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter] - Event tracking (HTTP-16)
 
 === Validation Stages Implementation
 
-* link:../../src/main/java/de/cuioss/http/security/validation/LengthValidationStage.java[LengthValidationStage] - Length constraints (HTTP-19)
-* link:../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - Character validation (HTTP-10, HTTP-11)
-* link:../../src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage] - Encoding validation (HTTP-9)
-* link:../../src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage] - Path normalization (HTTP-6, HTTP-8)
-* link:../../src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage] - Pattern detection (HTTP-7)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/validation/LengthValidationStage.java[LengthValidationStage] - Length constraints (HTTP-19)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - Character validation (HTTP-10, HTTP-11)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage] - Encoding validation (HTTP-9)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage] - Path normalization (HTTP-6, HTTP-8)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage] - Pattern detection (HTTP-7)
 
 === Pipeline Implementation
 
-* link:../../src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline] - Path validation pipeline (HTTP-4, HTTP-5)
-* link:../../src/main/java/de/cuioss/http/security/pipeline/URLParameterValidationPipeline.java[URLParameterValidationPipeline] - Parameter validation pipeline
-* link:../../src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] - Header validation pipeline
-* link:../../src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java[PipelineFactory] - Pipeline creation factory
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline] - Path validation pipeline (HTTP-4, HTTP-5)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLParameterValidationPipeline.java[URLParameterValidationPipeline] - Parameter validation pipeline
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] - Header validation pipeline
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java[PipelineFactory] - Pipeline creation factory
 
 === Configuration Implementation
 
-* link:../../src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java[SecurityConfiguration] - Main configuration (HTTP-13)
-* link:../../src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java[SecurityConfigurationBuilder] - Configuration builder
-* link:../../src/main/java/de/cuioss/http/security/config/SecurityDefaults.java[SecurityDefaults] - Default security constants
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java[SecurityConfiguration] - Main configuration (HTTP-13)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java[SecurityConfigurationBuilder] - Configuration builder
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java[SecurityDefaults] - Default security constants
 
 == Traceability Matrix
 

--- a/doc/http-security/security-requirements.adoc
+++ b/doc/http-security/security-requirements.adoc
@@ -283,31 +283,31 @@ The following classes implement the security requirements:
 
 === Security Validation Implementation
 
-* link:../../src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage] - Encoding attack prevention (SEC-4, SEC-13)
-* link:../../src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage] - Canonicalization security (SEC-5)
-* link:../../src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage] - Attack pattern detection (SEC-3, SEC-12)
-* link:../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - Input validation (SEC-6, SEC-7)
-* link:../../src/main/java/de/cuioss/http/security/validation/LengthValidationStage.java[LengthValidationStage] - DoS prevention (SEC-9, SEC-10)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage] - Encoding attack prevention (SEC-4, SEC-13)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage] - Canonicalization security (SEC-5)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage] - Attack pattern detection (SEC-3, SEC-12)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - Input validation (SEC-6, SEC-7)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/validation/LengthValidationStage.java[LengthValidationStage] - DoS prevention (SEC-9, SEC-10)
 
 === Security Monitoring Implementation
 
-* link:../../src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter] - Event tracking and attack recognition (SEC-11, SEC-12, SEC-15)
-* link:../../src/main/java/de/cuioss/http/security/monitoring/URLSecurityLogMessages.java[URLSecurityLogMessages] - Security logging (SEC-11)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter] - Event tracking and attack recognition (SEC-11, SEC-12, SEC-15)
+ * link:../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter] - Security event logging (SEC-11)
 
 === Security Configuration Implementation
 
-* link:../../src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java[SecurityConfiguration] - Secure defaults (SEC-14, SEC-18)
-* link:../../src/main/java/de/cuioss/http/security/config/SecurityDefaults.java[SecurityDefaults] - OWASP-compliant defaults (SEC-1, SEC-2, SEC-14)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java[SecurityConfiguration] - Secure defaults (SEC-14, SEC-18)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java[SecurityDefaults] - OWASP-compliant defaults (SEC-1, SEC-2, SEC-14)
 
 === Security Pipeline Implementation
 
-* link:../../src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline] - Path security enforcement (SEC-3, SEC-5)
-* link:../../src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java[PipelineFactory] - API security (SEC-17)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline] - Path security enforcement (SEC-3, SEC-5)
+* link:../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java[PipelineFactory] - API security (SEC-17)
 
 === Security Testing Implementation
 
-* link:../../src/test/java/de/cuioss/http/security/tests/[Security Test Suite] - Security testing support (SEC-16)
-* link:../../src/test/java/de/cuioss/http/security/database/[Attack Databases] - Attack pattern configuration (SEC-18)
+* link:../../cui-http-core/src/test/java/de/cuioss/http/security/tests/[Security Test Suite] - Security testing support (SEC-16)
+* link:../../cui-http-core/src/test/java/de/cuioss/http/security/database/[Attack Databases] - Attack pattern configuration (SEC-18)
 
 == Traceability Matrix
 

--- a/doc/http-security/specification/compliance-traceability.adoc
+++ b/doc/http-security/specification/compliance-traceability.adoc
@@ -40,26 +40,26 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 ==== Specifications
 
 * xref:../analysis/owasp-best-practices.adoc[Path Traversal Prevention]: OWASP best practices implementation
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]: Pipeline architecture
-* link:../../../src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage]: Attack pattern detection
-* link:../../../src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage]: Path canonicalization
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]: Pipeline architecture
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage]: Attack pattern detection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage]: Path canonicalization
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java[OWASPTop10AttackDatabaseTest]: OWASP A01 attack patterns (lines 50-126)
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java[OWASPTop10AttackDatabaseTest]: OWASP A01 attack patterns (lines 50-126)
 * `CLASSIC_PATH_TRAVERSAL_UNIX`: `../../../etc/passwd`
 * `URL_ENCODED_TRAVERSAL`: `%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd`
 * `DOUBLE_ENCODED_TRAVERSAL`: `%252e%252e%252f...`
 * `UTF8_OVERLONG_TRAVERSAL`: `%c0%ae%c0%ae%c0%af...`
 * `STRUTS2_COMPONENT_TRAVERSAL`: `/struts2-showcase/../../../etc/passwd`
 * `AUTH_BYPASS_TRAVERSAL`: `/admin/../user/profile`
-* link:../../../src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]: Comprehensive path traversal testing
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]: Comprehensive path traversal testing
 
 * `shouldRejectAllPathTraversalPatterns()`: 64 generated patterns
 * `shouldBlockCVEStylePatterns()`: CVE-based patterns
-* link:../../../src/test/java/de/cuioss/http/security/tests/EncodedPathTraversalAttackTest.java[EncodedPathTraversalAttackTest]: Encoded variants
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/EncodedPathTraversalAttackTest.java[EncodedPathTraversalAttackTest]: Encoded variants
 
-* link:../../../src/test/java/de/cuioss/http/security/tests/UnicodePathTraversalAttackTest.java[UnicodePathTraversalAttackTest]: Unicode-based traversal
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodePathTraversalAttackTest.java[UnicodePathTraversalAttackTest]: Unicode-based traversal
 
 *Status*: ✅ VERIFIED - Complete coverage with 200+ test cases
 
@@ -81,17 +81,17 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage]: URL decoding with double-encoding detection
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage]: RFC-compliant character validation
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java[CharacterValidationConstants]: Allowed character sets
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage]: URL decoding with double-encoding detection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage]: RFC-compliant character validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java[CharacterValidationConstants]: Allowed character sets
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/tests/DoubleEncodingAttackTest.java[DoubleEncodingAttackTest]: Double/triple encoding patterns (CWE-20, CWE-22)
-* link:../../../src/test/java/de/cuioss/http/security/tests/MixedEncodingAttackTest.java[MixedEncodingAttackTest]: Mixed encoding combinations (CWE-20, CWE-116, CWE-838)
-* link:../../../src/test/java/de/cuioss/http/security/tests/NullBytePathTraversalAttackTest.java[NullBytePathTraversalAttackTest]: Null byte injection
-* link:../../../src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java[DecodingStageTest]: Decoding stage validation
-* link:../../../src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest]: Character validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/DoubleEncodingAttackTest.java[DoubleEncodingAttackTest]: Double/triple encoding patterns (CWE-20, CWE-22)
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/MixedEncodingAttackTest.java[MixedEncodingAttackTest]: Mixed encoding combinations (CWE-20, CWE-116, CWE-838)
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/NullBytePathTraversalAttackTest.java[NullBytePathTraversalAttackTest]: Null byte injection
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java[DecodingStageTest]: Decoding stage validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest]: Character validation
 
 *Status*: ✅ VERIFIED - Complete coverage at HTTP/URL protocol layer
 
@@ -112,14 +112,14 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 ==== Specifications
 
 * xref:specification.adoc[Pipeline Architecture]: Sequential validation stages
-* link:../../../src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java[SecurityConfiguration]: Immutable configuration
-* link:../../../src/main/java/de/cuioss/http/security/config/SecurityDefaults.java[SecurityDefaults]: OWASP-compliant defaults
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java[SecurityConfiguration]: Immutable configuration
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java[SecurityDefaults]: OWASP-compliant defaults
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java[URLPathValidationPipelineTest]: Pipeline execution
-* link:../../../src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java[SecurityConfigurationTest]: Configuration validation
-* link:../../../src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java[SecurityDefaultsTest]: Secure defaults
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java[URLPathValidationPipelineTest]: Pipeline execution
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java[SecurityConfigurationTest]: Configuration validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java[SecurityDefaultsTest]: Secure defaults
 
 *Status*: ✅ VERIFIED - Defense-in-depth architecture implemented
 
@@ -137,14 +137,14 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java[SecurityConfiguration]: Configuration management
-* link:../../../src/main/java/de/cuioss/http/security/config/SecurityDefaults.java[SecurityDefaults]: Default values based on RFC standards
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java[SecurityConfiguration]: Configuration management
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java[SecurityDefaults]: Default values based on RFC standards
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java[SecurityConfigurationTest]: Configuration validation
-* link:../../../src/test/java/de/cuioss/http/security/config/SecurityConfigurationBuilderTest.java[SecurityConfigurationBuilderTest]: Builder pattern validation
-* link:../../../src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java[SecurityDefaultsTest]: Default configuration testing
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java[SecurityConfigurationTest]: Configuration validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationBuilderTest.java[SecurityConfigurationBuilderTest]: Builder pattern validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java[SecurityDefaultsTest]: Default configuration testing
 
 *Status*: ✅ VERIFIED - Secure defaults enforced
 
@@ -163,14 +163,14 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]: Authentication bypass prevention
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline]: Header validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]: Authentication bypass prevention
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline]: Header validation
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java[OWASPTop10AttackDatabaseTest]: `AUTH_BYPASS_TRAVERSAL` pattern
-* link:../../../src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest]: Header injection patterns (CWE-113, CWE-116)
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java[HTTPHeaderValidationPipelineTest]: Header validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java[OWASPTop10AttackDatabaseTest]: `AUTH_BYPASS_TRAVERSAL` pattern
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest]: Header injection patterns (CWE-113, CWE-116)
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java[HTTPHeaderValidationPipelineTest]: Header validation
 
 *Status*: ✅ VERIFIED - Authentication bypass patterns detected
 
@@ -189,15 +189,15 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage]: Unicode normalization (NFC)
-* link:../../../src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage]: Encoding consistency validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage]: Unicode normalization (NFC)
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage]: Encoding consistency validation
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/tests/UnicodeNormalizationAttackTest.java[UnicodeNormalizationAttackTest]: Unicode normalization attacks (CWE-20, CWE-176, CWE-838)
-* link:../../../src/test/java/de/cuioss/http/security/tests/UnicodeControlCharacterAttackTest.java[UnicodeControlCharacterAttackTest]: Control character attacks (CWE-74, CWE-20, CWE-176)
-* link:../../../src/test/java/de/cuioss/http/security/tests/HomographAttackDatabaseTest.java[HomographAttackDatabaseTest]: Homograph attacks (CWE-20, CWE-178)
-* link:../../../src/test/java/de/cuioss/http/security/validation/NormalizationStageTest.java[NormalizationStageTest]: Normalization validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodeNormalizationAttackTest.java[UnicodeNormalizationAttackTest]: Unicode normalization attacks (CWE-20, CWE-176, CWE-838)
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodeControlCharacterAttackTest.java[UnicodeControlCharacterAttackTest]: Control character attacks (CWE-74, CWE-20, CWE-176)
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HomographAttackDatabaseTest.java[HomographAttackDatabaseTest]: Homograph attacks (CWE-20, CWE-178)
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/NormalizationStageTest.java[NormalizationStageTest]: Normalization validation
 
 *Status*: ✅ VERIFIED - Input integrity validated
 
@@ -217,12 +217,12 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: Event tracking by failure type
-* link:../../../src/main/java/de/cuioss/http/security/monitoring/URLSecurityLogMessages.java[URLSecurityLogMessages]: Structured logging
+ * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: Event tracking by failure type
+ * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: Security event logging
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java[SecurityEventCounterTest]: Event counter validation
+ * link:../../../cui-http-core/src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java[SecurityEventCounterTest]: Event counter validation
 * All attack database tests verify security events are recorded:
 * `assertTrue(eventCounter.getTotalCount() > initialEventCount)`
 
@@ -242,20 +242,20 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]: Primary defense
-* link:../../../src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage]: Pattern detection
-* link:../../../src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage]: Path canonicalization
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]: Primary defense
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage]: Pattern detection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage]: Path canonicalization
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]: 64+ patterns
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]: 64+ patterns
 * References CVE-2019-5418, CVE-2018-1000671, CVE-2020-5398 (lines 64)
-* link:../../../src/test/java/de/cuioss/http/security/tests/EncodedPathTraversalAttackTest.java[EncodedPathTraversalAttackTest]: Encoded variants
-* link:../../../src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java[OWASPTop10AttackDatabaseTest]: Multiple traversal patterns
-* link:../../../src/test/java/de/cuioss/http/security/tests/ApacheCVEAttackDatabaseTest.java[ApacheCVEAttackDatabaseTest]: Apache-specific CVEs
-* link:../../../src/test/java/de/cuioss/http/security/tests/IISCVEAttackDatabaseTest.java[IISCVEAttackDatabaseTest]: IIS-specific CVEs
-* link:../../../src/test/java/de/cuioss/http/security/tests/NginxCVEAttackDatabaseTest.java[NginxCVEAttackDatabaseTest]: Nginx-specific CVEs
-* link:../../../src/test/java/de/cuioss/http/security/tests/DoubleEncodingAttackTest.java[DoubleEncodingAttackTest]: References CWE-22 (line 63)
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/EncodedPathTraversalAttackTest.java[EncodedPathTraversalAttackTest]: Encoded variants
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java[OWASPTop10AttackDatabaseTest]: Multiple traversal patterns
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/ApacheCVEAttackDatabaseTest.java[ApacheCVEAttackDatabaseTest]: Apache-specific CVEs
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/IISCVEAttackDatabaseTest.java[IISCVEAttackDatabaseTest]: IIS-specific CVEs
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/NginxCVEAttackDatabaseTest.java[NginxCVEAttackDatabaseTest]: Nginx-specific CVEs
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/DoubleEncodingAttackTest.java[DoubleEncodingAttackTest]: References CWE-22 (line 63)
 
 *Status*: ✅ VERIFIED - Extensive coverage with 500+ test cases
 
@@ -270,15 +270,15 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]: Relative path detection
-* link:../../../src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage]: `../` pattern detection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]: Relative path detection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage]: `../` pattern detection
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]:
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]:
 * Test case: `../../../etc/passwd` (line 209)
 * Relative path patterns in 64+ generated test cases
-* link:../../../src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java[OWASPTop10AttackDatabaseTest]:
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java[OWASPTop10AttackDatabaseTest]:
 * `CLASSIC_PATH_TRAVERSAL_UNIX`: `../../../etc/passwd`
 * `AUTH_BYPASS_TRAVERSAL`: `/admin/../user/profile`
 
@@ -295,14 +295,14 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage]: Advanced pattern detection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage]: Advanced pattern detection
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]:
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]:
 * Test case: `....//....//etc/passwd` (line 217)
 * Generator includes advanced patterns
-* link:../../../src/test/java/de/cuioss/http/security/generators/encoding/PathTraversalGenerator.java[PathTraversalGenerator]: Generates advanced patterns
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/PathTraversalGenerator.java[PathTraversalGenerator]: Generates advanced patterns
 
 *Status*: ✅ VERIFIED - Advanced patterns detected
 
@@ -317,14 +317,14 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]: Validates all path input
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/URLParameterValidationPipeline.java[URLParameterValidationPipeline]: Validates parameters
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]: Validates all path input
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLParameterValidationPipeline.java[URLParameterValidationPipeline]: Validates parameters
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/generators/url/PathTraversalParameterGeneratorTest.java[PathTraversalParameterGeneratorTest]: Parameter-based path traversal
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java[URLParameterValidationPipelineTest]: Parameter validation
-* link:../../../src/test/java/de/cuioss/http/security/tests/ProtocolHandlerAttackTest.java[ProtocolHandlerAttackTest]: References CWE-73 for protocol injection
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalParameterGeneratorTest.java[PathTraversalParameterGeneratorTest]: Parameter-based path traversal
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java[URLParameterValidationPipelineTest]: Parameter validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/ProtocolHandlerAttackTest.java[ProtocolHandlerAttackTest]: References CWE-73 for protocol injection
 
 *Status*: ✅ VERIFIED - External input validated
 
@@ -339,13 +339,13 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage]: Blocks command injection characters
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java[CharacterValidationConstants]: Defines safe character sets
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage]: Blocks command injection characters
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java[CharacterValidationConstants]: Defines safe character sets
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest]: Character validation including special characters
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java[URLParameterValidationPipelineTest]: Parameter validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest]: Character validation including special characters
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java[URLParameterValidationPipelineTest]: Parameter validation
 
 *Note*: Full command injection prevention requires application-layer validation. HTTP layer prevents injection characters in URLs/parameters.
 
@@ -364,13 +364,13 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]: Path containment
-* link:../../../src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage]: Canonicalization prevents bypass
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]: Path containment
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage]: Canonicalization prevents bypass
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]: Access control bypass prevention
-* link:../../../src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java[OWASPTop10AttackDatabaseTest]: `AUTH_BYPASS_TRAVERSAL`
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]: Access control bypass prevention
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java[OWASPTop10AttackDatabaseTest]: `AUTH_BYPASS_TRAVERSAL`
 
 *Status*: ✅ VERIFIED
 
@@ -389,8 +389,8 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java[URLPathValidationPipelineTest]: Pipeline execution
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java[URLParameterValidationPipelineTest]: Parameter flow control
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java[URLPathValidationPipelineTest]: Pipeline execution
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java[URLParameterValidationPipelineTest]: Parameter flow control
 
 *Status*: ✅ VERIFIED
 
@@ -405,13 +405,13 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: Event tracking by type
-* link:../../../src/main/java/de/cuioss/http/security/core/UrlSecurityFailureType.java[UrlSecurityFailureType]: Event categorization
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: Event tracking by type
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/core/UrlSecurityFailureType.java[UrlSecurityFailureType]: Event categorization
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java[SecurityEventCounterTest]: Event counting validation
-* link:../../../src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java[UrlSecurityFailureTypeTest]: Failure type enumeration
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java[SecurityEventCounterTest]: Event counting validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java[UrlSecurityFailureTypeTest]: Failure type enumeration
 
 *Status*: ✅ VERIFIED
 
@@ -426,17 +426,17 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/exceptions/UrlSecurityException.java[UrlSecurityException]: Detailed exception context
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/exceptions/UrlSecurityException.java[UrlSecurityException]: Detailed exception context
 * Failure type
 * Validation type
 * Original input
 * Sanitized input (if available)
 * Detailed error message
-* link:../../../src/main/java/de/cuioss/http/security/monitoring/URLSecurityLogMessages.java[URLSecurityLogMessages]: Structured log messages
+ * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: Structured event tracking
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/exceptions/UrlSecurityExceptionTest.java[UrlSecurityExceptionTest]: Exception content validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/exceptions/UrlSecurityExceptionTest.java[UrlSecurityExceptionTest]: Exception content validation
 * All attack tests verify exception content
 
 *Status*: ✅ VERIFIED
@@ -452,12 +452,11 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: Event generation and tracking
-* link:../../../src/main/java/de/cuioss/http/security/monitoring/URLSecurityLogMessages.java[URLSecurityLogMessages]: Log message generation
+ * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: Event generation and tracking
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java[SecurityEventCounterTest]: Event generation validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java[SecurityEventCounterTest]: Event generation validation
 * All attack tests verify events are generated
 
 *Status*: ✅ VERIFIED
@@ -474,20 +473,20 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 ==== Specifications
 
 * All validation stages implement input validation:
-* link:../../../src/main/java/de/cuioss/http/security/validation/LengthValidationStage.java[LengthValidationStage]
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage]
-* link:../../../src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage]
-* link:../../../src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage]
-* link:../../../src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage]
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/LengthValidationStage.java[LengthValidationStage]
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage]
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage]
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage]
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage]
 
 ==== Unit Tests
 
 * All validation stage tests:
-* link:../../../src/test/java/de/cuioss/http/security/validation/LengthValidationStageTest.java[LengthValidationStageTest]
-* link:../../../src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest]
-* link:../../../src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java[DecodingStageTest]
-* link:../../../src/test/java/de/cuioss/http/security/validation/NormalizationStageTest.java[NormalizationStageTest]
-* link:../../../src/test/java/de/cuioss/http/security/validation/PatternMatchingStageTest.java[PatternMatchingStageTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/LengthValidationStageTest.java[LengthValidationStageTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java[DecodingStageTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/NormalizationStageTest.java[NormalizationStageTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/PatternMatchingStageTest.java[PatternMatchingStageTest]
 
 *Status*: ✅ VERIFIED
 
@@ -504,13 +503,13 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage]: Blocks malicious characters
-* link:../../../src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage]: Detects attack patterns
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage]: Blocks malicious characters
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage]: Detects attack patterns
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest]
-* link:../../../src/test/java/de/cuioss/http/security/validation/PatternMatchingStageTest.java[PatternMatchingStageTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/PatternMatchingStageTest.java[PatternMatchingStageTest]
 * All attack database tests
 
 *Status*: ✅ VERIFIED
@@ -530,10 +529,10 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/tests/ApacheCVEAttackDatabaseTest.java[ApacheCVEAttackDatabaseTest]: Apache CVEs
-* link:../../../src/test/java/de/cuioss/http/security/tests/IISCVEAttackDatabaseTest.java[IISCVEAttackDatabaseTest]: IIS CVEs
-* link:../../../src/test/java/de/cuioss/http/security/tests/NginxCVEAttackDatabaseTest.java[NginxCVEAttackDatabaseTest]: Nginx CVEs
-* link:../../../src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]: References CVE-2019-5418, CVE-2018-1000671, CVE-2020-5398
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/ApacheCVEAttackDatabaseTest.java[ApacheCVEAttackDatabaseTest]: Apache CVEs
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/IISCVEAttackDatabaseTest.java[IISCVEAttackDatabaseTest]: IIS CVEs
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/NginxCVEAttackDatabaseTest.java[NginxCVEAttackDatabaseTest]: Nginx CVEs
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]: References CVE-2019-5418, CVE-2018-1000671, CVE-2020-5398
 
 *Status*: ✅ VERIFIED
 
@@ -548,14 +547,14 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline]: Header security
-* link:../../../src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest]: Protocol-level attacks (CWE-444)
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline]: Header security
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest]: Protocol-level attacks (CWE-444)
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java[HTTPHeaderValidationPipelineTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java[HTTPHeaderValidationPipelineTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest]
 
 *Status*: ✅ VERIFIED
 
@@ -573,7 +572,7 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/generators/AllGeneratorsIntegrationTest.java[AllGeneratorsIntegrationTest]: Generator framework testing
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/AllGeneratorsIntegrationTest.java[AllGeneratorsIntegrationTest]: Generator framework testing
 * All attack database tests demonstrate systematic security testing
 * Test coverage &gt; 80% (enforced by build)
 
@@ -592,13 +591,13 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage]: Character filtering
-* link:../../../src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage]: Encoding attack prevention
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage]: Character filtering
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage]: Encoding attack prevention
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/MixedEncodingAttackTest.java[MixedEncodingAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/MixedEncodingAttackTest.java[MixedEncodingAttackTest]
 
 *Note*: Full SQL injection prevention requires application-layer validation. HTTP layer provides input sanitization.
 
@@ -615,13 +614,13 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]: Access control enforcement
-* link:../../../src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage]: Canonicalization
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline]: Access control enforcement
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage]: Canonicalization
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]: 64+ test cases
-* link:../../../src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java[OWASPTop10AttackDatabaseTest]: Access control bypass patterns
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]: 64+ test cases
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java[OWASPTop10AttackDatabaseTest]: Access control bypass patterns
 * All CVE attack database tests
 
 *Status*: ✅ VERIFIED
@@ -637,13 +636,13 @@ The CUI-HTTP Security Validation library addresses OWASP Top 10 2021 categories 
 
 ==== Specifications
 
-* link:../../../src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: Event tracking
-* link:../../../src/main/java/de/cuioss/http/security/monitoring/URLSecurityLogMessages.java[URLSecurityLogMessages]: Structured logging
-* link:../../../src/main/java/de/cuioss/http/security/exceptions/UrlSecurityException.java[UrlSecurityException]: Detailed context
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: Event tracking
+ * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: Event tracking and logging
+ * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/exceptions/UrlSecurityException.java[UrlSecurityException]: Detailed context
 
 ==== Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java[SecurityEventCounterTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java[SecurityEventCounterTest]
 * All attack tests verify audit trail generation
 
 *Status*: ✅ VERIFIED

--- a/doc/http-security/specification/pipeline-architecture-standards.adoc
+++ b/doc/http-security/specification/pipeline-architecture-standards.adoc
@@ -80,8 +80,8 @@ HTTP security validation should focus exclusively on HTTP protocol violations an
 
 === 4. Unicode Handling
 
-* **Unicode characters in paths** → `URLPathValidationPipeline` with `allowHighBitCharacters(true)`
-* **Unicode in parameters** → `URLParameterValidationPipeline` with `allowHighBitCharacters(true)`
+* **Unicode characters in paths** → `URLPathValidationPipeline` with `allowExtendedAscii(true)`
+* **Unicode in parameters** → `URLParameterValidationPipeline` with `allowExtendedAscii(true)`
 
 === 5. Configuration Requirements
 
@@ -94,7 +94,7 @@ SecurityConfiguration config = SecurityConfiguration.defaults();
 
 // For Unicode path content:
 SecurityConfiguration unicodeConfig = SecurityConfiguration.builder()
-    .allowHighBitCharacters(true)
+    .allowExtendedAscii(true)
     .build();
 ----
 

--- a/doc/http-security/specification/specification.adoc
+++ b/doc/http-security/specification/specification.adoc
@@ -74,30 +74,30 @@ The following classes implement the core security validation components:
 [#_core_interfaces_and_data_types]
 ==== Core Interfaces
 
-* link:../../../src/main/java/de/cuioss/http/security/core/HttpSecurityValidator.java[HttpSecurityValidator] - Core functional interface for validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/core/HttpSecurityValidator.java[HttpSecurityValidator] - Core functional interface for validation
 
 [#_validation_types]
-* link:../../../src/main/java/de/cuioss/http/security/core/ValidationType.java[ValidationType] - Enumeration of input types for validation
-* link:../../../src/main/java/de/cuioss/http/security/core/UrlSecurityFailureType.java[UrlSecurityFailureType] - Failure type enumeration
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/core/ValidationType.java[ValidationType] - Enumeration of input types for validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/core/UrlSecurityFailureType.java[UrlSecurityFailureType] - Failure type enumeration
 
 [#_urlsecurityexception]
 ==== Exception Handling
 
-* link:../../../src/main/java/de/cuioss/http/security/exceptions/UrlSecurityException.java[UrlSecurityException] - Main exception for security violations
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/exceptions/UrlSecurityException.java[UrlSecurityException] - Main exception for security violations
 
 ==== Data Models
 
-* link:../../../src/main/java/de/cuioss/http/security/data/URLParameter.java[URLParameter] - URL parameter representation
-* link:../../../src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie] - Cookie data model
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/data/URLParameter.java[URLParameter] - URL parameter representation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java[Cookie] - Cookie data model
 
 For implementation details, see the JavaDoc of each class.
 
 The following tests verify the implementation:
 
-* link:../../../src/test/java/de/cuioss/http/security/core/HttpSecurityValidatorTest.java[HttpSecurityValidatorTest]
-* link:../../../src/test/java/de/cuioss/http/security/core/ValidationTypeTest.java[ValidationTypeTest]
-* link:../../../src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java[UrlSecurityFailureTypeTest]
-* link:../../../src/test/java/de/cuioss/http/security/exceptions/UrlSecurityExceptionTest.java[UrlSecurityExceptionTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/core/HttpSecurityValidatorTest.java[HttpSecurityValidatorTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/core/ValidationTypeTest.java[ValidationTypeTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java[UrlSecurityFailureTypeTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/exceptions/UrlSecurityExceptionTest.java[UrlSecurityExceptionTest]
 
 [#_configuration_architecture]
 == Configuration Architecture
@@ -110,9 +110,9 @@ _See Requirement xref:../functional-requirements.adoc#HTTP-14[HTTP-14: Type-Spec
 
 The following classes implement the security configuration system:
 
-* link:../../../src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java[SecurityConfiguration] - Main configuration record
-* link:../../../src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java[SecurityConfigurationBuilder] - Builder for configuration
-* link:../../../src/main/java/de/cuioss/http/security/config/SecurityDefaults.java[SecurityDefaults] - Default security constants
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java[SecurityConfiguration] - Main configuration record
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java[SecurityConfigurationBuilder] - Builder for configuration
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java[SecurityDefaults] - Default security constants
 
 [#_validation_type_configurations]
 The configuration system provides:
@@ -125,9 +125,9 @@ For implementation details and configuration constants, see the JavaDoc of the c
 
 The following tests verify the configuration implementation:
 
-* link:../../../src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java[SecurityConfigurationTest]
-* link:../../../src/test/java/de/cuioss/http/security/config/SecurityConfigurationBuilderTest.java[SecurityConfigurationBuilderTest]
-* link:../../../src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java[SecurityDefaultsTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java[SecurityConfigurationTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationBuilderTest.java[SecurityConfigurationBuilderTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java[SecurityDefaultsTest]
 
 [#_validation_stages]
 == Validation Stages
@@ -148,21 +148,21 @@ All validation stages follow these principles:
 The following classes implement the validation stages:
 
 [#_lengthvalidationstage]
-* link:../../../src/main/java/de/cuioss/http/security/validation/LengthValidationStage.java[LengthValidationStage] - Size limit validation (must be first to prevent DoS)
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/LengthValidationStage.java[LengthValidationStage] - Size limit validation (must be first to prevent DoS)
 
 [#_charactervalidationstage]
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - RFC-compliant character validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - RFC-compliant character validation
 
 [#_encodingvalidationstage]
 [#_decodingstage]
-* link:../../../src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage] - URL decoding with security checks
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage] - URL decoding with security checks
 
 [#_normalizationstage]
-* link:../../../src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage] - Path normalization per RFC 3986
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage] - Path normalization per RFC 3986
 
 [#_patternmatchingstage]
-* link:../../../src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage] - Attack pattern detection
-* link:../../../src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java[CharacterValidationConstants] - RFC-compliant character sets
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage] - Attack pattern detection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java[CharacterValidationConstants] - RFC-compliant character sets
 
 For implementation details, see the JavaDoc of each validation stage class.
 
@@ -184,10 +184,10 @@ For detailed pipeline selection guidelines and architecture standards, see xref:
 
 The following classes implement the validation pipeline system:
 
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline] - URL path validation
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/URLParameterValidationPipeline.java[URLParameterValidationPipeline] - URL parameter validation
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] - HTTP header validation
-* link:../../../src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java[PipelineFactory] - Factory for pipeline creation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java[URLPathValidationPipeline] - URL path validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLParameterValidationPipeline.java[URLParameterValidationPipeline] - URL parameter validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] - HTTP header validation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java[PipelineFactory] - Factory for pipeline creation
 
 Each pipeline is optimized for its specific HTTP component validation requirements.
 
@@ -204,8 +204,8 @@ The following classes implement security event tracking and monitoring:
 
 [#_event_counter_pattern]
 [#_securityeventcounter]
-* link:../../../src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter] - Thread-safe event counting
-* link:../../../src/main/java/de/cuioss/http/security/monitoring/URLSecurityLogMessages.java[URLSecurityLogMessages] - Structured logging with LogRecord pattern
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter] - Thread-safe event counting
+ * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter] - Thread-safe event counting and tracking
 
 For implementation details, see the JavaDoc of each monitoring class.
 
@@ -215,33 +215,33 @@ The following test suites verify the implementation meets this specification:
 
 === Unit Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/core/HttpSecurityValidatorTest.java[HttpSecurityValidatorTest] - Core interface tests
-* link:../../../src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java[UrlSecurityFailureTypeTest] - Failure type enumeration tests
-* link:../../../src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java[SecurityConfigurationTest] - Configuration tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/core/HttpSecurityValidatorTest.java[HttpSecurityValidatorTest] - Core interface tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java[UrlSecurityFailureTypeTest] - Failure type enumeration tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java[SecurityConfigurationTest] - Configuration tests
 
 === Validation Stage Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/validation/LengthValidationStageTest.java[LengthValidationStageTest] - Length validation tests
-* link:../../../src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest] - Character validation tests
-* link:../../../src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java[DecodingStageTest] - Decoding stage tests
-* link:../../../src/test/java/de/cuioss/http/security/validation/NormalizationStageTest.java[NormalizationStageTest] - Path normalization tests
-* link:../../../src/test/java/de/cuioss/http/security/validation/PatternMatchingStageTest.java[PatternMatchingStageTest] - Pattern matching tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/LengthValidationStageTest.java[LengthValidationStageTest] - Length validation tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest] - Character validation tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java[DecodingStageTest] - Decoding stage tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/NormalizationStageTest.java[NormalizationStageTest] - Path normalization tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/PatternMatchingStageTest.java[PatternMatchingStageTest] - Pattern matching tests
 
 === Pipeline Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java[URLPathValidationPipelineTest] - Path pipeline tests
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java[URLParameterValidationPipelineTest] - Parameter pipeline tests
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java[HTTPHeaderValidationPipelineTest] - Header pipeline tests
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/PipelineFactoryTest.java[PipelineFactoryTest] - Factory tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java[URLPathValidationPipelineTest] - Path pipeline tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java[URLParameterValidationPipelineTest] - Parameter pipeline tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java[HTTPHeaderValidationPipelineTest] - Header pipeline tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/PipelineFactoryTest.java[PipelineFactoryTest] - Factory tests
 
 === Attack Database Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/tests/OWASPZAPAttackDatabaseTest.java[OWASPZAPAttackDatabaseTest] - OWASP ZAP attack patterns
-* link:../../../src/test/java/de/cuioss/http/security/tests/ApacheCVEAttackDatabaseTest.java[ApacheCVEAttackDatabaseTest] - Apache CVE tests
-* link:../../../src/test/java/de/cuioss/http/security/tests/IISCVEAttackDatabaseTest.java[IISCVEAttackDatabaseTest] - IIS CVE tests
-* link:../../../src/test/java/de/cuioss/http/security/tests/UnicodePathTraversalAttackTest.java[UnicodePathTraversalAttackTest] - Unicode attack tests
-* link:../../../src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest] - Header injection tests
-* link:../../../src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest] - Request smuggling tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPZAPAttackDatabaseTest.java[OWASPZAPAttackDatabaseTest] - OWASP ZAP attack patterns
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/ApacheCVEAttackDatabaseTest.java[ApacheCVEAttackDatabaseTest] - Apache CVE tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/IISCVEAttackDatabaseTest.java[IISCVEAttackDatabaseTest] - IIS CVE tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodePathTraversalAttackTest.java[UnicodePathTraversalAttackTest] - Unicode attack tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest] - Header injection tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest] - Request smuggling tests
 
 == Performance Optimization
 
@@ -275,7 +275,7 @@ Each pipeline is configured with appropriate validation stages:
 * **URLParameterValidationPipeline**: Focused on parameter injection and XSS
 * **HTTPHeaderValidationPipeline**: Prevents header injection and CRLF attacks
 
-For usage examples, see the JavaDoc of link:../../../src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java[PipelineFactory].
+For usage examples, see the JavaDoc of link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java[PipelineFactory].
 
 == Security Considerations
 

--- a/doc/http-security/specification/testing.adoc
+++ b/doc/http-security/specification/testing.adoc
@@ -44,9 +44,6 @@ src/test/java/de/cuioss/http/security/
 ├── generators/                              # Test data generators (organized by type)
 │   ├── AllGeneratorsIntegrationTest.java   # Generator integration tests
 │   ├── SupportedValidationTypeGenerator.java
-│   ├── body/                               # Note: HTTP body validation has been eliminated
-│   │   ├── HTTPBodyGenerator.java          # (Deprecated - no longer used)
-│   │   └── ValidHTTPBodyContentGenerator.java  # (Deprecated - no longer used)
 │   ├── cookie/                             # Cookie generators
 │   │   ├── AttackCookieGenerator.java
 │   │   └── ValidCookieGenerator.java
@@ -140,7 +137,7 @@ package de.cuioss.http.security.attacks;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
-import de.cuioss.test.generator.junit.TypeGeneratorSource;
+import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -152,17 +149,18 @@ public class PathTraversalAttackTest {
     private final HttpSecurityValidator validator = createValidator();
 
     private HttpSecurityValidator createValidator() {
-        // Create a path validation pipeline for testing
-        return PipelineFactory.createPipeline(ValidationType.URL_PATH);
+        var config = SecurityConfiguration.defaults();
+        var counter = new SecurityEventCounter();
+        return PipelineFactory.createPipeline(ValidationType.URL_PATH, config, counter);
     }
     
     @ParameterizedTest(name = "T1: Path traversal [{index}]: {0}")
-    @TypeGeneratorSource(value = PathTraversalGenerator.class, count = 100)
+    @TypeGeneratorSource(value = PathTraversalURLGenerator.class, count = 100)
     void testBasicPathTraversal_T1(String attack) {
         // T1: Basic path traversal patterns from generator
         UrlSecurityException exception = assertThrows(
             UrlSecurityException.class, 
-            () -> validator.execute(attack),
+            () -> validator.validate(attack),
             "Failed to detect path traversal: " + attack
         );
         
@@ -180,7 +178,7 @@ public class PathTraversalAttackTest {
         // T2: URL-encoded path traversal - caught early at character validation
         UrlSecurityException exception = assertThrows(
             UrlSecurityException.class, 
-            () -> validator.execute(encoded)
+            () -> validator.validate(encoded)
         );
         
         // Should be caught at character validation or as encoding issue
@@ -197,7 +195,7 @@ public class PathTraversalAttackTest {
         // T3: Unicode-based path traversal
         UrlSecurityException exception = assertThrows(
             UrlSecurityException.class, 
-            () -> validator.execute(unicode)
+            () -> validator.validate(unicode)
         );
         
         // Should detect unicode attacks
@@ -215,7 +213,7 @@ public class PathTraversalAttackTest {
         // BoundaryFuzzingGenerator includes null byte patterns
         UrlSecurityException exception = assertThrows(
             UrlSecurityException.class, 
-            () -> validator.execute(nullByteAttack)
+            () -> validator.validate(nullByteAttack)
         );
         
         // Must be caught as appropriate security issue
@@ -235,74 +233,60 @@ public class PathTraversalAttackTest {
 
 === Database Structure
 
+Attack databases implement the `AttackDatabase` interface providing curated collections of security test cases:
+
+* `ApacheCVEAttackDatabase` - Apache HTTP Server and Tomcat CVE exploits
+* `IISCVEAttackDatabase` - Microsoft IIS and Windows vulnerabilities
+* `NginxCVEAttackDatabase` - Nginx server CVE patterns
+* `OWASPTop10AttackDatabase` - OWASP Top 10 2021 attack vectors
+* `ModSecurityCRSAttackDatabase` - ModSecurity Core Rule Set patterns
+* `OWASPZAPAttackDatabase` - OWASP ZAP scanner patterns
+* `HomographAttackDatabase` - Unicode homograph attacks
+* `IPv6AttackDatabase` - IPv6-specific patterns
+* `ProtocolHandlerAttackDatabase` - Protocol manipulation attacks
+* `IDNAttackDatabase` - Internationalized Domain Name attacks
+
+Each database provides attack test cases as `AttackTestCase` records with attack string, expected `UrlSecurityFailureType`, description, and detection rationale.
+
+=== Attack Database Usage
+
 [source,java]
 ----
-package de.cuioss.http.security.database;
+import de.cuioss.http.security.database.ApacheCVEAttackDatabase;
+import de.cuioss.http.security.database.AttackTestCase;
 
-/**
- * Central repository of attack patterns.
- */
-public class AttackPatternDatabase {
-    
-    private final Map<String, AttackPattern> patterns = new HashMap<>();
-    
-    public record AttackPattern(
-        String id,
-        String name,
-        String pattern,
-        AttackCategory category,
-        String cveReference,
-        String owaspReference,
-        String description,
-        boolean shouldBlock,
-        String justification
-    ) {}
-    
-    public enum AttackCategory {
-        PATH_TRAVERSAL,
-        ENCODING_BYPASS,
-        UNICODE_ATTACK,
-        INJECTION,
-        HTTP_SMUGGLING,
-        DOS_ATTACK,
-        PROTOCOL_ABUSE
-    }
-    
-    public AttackPatternDatabase() {
-        loadCVEPatterns();
-        loadOWASPPatterns();
-        loadModSecurityPatterns();
-    }
-    
-    private void loadCVEPatterns() {
-        // CVE-2021-41773: Apache path traversal
-        patterns.put("CVE-2021-41773", new AttackPattern(
-            "CVE-2021-41773",
-            "Apache Path Traversal",
-            "/.%2e/",
-            AttackCategory.PATH_TRAVERSAL,
-            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-41773",
-            "CWE-22",
-            "Apache HTTP Server 2.4.49 path traversal",
-            true,
-            "Known critical vulnerability allowing directory traversal"
-        ));
-        
-        // CVE-2021-42013: Apache double encoding
-        patterns.put("CVE-2021-42013", new AttackPattern(
-            "CVE-2021-42013",
-            "Apache Double Encoding",
-            "%%32%65",
-            AttackCategory.ENCODING_BYPASS,
-            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42013",
-            "CWE-22",
-            "Apache HTTP Server double encoding bypass",
-            true,
-            "Double encoding bypass of CVE-2021-41773 fix"
-        ));
-        
-        // More CVE patterns loaded from database...
-    }
+@ParameterizedTest
+@MethodSource("apacheCVEAttacks")
+void shouldDetectApacheCVEs(AttackTestCase testCase) {
+    UrlSecurityException exception = assertThrows(
+        UrlSecurityException.class,
+        () -> pathValidator.validate(testCase.attackString())
+    );
+    assertEquals(testCase.expectedFailureType(), exception.getFailureType());
+}
+
+static Stream<AttackTestCase> apacheCVEAttacks() {
+    return StreamSupport.stream(
+        new ApacheCVEAttackDatabase().getAttackTestCases().spliterator(),
+        false
+    );
+}
+----
+
+=== Using ArgumentsProvider
+
+Each database includes a nested `ArgumentsProvider` for cleaner test declarations:
+
+[source,java]
+----
+@ParameterizedTest
+@ArgumentsSource(ApacheCVEAttackDatabase.ArgumentsProvider.class)
+void shouldRejectApacheCVEs(AttackTestCase testCase) {
+    UrlSecurityException exception = assertThrows(
+        UrlSecurityException.class,
+        () -> pathValidator.validate(testCase.attackString())
+    );
+    assertEquals(testCase.expectedFailureType(), exception.getFailureType());
 }
 ----
 
@@ -412,19 +396,18 @@ public class PerformanceValidationBenchmark {
     @Setup(Level.Trial)
     public void setupBenchmark() {
         // Setup configuration
-        UrlSecurityConfig baseConfig = UrlSecurityConfig.builder()
+        var config = SecurityConfiguration.builder()
             .maxPathLength(2048)
-            .maxDirectoryDepth(10)
             .build();
         
-        SecurityEventCounter eventCounter = new SecurityEventCounter();
+        var eventCounter = new SecurityEventCounter();
         
-        // Create validators for different types
-        pathValidator = createPathValidator(baseConfig, eventCounter);
-        paramNameValidator = createParameterNameValidator(baseConfig, eventCounter);
-        paramValueValidator = createParameterValueValidator(baseConfig, eventCounter);
-        headerNameValidator = createHeaderNameValidator(baseConfig, eventCounter);
-        headerValueValidator = createHeaderValueValidator(baseConfig, eventCounter);
+        // Create validators using PipelineFactory
+        pathValidator = PipelineFactory.createUrlPathPipeline(config, eventCounter);
+        paramNameValidator = PipelineFactory.createParameterNamePipeline(config, eventCounter);
+        paramValueValidator = PipelineFactory.createUrlParameterPipeline(config, eventCounter);
+        headerNameValidator = PipelineFactory.createHeaderNamePipeline(config, eventCounter);
+        headerValueValidator = PipelineFactory.createHeaderValuePipeline(config, eventCounter);
         
         // Setup generators
         attackGen = new PathTraversalGenerator();
@@ -523,30 +506,14 @@ public class PerformanceValidationBenchmark {
         }
     }
     
-    private HttpSecurityValidator createPathValidator(UrlSecurityConfig baseConfig, SecurityEventCounter eventCounter) {
-        ConfigStageProvider pathConfig = new URLPathConfig(baseConfig);
-        return new UnifiedValidationPipeline(pathConfig, eventCounter);
-    }
-    
-    private HttpSecurityValidator createParameterNameValidator(UrlSecurityConfig baseConfig, SecurityEventCounter eventCounter) {
-        ConfigStageProvider paramNameConfig = new URLParameterNameConfig(baseConfig);
-        return new UnifiedValidationPipeline(paramNameConfig, eventCounter);
-    }
-    
-    private HttpSecurityValidator createParameterValueValidator(UrlSecurityConfig baseConfig, SecurityEventCounter eventCounter) {
-        ConfigStageProvider paramValueConfig = new URLParameterValueConfig(baseConfig);
-        return new UnifiedValidationPipeline(paramValueConfig, eventCounter);
-    }
-    
-    private HttpSecurityValidator createHeaderNameValidator(UrlSecurityConfig baseConfig, SecurityEventCounter eventCounter) {
-        ConfigStageProvider headerNameConfig = new HTTPHeaderNameConfig(baseConfig);
-        return new UnifiedValidationPipeline(headerNameConfig, eventCounter);
-    }
-    
-    private HttpSecurityValidator createHeaderValueValidator(UrlSecurityConfig baseConfig, SecurityEventCounter eventCounter) {
-        ConfigStageProvider headerValueConfig = new HTTPHeaderValueConfig(baseConfig);
-        return new UnifiedValidationPipeline(headerValueConfig, eventCounter);
-    }
+    // PipelineFactory static methods used directly in setupBenchmark()
+    // Available factory methods:
+    //   PipelineFactory.createUrlPathPipeline(config, eventCounter)
+    //   PipelineFactory.createParameterNamePipeline(config, eventCounter)
+    //   PipelineFactory.createUrlParameterPipeline(config, eventCounter)
+    //   PipelineFactory.createHeaderNamePipeline(config, eventCounter)
+    //   PipelineFactory.createHeaderValuePipeline(config, eventCounter)
+    //   PipelineFactory.createPipeline(ValidationType, config, eventCounter)
     
     /**
      * Main method for running benchmarks standalone
@@ -619,7 +586,7 @@ Add to GitHub Actions or Jenkins:
 
 === Security Coverage Metrics
 
-1. **Attack Pattern Coverage**: 100% of patterns in AttackPatternDatabase
+1. **Attack Pattern Coverage**: 100% of patterns in attack databases
 2. **CVE Coverage**: All relevant CVEs from 2020-2024
 3. **OWASP Coverage**: Complete OWASP Top 10 2021
 4. **Encoding Coverage**: All encoding combinations up to 3 levels
@@ -651,89 +618,36 @@ Add to GitHub Actions or Jenkins:
 
 == Generator Usage Guidelines
 
-=== Custom Test Annotations
+=== Generator-based Parameterized Tests
+
+The framework uses `@TypeGeneratorSource` from `cui-test-generator` for parameterized tests:
 
 [source,java]
 ----
-package de.cuioss.http.security.testing;
+@EnableGeneratorController
+class SecurityValidationTest {
 
-import org.junit.jupiter.params.provider.ArgumentsSource;
-import java.lang.annotation.*;
+    private final HttpSecurityValidator pathValidator =
+        PipelineFactory.createUrlPathPipeline(
+            SecurityConfiguration.defaults(),
+            new SecurityEventCounter());
 
-/**
- * Custom annotation for generator-based tests.
- * Automatically provides test data from all security generators.
- */
-@Target({ElementType.METHOD})
-@Retention(RetentionPolicy.RUNTIME)
-@ArgumentsSource(GeneratorsArgumentsProvider.class)
-@Documented
-public @interface GeneratorsSource {
-    /**
-     * Which generator types to use
-     */
-    GeneratorType[] value() default {
-        GeneratorType.PATH_TRAVERSAL,
-        GeneratorType.ENCODING,
-        GeneratorType.UNICODE,
-        GeneratorType.BOUNDARY
-    };
-    
-    /**
-     * Number of test cases to generate per generator
-     */
-    int limit() default 100;
-}
-
-public enum GeneratorType {
-    PATH_TRAVERSAL,
-    ENCODING,
-    UNICODE,
-    BOUNDARY,
-    VALID_URL,
-    INVALID_URL,
-    PARAMETER_NAME,
-    PARAMETER_VALUE,
-    COOKIE,
-    HTTP_BODY
-}
-
-/**
- * ArgumentsProvider for @GeneratorsSource annotation.
- */
-public class GeneratorsArgumentsProvider implements ArgumentsProvider {
-    @Override
-    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-        GeneratorsSource annotation = context.getRequiredTestMethod()
-            .getAnnotation(GeneratorsSource.class);
-        
-        List<Stream<Arguments>> streams = new ArrayList<>();
-        
-        for (GeneratorType type : annotation.value()) {
-            TypedGenerator<String> generator = createGenerator(type);
-            Stream<Arguments> stream = Stream.generate(() -> 
-                Arguments.of(generator.next(), type.name())
-            ).limit(annotation.limit());
-            streams.add(stream);
-        }
-        
-        // Combine all streams
-        return streams.stream().flatMap(Function.identity());
+    @ParameterizedTest(name = "Valid path [{index}]: {0}")
+    @TypeGeneratorSource(value = ValidURLPathGenerator.class, count = 10)
+    void shouldAcceptValidPaths(String validPath) {
+        Optional<String> result = pathValidator.validate(validPath);
+        assertTrue(result.isPresent(), "Valid path should pass: " + validPath);
     }
-    
-    private TypedGenerator<String> createGenerator(GeneratorType type) {
-        return switch (type) {
-            case PATH_TRAVERSAL -> new PathTraversalGenerator();
-            case ENCODING -> new EncodingCombinationGenerator();
-            case UNICODE -> new UnicodeAttackGenerator();
-            case BOUNDARY -> new BoundaryFuzzingGenerator();
-            case VALID_URL -> new ValidURLGenerator();
-            case INVALID_URL -> new InvalidURLGenerator();
-            case PARAMETER_NAME -> new URLParameterNameGenerator();
-            case PARAMETER_VALUE -> new URLParameterValueGenerator();
-            case COOKIE -> new CookieGenerator();
-            case HTTP_BODY -> throw new UnsupportedOperationException("HTTP body validation has been eliminated from the architecture");
-        };
+
+    @ParameterizedTest(name = "Path traversal [{index}]: {0}")
+    @TypeGeneratorSource(value = PathTraversalURLGenerator.class, count = 5)
+    void shouldRejectPathTraversal(String attack) {
+        UrlSecurityException exception = assertThrows(
+            UrlSecurityException.class,
+            () -> pathValidator.validate(attack)
+        );
+        assertEquals(UrlSecurityFailureType.PATH_TRAVERSAL_DETECTED,
+            exception.getFailureType());
     }
 }
 ----
@@ -746,65 +660,52 @@ public class GeneratorsArgumentsProvider implements ArgumentsProvider {
 
 [source,java]
 ----
-package de.cuioss.http.security.validation;
+import de.cuioss.http.security.core.ValidationType;
+import de.cuioss.http.security.pipeline.PipelineFactory;
 
-/**
- * Tests to ensure ValidationType is properly propagated through the system.
- */
-public class ValidationTypeTest {
-    
+class ValidationTypeTest {
+
+    private final SecurityConfiguration config = SecurityConfiguration.defaults();
+    private final SecurityEventCounter counter = new SecurityEventCounter();
+
     @Test
-    void testValidationTypeInException() {
-        // Create validators for different types
-        UrlSecurityConfig config = UrlSecurityConfig.builder().build();
-        
-        // Test URL_PATH type
-        ConfigStageProvider pathConfig = new URLPathConfig(config);
-        HttpSecurityValidator pathValidator = new UnifiedValidationPipeline(
-            pathConfig, new SecurityEventCounter());
-        
+    void shouldAssociateValidationTypeWithException() {
+        HttpSecurityValidator pathValidator =
+            PipelineFactory.createPipeline(ValidationType.URL_PATH, config, counter);
+
+        UrlSecurityException exception = assertThrows(
+            UrlSecurityException.class,
+            () -> pathValidator.validate("../../../etc/passwd")
+        );
+        assertEquals(ValidationType.URL_PATH, exception.getValidationType());
+    }
+
+    @Test
+    void shouldPreserveValidationTypeAcrossAllPipelines() {
+        var pipelines = PipelineFactory.createCommonPipelines(config, counter);
+
+        HttpSecurityValidator pathValidator = pipelines.urlPathPipeline();
+        HttpSecurityValidator paramValidator = pipelines.urlParameterPipeline();
+        HttpSecurityValidator headerValidator = pipelines.headerNamePipeline();
+
+        // Each pipeline assigns the correct ValidationType on failure
         UrlSecurityException pathException = assertThrows(
             UrlSecurityException.class,
-            () -> pathValidator.execute("../../../etc/passwd")
+            () -> pathValidator.validate("../../../etc/passwd")
         );
         assertEquals(ValidationType.URL_PATH, pathException.getValidationType());
-        
-        // Test PARAMETER_VALUE type
-        ConfigStageProvider paramConfig = new URLParameterValueConfig(config);
-        HttpSecurityValidator paramValidator = new UnifiedValidationPipeline(
-            paramConfig, new SecurityEventCounter());
-        
+
         UrlSecurityException paramException = assertThrows(
             UrlSecurityException.class,
-            () -> paramValidator.execute("<script>alert(1)</script>")
+            () -> paramValidator.validate("<script>alert(1)</script>")
         );
         assertEquals(ValidationType.PARAMETER_VALUE, paramException.getValidationType());
-        
-        // Test HEADER_VALUE type
-        ConfigStageProvider headerConfig = new HTTPHeaderValueConfig(config);
-        HttpSecurityValidator headerValidator = new UnifiedValidationPipeline(
-            headerConfig, new SecurityEventCounter());
-        
+
         UrlSecurityException headerException = assertThrows(
             UrlSecurityException.class,
-            () -> headerValidator.execute("Bearer\\r\\nX-Injected: true")
+            () -> headerValidator.validate("Bearer\r\nX-Injected: true")
         );
-        assertEquals(ValidationType.HEADER_VALUE, headerException.getValidationType());
-    }
-    
-    @Test
-    void testValidationTypeConsistency() {
-        // Ensure ValidationType is consistent across all stages in a pipeline
-        UrlSecurityConfig config = UrlSecurityConfig.builder().build();
-        ConfigStageProvider pathConfig = new URLPathConfig(config);
-        
-        // All stages should report the same ValidationType
-        assertEquals(ValidationType.URL_PATH, pathConfig.getValidationType());
-        for (HttpSecurityValidator stage : pathConfig.getStages()) {
-            if (stage != null) {
-                assertEquals(ValidationType.URL_PATH, stage.getType());
-            }
-        }
+        assertEquals(ValidationType.HEADER_NAME, headerException.getValidationType());
     }
 }
 ----
@@ -826,135 +727,32 @@ import static org.junit.jupiter.api.Assertions.*;
  * Comprehensive security test using all generators.
  */
 @EnableGeneratorController
-public class ComprehensiveSecurityTest {
+class ComprehensiveSecurityTest {
 
-    private static final CuiLogger logger = new CuiLogger(ComprehensiveSecurityTest.class);
-
-    private final HttpSecurityValidator pathValidator = createPathValidator();
-    private final HttpSecurityValidator paramValidator = createParameterValidator();
-    private final HttpSecurityValidator headerValidator = createHeaderValidator();
-    
-    private HttpSecurityValidator createPathValidator() {
-        UrlSecurityConfig baseConfig = UrlSecurityConfig.builder().build();
-        ConfigStageProvider pathConfig = new URLPathConfig(baseConfig);
-        return new UnifiedValidationPipeline(pathConfig, new SecurityEventCounter());
-    }
-    
-    private HttpSecurityValidator createParameterValidator() {
-        UrlSecurityConfig baseConfig = UrlSecurityConfig.builder().build();
-        ConfigStageProvider paramConfig = new URLParameterValueConfig(baseConfig);
-        return new UnifiedValidationPipeline(paramConfig, new SecurityEventCounter());
-    }
-    
-    private HttpSecurityValidator createHeaderValidator() {
-        UrlSecurityConfig baseConfig = UrlSecurityConfig.builder().build();
-        ConfigStageProvider headerConfig = new HTTPHeaderValueConfig(baseConfig);
-        return new UnifiedValidationPipeline(headerConfig, new SecurityEventCounter());
-    }
-
-    private boolean isValidPath(String path) {
-        // Helper method to validate if a path is considered valid
-        // This checks for common invalid patterns
-        return path != null &&
-               !path.isEmpty() &&
-               !path.contains("..") &&
-               !path.contains("\\") &&
-               !path.contains("\0");
-    }
+    private final SecurityConfiguration config = SecurityConfiguration.defaults();
+    private final SecurityEventCounter counter = new SecurityEventCounter();
+    private final HttpSecurityValidator pathValidator =
+        PipelineFactory.createUrlPathPipeline(config, counter);
+    private final HttpSecurityValidator paramValidator =
+        PipelineFactory.createUrlParameterPipeline(config, counter);
+    private final HttpSecurityValidator headerValidator =
+        PipelineFactory.createHeaderValuePipeline(config, counter);
 
     @ParameterizedTest(name = "Attack detection [{index}]: {0}")
-    @CompositeTypeGeneratorSource(
-        generatorClasses = {
-            PathTraversalGenerator.class,
-            EncodingCombinationGenerator.class,
-            UnicodeAttackGenerator.class,
-            BoundaryFuzzingGenerator.class
-        }, 
-        count = 200
-    )
-    void testAllAttackPatterns(String attack) {
-        // All attack patterns should be blocked
+    @TypeGeneratorSource(value = PathTraversalURLGenerator.class, count = 50)
+    void shouldRejectPathTraversal(String attack) {
         UrlSecurityException exception = assertThrows(
             UrlSecurityException.class,
-            () -> pathValidator.execute(attack),
-            "Failed to detect attack: " + attack
+            () -> pathValidator.validate(attack)
         );
-        
-        // Verify ValidationType is properly set
-        assertEquals(ValidationType.URL_PATH, exception.getValidationType(),
-            "Exception should include ValidationType");
-        
-        // Log failure type for analysis
-        logger.debug("Detected {} for attack (type: {}): {}", 
-            exception.getFailureType(), 
-            exception.getValidationType(), attack);
+        assertEquals(ValidationType.URL_PATH, exception.getValidationType());
     }
-    
+
     @ParameterizedTest(name = "Valid URL [{index}]")
-    @TypeGeneratorSource(value = ValidURLGenerator.class, count = 500)
-    void testValidURLs(String validUrl) {
-        // Valid URLs should pass without exception
-        String result = assertDoesNotThrow(
-            () -> pathValidator.execute(validUrl),
-            "False positive for valid URL: " + validUrl
-        );
-        
-        assertNotNull(result);
-        // Result might be normalized but should still be valid
-        assertTrue(isValidPath(result), "Validation result should be a valid path: " + result);
-    }
-    
-    @ParameterizedTest(name = "Parameter validation [{index}]")
-    @TypeGeneratorSource(value = ValidURLGenerator.class, count = 200)
-    void testParameterValidation(String paramValue) {
-        // Test parameter-specific validation
-        // URLParameterValueGenerator creates both attack and valid parameters
-        try {
-            String result = paramValidator.execute(paramValue);
-            // Valid parameter passed
-            assertNotNull(result);
-        } catch (UrlSecurityException e) {
-            // Attack parameter detected - verify it's a known attack type
-            assertTrue(
-                e.getFailureType() == UrlSecurityFailureType.INVALID_CHARACTER ||
-                e.getFailureType() == UrlSecurityFailureType.INVALID_ENCODING ||
-                e.getFailureType() == UrlSecurityFailureType.PATH_TRAVERSAL_DETECTED ||
-                e.getFailureType() == UrlSecurityFailureType.SUSPICIOUS_PATTERN
-            );
-        }
-    }
-    
-    @ParameterizedTest(name = "Boundary fuzzing [{index}]")
-    @TypeGeneratorSource(value = BoundaryFuzzingGenerator.class, count = 100)
-    void testBoundaryConditions(String boundary) {
-        // Boundary conditions should be handled gracefully
-        try {
-            pathValidator.execute(boundary);
-            // If it passes, verify length constraints
-            assertTrue(boundary.length() <= UrlSecurityConfig.DEFAULT_MAX_PATH_LENGTH);
-        } catch (UrlSecurityException e) {
-            // Expected for oversized or malformed inputs
-            assertTrue(
-                e.getFailureType() == UrlSecurityFailureType.PATH_TOO_LONG ||
-                e.getFailureType() == UrlSecurityFailureType.EXCESSIVE_NESTING ||
-                e.getFailureType() == UrlSecurityFailureType.INVALID_CHARACTER
-            );
-        }
-    }
-    
-    @Test
-    void testGeneratorCoverage() {
-        // Verify all generators produce unique patterns
-        Set<String> uniquePatterns = new HashSet<>();
-        PathTraversalGenerator gen = new PathTraversalGenerator();
-        
-        for (int i = 0; i < 1000; i++) {
-            uniquePatterns.add(gen.next());
-        }
-        
-        // Should generate many unique patterns
-        assertTrue(uniquePatterns.size() > 500, 
-            "Generator should produce diverse patterns");
+    @TypeGeneratorSource(value = ValidURLPathGenerator.class, count = 50)
+    void shouldAcceptValidPaths(String validPath) {
+        Optional<String> result = pathValidator.validate(validPath);
+        assertTrue(result.isPresent(), "Valid path should pass: " + validPath);
     }
 }
 ----
@@ -963,206 +761,23 @@ public class ComprehensiveSecurityTest {
 
 1. **Always use TypedGenerator interface** - Ensures type safety
 2. **Use Generator class, never Random** - Maintains determinism  
-3. **Respect configuration limits** - Check DEFAULT_* constants
+3. **Respect configuration limits** - Check constants in `SecurityConfiguration`
 4. **Document attack sources** - Include CVE/OWASP references
-5. **Test generators themselves** - Task G10 validates all generators
-6. **Use @GeneratorsSource** - For comprehensive parameterized testing
+5. **Test generators themselves** - `AllGeneratorsIntegrationTest` validates all generators
+6. **Use @TypeGeneratorSource** - For generator-based parameterized testing
 7. **Combine generators** - Test interaction between different attack types
 8. **Track failure types** - Ensure attacks are caught for the right reasons
-
-=== Additional Test Examples
-
-[source,java]
-----
-/**
- * False positive prevention tests.
- */
-public class FalsePositiveTest {
-
-    private final HttpSecurityValidator validator = createValidator();
-
-    private HttpSecurityValidator createValidator() {
-        // Create a path validation pipeline for testing
-        return PipelineFactory.createPipeline(ValidationType.URL_PATH);
-    }
-    
-    @ParameterizedTest(name = "Valid URLs should pass [{index}]: {0}")
-    @GeneratorsSource(value = GeneratorType.VALID_URL, limit = 500)
-    void testValidURLsNoFalsePositives(String validUrl, String generatorType) {
-        // T31: Legitimate paths should pass validation
-        String result = assertDoesNotThrow(
-            () -> validator.execute(validUrl),
-            "False positive on valid URL: " + validUrl
-        );
-        
-        // Result should be non-null and potentially normalized
-        assertNotNull(result);
-    }
-    
-    @ParameterizedTest(name = "Invalid URLs should fail [{index}]: {0}")
-    @GeneratorsSource(value = GeneratorType.INVALID_URL, limit = 200)
-    void testInvalidURLsDetected(String invalidUrl, String generatorType) {
-        // T32: Malformed URLs should be rejected
-        assertThrows(
-            UrlSecurityException.class,
-            () -> validator.execute(invalidUrl),
-            "Failed to detect invalid URL: " + invalidUrl
-        );
-    }
-}
-
-/**
- * Performance validation tests.
- */
-public class PerformanceValidationTest {
-
-    private final HttpSecurityValidator validator = createValidator();
-
-    private HttpSecurityValidator createValidator() {
-        // Create a path validation pipeline for testing
-        return PipelineFactory.createPipeline(ValidationType.URL_PATH);
-    }
-    
-    @ParameterizedTest(name = "Performance test [{index}]")
-    @GeneratorsSource(value = {
-        GeneratorType.VALID_URL,
-        GeneratorType.PATH_TRAVERSAL,
-        GeneratorType.ENCODING
-    }, limit = 1000)
-    void testPerformanceUnderLoad_T34(String input, String generatorType) {
-        // T34-T36: Verify <1ms performance requirement
-        long startTime = System.nanoTime();
-        
-        try {
-            validator.execute(input);
-        } catch (UrlSecurityException e) {
-            // Expected for attack inputs
-        }
-        
-        long duration = System.nanoTime() - startTime;
-        long durationMs = duration / 1_000_000;
-        
-        // Must complete within 1ms
-        assertTrue(durationMs < 1, 
-            "Validation took " + durationMs + "ms for " + generatorType);
-    }
-}
-
-/**
- * Cookie and HTTP header validation tests.
- * Note: HTTP body validation has been eliminated from the architecture.
- * All URL validation is now handled by URLPathValidationPipeline.
- */
-public class HTTPDataValidationTest {
-
-    private final HttpSecurityValidator cookieValidator = createCookieValidator();
-    private final HttpSecurityValidator headerValidator = createHeaderValidator();
-
-    private HttpSecurityValidator createCookieValidator() {
-        // Create a cookie validation pipeline
-        // Note: This would typically use specialized cookie validation rules
-        return PipelineFactory.createPipeline(ValidationType.HEADER_VALUE);
-    }
-
-    private HttpSecurityValidator createHeaderValidator() {
-        // Create a header validation pipeline
-        return PipelineFactory.createPipeline(ValidationType.HEADER_VALUE);
-    }
-
-    @ParameterizedTest(name = "Cookie validation [{index}]")
-    @GeneratorsSource(value = GeneratorType.COOKIE, limit = 100)
-    void testCookieValidation(String cookieValue, String generatorType) {
-        // CookieGenerator creates both valid and attack cookies
-        try {
-            String result = cookieValidator.execute(cookieValue);
-            // Valid cookie
-            assertNotNull(result);
-        } catch (UrlSecurityException e) {
-            // Attack cookie detected
-            assertNotNull(e.getFailureType());
-        }
-    }
-    
-    @ParameterizedTest(name = "HTTP header validation [{index}]")
-    @GeneratorsSource(value = GeneratorType.HTTP_HEADER, limit = 100)
-    void testHTTPHeaderValidation(String headerValue, String generatorType) {
-        // HTTPHeaderGenerator creates various header content types
-        try {
-            String result = headerValidator.execute(headerValue);
-            // Valid header content
-            assertNotNull(result);
-        } catch (UrlSecurityException e) {
-            // Malicious header content detected
-            assertNotNull(e.getFailureType());
-        }
-    }
-}
-
-/**
- * Combined attack tests using multiple generators.
- */
-public class CombinedAttackTest {
-
-    private static final CuiLogger logger = new CuiLogger(CombinedAttackTest.class);
-
-    private final HttpSecurityValidator validator = createValidator();
-
-    private HttpSecurityValidator createValidator() {
-        // Create a path validation pipeline for testing
-        return PipelineFactory.createPipeline(ValidationType.URL_PATH);
-    }
-    
-    @ParameterizedTest(name = "Combined attacks [{index}]: {1}")
-    @GeneratorsSource(value = {
-        GeneratorType.PATH_TRAVERSAL,
-        GeneratorType.ENCODING,
-        GeneratorType.UNICODE,
-        GeneratorType.BOUNDARY
-    }, limit = 50)  // 50 each = 200 total tests
-    void testAllAttackTypes(String attack, String generatorType) {
-        // Test that all attack types are properly detected
-        UrlSecurityException exception = assertThrows(
-            UrlSecurityException.class,
-            () -> validator.execute(attack),
-            "Failed to detect " + generatorType + " attack: " + attack
-        );
-        
-        // Track which failure types are triggered by which generators
-        logger.info("Generator: {} -> FailureType: {}", 
-            generatorType, exception.getFailureType());
-    }
-    
-    @ParameterizedTest(name = "Mixed valid/invalid [{index}]: {1}")
-    @GeneratorsSource(value = {
-        GeneratorType.VALID_URL,
-        GeneratorType.INVALID_URL,
-        GeneratorType.PATH_TRAVERSAL
-    }, limit = 33)  // ~100 total tests mixed
-    void testMixedInputs(String input, String generatorType) {
-        // Test mix of valid and invalid inputs
-        boolean isValid = generatorType.equals("VALID_URL");
-        
-        if (isValid) {
-            assertDoesNotThrow(() -> validator.execute(input));
-        } else {
-            assertThrows(UrlSecurityException.class, 
-                () -> validator.execute(input));
-        }
-    }
-}
-----
 
 == Success Criteria
 
 The test harness achieves success when:
 
 1. ✅ **ALL tests pass** - No failures accepted
-2. ✅ All 10 generators (G1-G10) implemented and tested
-3. ✅ All 36 test cases (T1-T36) passing
-4. ✅ 100% of known CVE patterns blocked
-5. ✅ OWASP Top 10 compliance achieved
-6. ✅ <1ms performance for ALL validations
-7. ✅ Zero false positives - valid URLs must pass
-8. ✅ Zero false negatives - all attacks must be detected
-9. ✅ CI/CD integration complete
-10. ✅ Comprehensive reporting available
+2. ✅ All generators implemented and tested
+3. ✅ 100% of known CVE patterns blocked
+4. ✅ OWASP Top 10 compliance achieved
+5. ✅ <1ms performance for ALL validations
+6. ✅ Zero false positives - valid URLs must pass
+7. ✅ Zero false negatives - all attacks must be detected
+8. ✅ CI/CD integration complete
+9. ✅ Comprehensive reporting available

--- a/doc/security-readme.adoc
+++ b/doc/security-readme.adoc
@@ -70,7 +70,6 @@ See `de.cuioss.http.security.pipeline.URLParameterValidationPipeline`.
 // Create pipeline with configuration
 SecurityConfiguration config = SecurityConfiguration.builder()
     .maxPathLength(2048)
-    .allowPathTraversal(false)
     .build();
 
 SecurityEventCounter counter = new SecurityEventCounter();
@@ -81,7 +80,8 @@ URLPathValidationPipeline pipeline = new URLPathValidationPipeline(
 
 // Validate input
 try {
-    String validated = pipeline.validate("/api/users/123");
+    String validated = pipeline.validate("/api/users/123")
+        .orElseThrow(() -> new UrlSecurityException("Validation returned empty"));
     // Use validated path
 } catch (UrlSecurityException e) {
     log.warn("Security violation: {}", e.getFailureType());
@@ -95,16 +95,17 @@ SecurityConfiguration config = SecurityConfiguration.builder().build();
 SecurityEventCounter counter = new SecurityEventCounter();
 HttpSecurityValidator validator = PipelineFactory.createPipeline(
     ValidationType.URL_PATH, config, counter);
-String validated = validator.validate(userInput);
+String validated = validator.validate(userInput)
+    .orElseThrow(() -> new UrlSecurityException("Validation returned empty"));
 ----
 
 
 == Pipeline Selection Rules
 
-See xref:../doc/http-security/specification/pipeline-architecture-standards.adoc[Pipeline Architecture Standards] for detailed selection criteria.
+See xref:http-security/specification/pipeline-architecture-standards.adoc[Pipeline Architecture Standards] for detailed selection criteria.
 
 == Related Documentation
 
-* xref:../doc/http-security/README.adoc[Complete HTTP Security Documentation]
-* xref:../doc/http-security/specification/specification.adoc[Architecture Specification]
-* xref:../doc/http-security/specification/testing.adoc[Testing Framework]
+* xref:http-security/README.adoc[Complete HTTP Security Documentation]
+* xref:http-security/specification/specification.adoc[Architecture Specification]
+* xref:http-security/specification/testing.adoc[Testing Framework]

--- a/doc/test-framework-structure.adoc
+++ b/doc/test-framework-structure.adoc
@@ -10,125 +10,126 @@ The test framework is organized in the following structure under `src/test/java/
 
 === Configuration Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java[SecurityConfigurationTest]
-* link:../../../src/test/java/de/cuioss/http/security/config/SecurityConfigurationBuilderTest.java[SecurityConfigurationBuilderTest]
-* link:../../../src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java[SecurityDefaultsTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java[SecurityConfigurationTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationBuilderTest.java[SecurityConfigurationBuilderTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java[SecurityDefaultsTest]
 
 === Core Component Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/core/HttpSecurityValidatorTest.java[HttpSecurityValidatorTest]
-* link:../../../src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java[UrlSecurityFailureTypeTest]
-* link:../../../src/test/java/de/cuioss/http/security/core/ValidationTypeTest.java[ValidationTypeTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/core/HttpSecurityValidatorTest.java[HttpSecurityValidatorTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java[UrlSecurityFailureTypeTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/core/ValidationTypeTest.java[ValidationTypeTest]
 
 === Attack Pattern Databases
 
-* link:../../../src/test/java/de/cuioss/http/security/database/AttackDatabase.java[AttackDatabase] - Database interface
-* link:../../../src/test/java/de/cuioss/http/security/database/AttackTestCase.java[AttackTestCase] - Test case record
-* link:../../../src/test/java/de/cuioss/http/security/database/ApacheCVEAttackDatabase.java[ApacheCVEAttackDatabase] - Apache CVE patterns
-* link:../../../src/test/java/de/cuioss/http/security/database/HomographAttackDatabase.java[HomographAttackDatabase] - Unicode homograph attacks
-* link:../../../src/test/java/de/cuioss/http/security/database/IDNAttackDatabase.java[IDNAttackDatabase] - Internationalized domain attacks
-* link:../../../src/test/java/de/cuioss/http/security/database/IISCVEAttackDatabase.java[IISCVEAttackDatabase] - IIS CVE patterns
-* link:../../../src/test/java/de/cuioss/http/security/database/IPv6AttackDatabase.java[IPv6AttackDatabase] - IPv6 address exploits
-* link:../../../src/test/java/de/cuioss/http/security/database/NginxCVEAttackDatabase.java[NginxCVEAttackDatabase] - Nginx CVE patterns
-* link:../../../src/test/java/de/cuioss/http/security/database/OWASPTop10AttackDatabase.java[OWASPTop10AttackDatabase] - OWASP Top 10 patterns
-* link:../../../src/test/java/de/cuioss/http/security/database/ProtocolHandlerAttackDatabase.java[ProtocolHandlerAttackDatabase] - Protocol handler exploits
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/database/AttackDatabase.java[AttackDatabase] - Database interface
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/database/AttackTestCase.java[AttackTestCase] - Test case record
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/database/ApacheCVEAttackDatabase.java[ApacheCVEAttackDatabase] - Apache CVE patterns
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/database/HomographAttackDatabase.java[HomographAttackDatabase] - Unicode homograph attacks
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/database/IDNAttackDatabase.java[IDNAttackDatabase] - Internationalized domain attacks
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/database/IISCVEAttackDatabase.java[IISCVEAttackDatabase] - IIS CVE patterns
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/database/IPv6AttackDatabase.java[IPv6AttackDatabase] - IPv6 address exploits
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/database/NginxCVEAttackDatabase.java[NginxCVEAttackDatabase] - Nginx CVE patterns
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/database/OWASPTop10AttackDatabase.java[OWASPTop10AttackDatabase] - OWASP Top 10 patterns
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/database/ProtocolHandlerAttackDatabase.java[ProtocolHandlerAttackDatabase] - Protocol handler exploits
 
 === Exception Handling Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/exceptions/UrlSecurityExceptionTest.java[UrlSecurityExceptionTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/exceptions/UrlSecurityExceptionTest.java[UrlSecurityExceptionTest]
 
 === Test Data Generators
 
 ==== Main Generator Classes
 
-* link:../../../src/test/java/de/cuioss/http/security/generators/AllGeneratorsIntegrationTest.java[AllGeneratorsIntegrationTest] - Generator integration tests
-* link:../../../src/test/java/de/cuioss/http/security/generators/SupportedValidationTypeGenerator.java[SupportedValidationTypeGenerator]
-
-==== HTTP Body Generators
-
-* link:../../../src/test/java/de/cuioss/http/security/generators/body/HTTPBodyGenerator.java[HTTPBodyGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/body/ValidHTTPBodyContentGenerator.java[ValidHTTPBodyContentGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/AllGeneratorsIntegrationTest.java[AllGeneratorsIntegrationTest] - Generator integration tests
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/SupportedValidationTypeGenerator.java[SupportedValidationTypeGenerator]
 
 ==== Cookie Generators
 
-* link:../../../src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGenerator.java[AttackCookieGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/cookie/ValidCookieGenerator.java[ValidCookieGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGenerator.java[AttackCookieGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/ValidCookieGenerator.java[ValidCookieGenerator]
 
 ==== Encoding Attack Generators
 
-* link:../../../src/test/java/de/cuioss/http/security/generators/encoding/BoundaryFuzzingGenerator.java[BoundaryFuzzingGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/encoding/DoubleEncodingAttackGenerator.java[DoubleEncodingAttackGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/encoding/EncodingCombinationGenerator.java[EncodingCombinationGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/encoding/PathTraversalGenerator.java[PathTraversalGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/encoding/UnicodeAttackGenerator.java[UnicodeAttackGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/encoding/UnicodeControlCharacterAttackGenerator.java[UnicodeControlCharacterAttackGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/encoding/UnicodeNormalizationAttackGenerator.java[UnicodeNormalizationAttackGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/BoundaryFuzzingGenerator.java[BoundaryFuzzingGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/DoubleEncodingAttackGenerator.java[DoubleEncodingAttackGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/EncodingCombinationGenerator.java[EncodingCombinationGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/PathTraversalGenerator.java[PathTraversalGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeAttackGenerator.java[UnicodeAttackGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeControlCharacterAttackGenerator.java[UnicodeControlCharacterAttackGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeNormalizationAttackGenerator.java[UnicodeNormalizationAttackGenerator]
 
 ==== HTTP Header Generators
 
-* link:../../../src/test/java/de/cuioss/http/security/generators/header/HttpHeaderInjectionAttackGenerator.java[HttpHeaderInjectionAttackGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/header/HTTPHeaderInjectionGenerator.java[HTTPHeaderInjectionGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/header/InvalidHTTPHeaderNameGenerator.java[InvalidHTTPHeaderNameGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/header/ValidHTTPHeaderNameGenerator.java[ValidHTTPHeaderNameGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/header/ValidHTTPHeaderValueGenerator.java[ValidHTTPHeaderValueGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/header/HttpHeaderInjectionAttackGenerator.java[HttpHeaderInjectionAttackGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/header/HTTPHeaderInjectionGenerator.java[HTTPHeaderInjectionGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/header/InvalidHTTPHeaderNameGenerator.java[InvalidHTTPHeaderNameGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/header/ValidHTTPHeaderNameGenerator.java[ValidHTTPHeaderNameGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/header/ValidHTTPHeaderValueGenerator.java[ValidHTTPHeaderValueGenerator]
 
 ==== Protocol Injection Generators
 
-* link:../../../src/test/java/de/cuioss/http/security/generators/injection/HttpRequestSmugglingAttackGenerator.java[HttpRequestSmugglingAttackGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/injection/ProtocolHandlerAttackGenerator.java[ProtocolHandlerAttackGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/HttpRequestSmugglingAttackGenerator.java[HttpRequestSmugglingAttackGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/ProtocolHandlerAttackGenerator.java[ProtocolHandlerAttackGenerator]
 
 ==== URL-Specific Generators
 
-* link:../../../src/test/java/de/cuioss/http/security/generators/url/AttackURLParameterGenerator.java[AttackURLParameterGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/url/InvalidURLGenerator.java[InvalidURLGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/url/NullByteInjectionParameterGenerator.java[NullByteInjectionParameterGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/url/NullByteURLGenerator.java[NullByteURLGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/url/PathTraversalParameterGenerator.java[PathTraversalParameterGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/url/PathTraversalURLGenerator.java[PathTraversalURLGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/url/URLLengthLimitAttackGenerator.java[URLLengthLimitAttackGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/url/ValidURLGenerator.java[ValidURLGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/url/ValidURLParameterGenerator.java[ValidURLParameterGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/url/ValidURLParameterStringGenerator.java[ValidURLParameterStringGenerator]
-* link:../../../src/test/java/de/cuioss/http/security/generators/url/ValidURLPathGenerator.java[ValidURLPathGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/AttackURLParameterGenerator.java[AttackURLParameterGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/InvalidURLGenerator.java[InvalidURLGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/NullByteInjectionParameterGenerator.java[NullByteInjectionParameterGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/NullByteURLGenerator.java[NullByteURLGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalParameterGenerator.java[PathTraversalParameterGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalURLGenerator.java[PathTraversalURLGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/URLLengthLimitAttackGenerator.java[URLLengthLimitAttackGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLGenerator.java[ValidURLGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLParameterGenerator.java[ValidURLParameterGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLParameterStringGenerator.java[ValidURLParameterStringGenerator]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLPathGenerator.java[ValidURLPathGenerator]
 
 === Security Monitoring Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java[SecurityEventCounterTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java[SecurityEventCounterTest]
 
 === Validation Pipeline Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java[HTTPHeaderValidationPipelineTest]
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/PipelineFactoryTest.java[PipelineFactoryTest]
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java[URLParameterValidationPipelineTest]
-* link:../../../src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java[URLPathValidationPipelineTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java[HTTPHeaderValidationPipelineTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/PipelineFactoryTest.java[PipelineFactoryTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java[URLParameterValidationPipelineTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java[URLPathValidationPipelineTest]
 
 === Validation Stage Tests
 
-* link:../../../src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest]
-* link:../../../src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java[DecodingStageTest]
-* link:../../../src/test/java/de/cuioss/http/security/validation/LengthValidationStageTest.java[LengthValidationStageTest]
-* link:../../../src/test/java/de/cuioss/http/security/validation/NormalizationStageTest.java[NormalizationStageTest]
-* link:../../../src/test/java/de/cuioss/http/security/validation/PatternMatchingStageTest.java[PatternMatchingStageTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java[DecodingStageTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/LengthValidationStageTest.java[LengthValidationStageTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/NormalizationStageTest.java[NormalizationStageTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/validation/PatternMatchingStageTest.java[PatternMatchingStageTest]
 
 === Attack Test Categories
 
-* link:../../../src/test/java/de/cuioss/http/security/tests/CVEAttackDatabaseIntegrationTest.java[CVEAttackDatabaseIntegrationTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/DoubleEncodingAttackTest.java[DoubleEncodingAttackTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/EncodedPathTraversalAttackTest.java[EncodedPathTraversalAttackTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/HomographAttackDatabaseTest.java[HomographAttackDatabaseTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/IDNAttackDatabaseTest.java[IDNAttackDatabaseTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/IPv6AttackDatabaseTest.java[IPv6AttackDatabaseTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/LegitimateURLPatternTest.java[LegitimateURLPatternTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/MixedEncodingAttackTest.java[MixedEncodingAttackTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/NullByteInjectionAttackTest.java[NullByteInjectionAttackTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/OWASPTop10DatabaseTest.java[OWASPTop10DatabaseTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/PathSegmentAttackTest.java[PathSegmentAttackTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/ProtocolHandlerAttackTest.java[ProtocolHandlerAttackTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/RelativePathAttackTest.java[RelativePathAttackTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/SymbolicLinkAttackTest.java[SymbolicLinkAttackTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/UnicodeNormalizationAttackTest.java[UnicodeNormalizationAttackTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/URLEncodingAttackTest.java[URLEncodingAttackTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/UTFOverlongEncodingAttackTest.java[UTFOverlongEncodingAttackTest]
-* link:../../../src/test/java/de/cuioss/http/security/tests/WindowsReservedNamesAttackTest.java[WindowsReservedNamesAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/ApacheCVEAttackDatabaseTest.java[ApacheCVEAttackDatabaseTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java[CookieChaosAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/DoubleEncodingAttackTest.java[DoubleEncodingAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/EdgeCaseValidURLsDatabaseTest.java[EdgeCaseValidURLsDatabaseTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/EncodedPathTraversalAttackTest.java[EncodedPathTraversalAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HomographAttackDatabaseTest.java[HomographAttackDatabaseTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/Http1VulnerabilitiesTest.java[Http1VulnerabilitiesTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/IDNAttackDatabaseTest.java[IDNAttackDatabaseTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/IISCVEAttackDatabaseTest.java[IISCVEAttackDatabaseTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/IPv6AttackDatabaseTest.java[IPv6AttackDatabaseTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/LegitimatePathPatternsDatabaseTest.java[LegitimatePathPatternsDatabaseTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/LegitimateSpecialCharactersDatabaseTest.java[LegitimateSpecialCharactersDatabaseTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/MixedEncodingAttackTest.java[MixedEncodingAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/ModSecurityCRSAttackDatabaseTest.java[ModSecurityCRSAttackDatabaseTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/NginxCVEAttackDatabaseTest.java[NginxCVEAttackDatabaseTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/NullBytePathTraversalAttackTest.java[NullBytePathTraversalAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java[OWASPTop10AttackDatabaseTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPZAPAttackDatabaseTest.java[OWASPZAPAttackDatabaseTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/ProtocolHandlerAttackTest.java[ProtocolHandlerAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodeControlCharacterAttackTest.java[UnicodeControlCharacterAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodeNormalizationAttackTest.java[UnicodeNormalizationAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodePathTraversalAttackTest.java[UnicodePathTraversalAttackTest]
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/tests/URLLengthLimitAttackTest.java[URLLengthLimitAttackTest]

--- a/doc/test-generators-readme.adoc
+++ b/doc/test-generators-readme.adoc
@@ -57,7 +57,7 @@ All databases implement `AttackDatabase` interface and provide `AttackTestCase` 
 
 == Test Generators
 
-The test artifact includes generators organized by category (body, cookie, encoding, header, injection, url).
+The test artifact includes generators organized by category (cookie, encoding, header, injection, url).
 
 For complete generator architecture and categories, see xref:http-security/specification/testing.adoc[Testing Framework].
 


### PR DESCRIPTION
Corrects 17 documentation files to match the actual codebase:

- Fix source path links (cui-http-core/ prefix for multi-module project)
- Replace fictional class names with real APIs
- Fix test file references, add missing log messages
- Remove fictional code examples, replace with accurate snippets