### PR TITLE
docs: fix heading level and pipeline variable in code example

### DIFF
--- a/doc/client-handlers-readme.adoc
+++ b/doc/client-handlers-readme.adoc
@@ -34,7 +34,7 @@ Builder-based HTTP client wrapper with automatic SSL context creation for HTTPS.
 * Configurable connection and read timeouts (default: 10 seconds)
 * Thread-safe after construction
 
-===== xref:../cui-http-core/src/main/java/de/cuioss/http/client/adapter/package-info.java[HTTP Adapters (New Architecture)]
+==== xref:../cui-http-core/src/main/java/de/cuioss/http/client/adapter/package-info.java[HTTP Adapters (New Architecture)]
 
 Async-first HTTP client adapters with composable retry and caching.
 

--- a/doc/http-security/specification/testing.adoc
+++ b/doc/http-security/specification/testing.adoc
@@ -686,7 +686,7 @@ class ValidationTypeTest {
 
         HttpSecurityValidator pathValidator = pipelines.urlPathPipeline();
         HttpSecurityValidator paramValidator = pipelines.urlParameterPipeline();
-        HttpSecurityValidator headerValidator = pipelines.headerNamePipeline();
+        HttpSecurityValidator headerValidator = pipelines.headerValuePipeline();
 
         // Each pipeline assigns the correct ValidationType on failure
         UrlSecurityException pathException = assertThrows(
@@ -705,7 +705,7 @@ class ValidationTypeTest {
             UrlSecurityException.class,
             () -> headerValidator.validate("Bearer\r\nX-Injected: true")
         );
-        assertEquals(ValidationType.HEADER_NAME, headerException.getValidationType());
+        assertEquals(ValidationType.HEADER_VALUE, headerException.getValidationType());
     }
 }
 ----


### PR DESCRIPTION
Fixes two issues flagged in PR #65 review:

- Heading level of HTTP Adapters section in client-handlers-readme.adoc: changed from ===== to ==== for correct TOC visibility
- Pipeline variable mismatch in testing.adoc code example: headerNamePipeline → headerValuePipeline with corresponding ValidationType.HEADER_VALUE