### PR TITLE
test: gate dedup steady-state check (do not merge)

### DIFF
--- a/GATE-DEDUP-TEST.md
+++ b/GATE-DEDUP-TEST.md
@@ -1,0 +1,1 @@
+gate dedup steady-state check (throwaway, will be closed)

--- a/GATE-DEDUP-TEST.md
+++ b/GATE-DEDUP-TEST.md
@@ -1,1 +1,2 @@
 gate dedup steady-state check (throwaway, will be closed)
+second change while PR is open


### PR DESCRIPTION
Throwaway PR to verify the reusable-maven-build gate skips a push build when an open PR exists. Will be closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test documentation with additional test case entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->