### PR TITLE
fix(client): report 2xx responses with no-content converters as success

### DIFF
--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
@@ -20,6 +20,7 @@ import de.cuioss.http.client.converter.HttpRequestConverter;
 import de.cuioss.http.client.converter.HttpResponseConverter;
 import de.cuioss.http.client.converter.VoidResponseConverter;
 import de.cuioss.http.client.handler.HttpHandler;
+import de.cuioss.http.client.handler.HttpStatusFamily;
 import de.cuioss.http.client.result.HttpErrorCategory;
 import de.cuioss.http.client.result.HttpResult;
 import de.cuioss.tools.logging.CuiLogger;
@@ -699,7 +700,6 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
      * @param cacheKey Cache key for storing new entries
      * @return HttpResult with success or failure status
      */
-    @SuppressWarnings("java:S3655") // owolff: false positive, content is checked
     private HttpResult<T> handleHttpResponse(
             HttpResponse<?> response,
             HttpMethod method,
@@ -722,8 +722,10 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
         // Convert response body
         Optional<T> content = responseConverter.convert(response.body());
 
-        // Handle conversion failure
-        if (content.isEmpty() && statusCode >= 200 && statusCode < 300) {
+        // Handle conversion failure. Converters that intentionally produce no content
+        // (e.g. VoidResponseConverter for status-code-only operations) are exempt.
+        if (content.isEmpty() && HttpStatusFamily.isSuccess(statusCode)
+                && !responseConverter.emptyContentIsValid()) {
             LOGGER.warn(WARN.RESPONSE_CONVERSION_FAILED, statusCode);
             return HttpResult.<T>failure(
                     "Failed to convert response body",
@@ -732,21 +734,21 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
             );
         }
 
-        // Cache successful GET responses with ETag
-        // Note: content.isPresent() is guaranteed because statusCode 200 with empty content returns early at line 700
-        if (method == HttpMethod.GET && statusCode == 200 && etag != null) {
+        // Cache successful GET responses with ETag (only when content exists;
+        // no-content converters have nothing to cache)
+        if (method == HttpMethod.GET && statusCode == 200 && etag != null && content.isPresent()) {
             CacheEntry<T> newEntry = new CacheEntry<>(content.get(), etag, System.currentTimeMillis());
             putInCache(cacheKey, newEntry);
             LOGGER.debug("Cached GET response with ETag: %s", etag);
         }
 
         // Return success for 2xx status codes
-        if (statusCode >= 200 && statusCode < 300) {
+        if (HttpStatusFamily.isSuccess(statusCode)) {
             return HttpResult.<T>success(content.orElse(null), etag, statusCode);
         }
 
         // Return failure for error status codes
-        HttpErrorCategory errorCategory = categorizeStatusCode(statusCode);
+        HttpErrorCategory errorCategory = HttpStatusFamily.fromStatusCode(statusCode).toErrorCategory();
 
         return HttpResult.<T>failureWithFallback(
                 "HTTP %d: %s".formatted(statusCode, method.methodName()),
@@ -756,23 +758,6 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
                 null, // no cached ETag
                 statusCode // include HTTP status code
         );
-    }
-
-    /**
-     * Categorizes HTTP status code into error category.
-     *
-     * @param statusCode HTTP status code
-     * @return Appropriate error category
-     */
-    private HttpErrorCategory categorizeStatusCode(int statusCode) {
-        if (statusCode >= 400 && statusCode < 500) {
-            return HttpErrorCategory.CLIENT_ERROR;
-        } else if (statusCode >= 500 && statusCode < 600) {
-            return HttpErrorCategory.SERVER_ERROR;
-        } else {
-            // 3xx (other than 304), 1xx, or unknown codes
-            return HttpErrorCategory.INVALID_CONTENT;
-        }
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/client/converter/HttpResponseConverter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/converter/HttpResponseConverter.java
@@ -36,7 +36,8 @@ import java.util.Optional;
  * <ul>
  *   <li><strong>Success:</strong> Return {@code Optional.of(parsedObject)} when conversion succeeds</li>
  *   <li><strong>Parsing Failure:</strong> Return {@code Optional.empty()} when conversion fails
- *       (adapter will create {@code HttpResult.failure()} with {@code HttpErrorCategory.INVALID_CONTENT})</li>
+ *       (adapter will create {@code HttpResult.failure()} with {@code HttpErrorCategory.INVALID_CONTENT},
+ *       unless {@link #emptyContentIsValid()} returns {@code true})</li>
  *   <li><strong>Never throw exceptions:</strong> Always return {@code Optional.empty()} on failure</li>
  * </ul>
  *
@@ -147,6 +148,27 @@ public interface HttpResponseConverter<T> {
     // Callers use the handler to read response bodies, not to access type-specific operations
     @SuppressWarnings("java:S1452")
     HttpResponse.BodyHandler<?> getBodyHandler();
+
+    /**
+     * Indicates whether an empty conversion result is a valid outcome for
+     * successful (2xx) responses.
+     * <p>
+     * By default, an empty {@link #convert(Object)} result on a 2xx response is
+     * treated as a conversion failure and mapped to
+     * {@code HttpErrorCategory.INVALID_CONTENT}. Converters that intentionally
+     * produce no content (such as {@link VoidResponseConverter}, which discards
+     * the body because only the status code matters) must override this method
+     * to return {@code true} so that successful responses are reported as
+     * {@code HttpResult.Success} without content.
+     * </p>
+     *
+     * @return {@code true} if an empty conversion result on a 2xx response
+     *         represents success, {@code false} if it represents a conversion failure
+     * @since 1.5
+     */
+    default boolean emptyContentIsValid() {
+        return false;
+    }
 
     /**
      * Returns the expected content type for responses.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/converter/VoidResponseConverter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/converter/VoidResponseConverter.java
@@ -115,6 +115,21 @@ public final class VoidResponseConverter implements HttpResponseConverter<Void> 
     }
 
     /**
+     * Returns {@code true} because this converter intentionally produces no content.
+     * <p>
+     * A successful (2xx) response handled by this converter must be reported as
+     * {@code HttpResult.Success} without content instead of being misclassified
+     * as a conversion failure.
+     * </p>
+     *
+     * @return always {@code true}
+     */
+    @Override
+    public boolean emptyContentIsValid() {
+        return true;
+    }
+
+    /**
      * Returns a body handler that efficiently discards the response body.
      * <p>
      * Uses {@link HttpResponse.BodyHandlers#discarding()} which doesn't read

--- a/cui-http-core/src/main/java/de/cuioss/http/client/result/HttpResult.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/result/HttpResult.java
@@ -160,7 +160,8 @@ public sealed interface HttpResult<T>
     /**
      * Gets the content if available.
      * <ul>
-     *   <li>For Success: always present (contains the result)</li>
+     *   <li>For Success: present unless the operation intentionally produces no
+     *       content (e.g. status-code-only operations with a {@code Void} content type)</li>
      *   <li>For Failure: present only if fallback content exists</li>
      * </ul>
      *
@@ -240,13 +241,14 @@ public sealed interface HttpResult<T>
      * return HttpResult.success(cachedContent, cachedEtag, 304);
      * </pre>
      *
-     * @param content the response content, must not be null
+     * @param content the response content; may be null only for operations that
+     *                 intentionally produce no content (e.g. {@code Void} status-code-only operations)
      * @param etag optional ETag header value for caching
      * @param httpStatus HTTP status code
      * @param <T> content type
      * @return Success result
      */
-    static <T> HttpResult<T> success(T content, @Nullable String etag, int httpStatus) {
+    static <T> HttpResult<T> success(@Nullable T content, @Nullable String etag, int httpStatus) {
         return new Success<>(content, etag, httpStatus);
     }
 
@@ -316,12 +318,14 @@ public sealed interface HttpResult<T>
      * Successful HTTP operation with content.
      * Contains content loaded from server (HTTP 200) or validated from cache (HTTP 304).
      *
-     * @param content the response content, never null
+     * @param content the response content; null only for operations that intentionally
+     *                produce no content (e.g. {@code Void} status-code-only operations)
      * @param etag optional ETag header value for caching
      * @param httpStatus HTTP status code (typically 200 or 304)
      * @param <T> content type
      */
     record Success<T>(
+    @Nullable
     T content,
     @Nullable
     String etag,
@@ -335,7 +339,7 @@ public sealed interface HttpResult<T>
 
         @Override
         public Optional<T> getContent() {
-            return Optional.of(content);
+            return Optional.ofNullable(content);
         }
 
         @Override
@@ -355,7 +359,8 @@ public sealed interface HttpResult<T>
 
         @Override
         public <U> HttpResult<U> map(Function<T, U> mapper) {
-            return new Success<>(mapper.apply(content), etag, httpStatus);
+            U mappedContent = content != null ? mapper.apply(content) : null;
+            return new Success<>(mappedContent, etag, httpStatus);
         }
     }
 

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/AbstractValidationPipeline.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/AbstractValidationPipeline.java
@@ -83,14 +83,15 @@ public abstract class AbstractValidationPipeline implements HttpSecurityValidato
                 // Track security event
                 eventCounter.increment(e.getFailureType());
 
-                // Re-throw with correct validation type
+                // Re-throw with correct validation type, preserving the original
+                // stage exception as cause to keep the full exception chain
                 throw UrlSecurityException.builder()
                         .failureType(e.getFailureType())
                         .validationType(getValidationType())
                         .originalInput(value) // Use original input, not current result
                         .sanitizedInput(e.getSanitizedInput().orElse(null))
                         .detail(e.getDetail().orElse("Validation failed"))
-                        .cause(e.getCause())
+                        .cause(e)
                         .build();
             }
         }

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
@@ -192,6 +192,77 @@ class ETagAwareHttpAdapterIntegrationTest {
     }
 
     /**
+     * Test status-code-only adapter: DELETE with 204 must be reported as success
+     * even though VoidResponseConverter never produces content.
+     */
+    @Test
+    @DisplayName("statusCodeOnly DELETE should report 204 as success")
+    @ModuleDispatcher
+    void statusCodeOnlyDeleteShouldReport204AsSuccess(URIBuilder uriBuilder) {
+        dispatcher.withNoContent();
+
+        String serverUrl = uriBuilder.addPathSegments("api", "data", "1").build().toString();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+
+        HttpAdapter<Void> adapter = ETagAwareHttpAdapter.statusCodeOnly(handler);
+
+        HttpResult<Void> result = adapter.deleteBlocking();
+
+        assertTrue(result.isSuccess(), "204 with Void converter must be success, not INVALID_CONTENT failure");
+        assertEquals(204, result.getHttpStatus().orElse(-1));
+        assertTrue(result.getContent().isEmpty(), "Void result carries no content");
+        assertTrue(result.getErrorCategory().isEmpty(), "Success must not carry an error category");
+    }
+
+    /**
+     * Test status-code-only adapter: HEAD with 200 and ETag must be success with ETag exposed.
+     */
+    @Test
+    @DisplayName("statusCodeOnly HEAD should report 200 as success and expose ETag")
+    @ModuleDispatcher
+    void statusCodeOnlyHeadShouldReport200AsSuccess(URIBuilder uriBuilder) {
+        dispatcher.withSuccessAndETag("", "\"etag-head\"");
+
+        String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+
+        HttpAdapter<Void> adapter = ETagAwareHttpAdapter.statusCodeOnly(handler);
+
+        HttpResult<Void> result = adapter.headBlocking();
+
+        assertTrue(result.isSuccess(), "200 with Void converter must be success");
+        assertEquals(200, result.getHttpStatus().orElse(-1));
+        assertEquals("\"etag-head\"", result.getETag().orElse(null), "ETag should be exposed");
+    }
+
+    /**
+     * Test status-code-only adapter: GET with 200 and ETag must not fail on the
+     * caching path even though the converter produces no cacheable content.
+     */
+    @Test
+    @DisplayName("statusCodeOnly GET with ETag should succeed without caching")
+    @ModuleDispatcher
+    void statusCodeOnlyGetWithETagShouldSucceedWithoutCaching(URIBuilder uriBuilder) {
+        dispatcher.withSuccessAndETag("ignored-body", "\"etag-get\"");
+
+        String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+
+        HttpAdapter<Void> adapter = ETagAwareHttpAdapter.statusCodeOnly(handler);
+
+        HttpResult<Void> result = adapter.getBlocking();
+
+        assertTrue(result.isSuccess(), "200 with Void converter must be success");
+        assertEquals(200, result.getHttpStatus().orElse(-1));
+
+        // Second GET must not send If-None-Match (nothing was cached)
+        HttpResult<Void> result2 = adapter.getBlocking();
+        assertTrue(result2.isSuccess());
+        assertFalse(dispatcher.getLastIfNoneMatch().isPresent(),
+                "No If-None-Match expected - Void responses are never cached");
+    }
+
+    /**
      * Test server error: 503 response, returns SERVER_ERROR failure with status code
      */
     @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/client/converter/HttpResponseConverterTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/converter/HttpResponseConverterTest.java
@@ -106,6 +106,14 @@ class HttpResponseConverterTest {
     }
 
     @Test
+    void emptyContentIsValidDefaultsToFalse() {
+        var converter = new TestStringConverter();
+
+        assertFalse(converter.emptyContentIsValid(),
+                "Content-producing converters must treat empty conversion results as failures");
+    }
+
+    @Test
     void convertReturnsEmptyOnNullInput() {
         var converter = new TestStringConverter();
 

--- a/cui-http-core/src/test/java/de/cuioss/http/client/converter/VoidResponseConverterTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/converter/VoidResponseConverterTest.java
@@ -71,6 +71,16 @@ class VoidResponseConverterTest {
     }
 
     /**
+     * Test that emptyContentIsValid() returns true so 2xx responses without
+     * content are reported as success instead of INVALID_CONTENT failures.
+     */
+    @Test
+    void shouldDeclareEmptyContentAsValid() {
+        assertTrue(VoidResponseConverter.INSTANCE.emptyContentIsValid(),
+                "Void converter intentionally produces no content - empty must be valid");
+    }
+
+    /**
      * Test that getBodyHandler() returns a discarding handler.
      * We verify it's not null and is the correct type.
      */

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java
@@ -173,6 +173,18 @@ class URLPathValidationPipelineTest {
         }
 
         @Test
+        void shouldPreserveStageExceptionAsCause() {
+            UrlSecurityException exception = assertThrows(UrlSecurityException.class, () ->
+                    pipeline.validate("/api/../../../etc/passwd"));
+
+            assertInstanceOf(UrlSecurityException.class, exception.getCause(),
+                    "Pipeline must preserve the originating stage exception as cause");
+            UrlSecurityException stageException = (UrlSecurityException) exception.getCause();
+            assertEquals(exception.getFailureType(), stageException.getFailureType(),
+                    "Rewrapped exception must keep the stage's failure type");
+        }
+
+        @Test
         void shouldHaveCorrectEqualsAndHashCode() {
             URLPathValidationPipeline pipeline1 = new URLPathValidationPipeline(config, eventCounter);
             URLPathValidationPipeline pipeline2 = new URLPathValidationPipeline(config, eventCounter);


### PR DESCRIPTION
## Summary

Fixes a functional bug where `ETagAwareHttpAdapter.statusCodeOnly()` adapters reported every **successful** 2xx response as an `INVALID_CONTENT` **failure**, plus two smaller correctness cleanups found during a full code analysis.

### Bug: statusCodeOnly() always failed on success

`VoidResponseConverter.convert()` intentionally always returns `Optional.empty()` (the body is discarded — only the status code matters). But `handleHttpResponse` treated *any* empty conversion result on a 2xx response as a conversion failure:

```java
if (content.isEmpty() && statusCode >= 200 && statusCode < 300) {
    return HttpResult.failure("Failed to convert response body", null, INVALID_CONTENT);
}
```

So `adapter.deleteBlocking()` on a 204, `headBlocking()` on a 200, etc. — the documented use cases for `statusCodeOnly()` — always returned a failure. The path was untested (existing tests only asserted adapter construction).

### Changes

- **`HttpResponseConverter.emptyContentIsValid()`** (new, default `false`): lets converters that intentionally produce no content opt out of the empty-content-is-failure rule. `VoidResponseConverter` overrides it to `true`.
- **`ETagAwareHttpAdapter`**: exempts such converters from the conversion-failure guard; guards the ETag-cache write with `content.isPresent()` (previously `content.get()` could throw for a Void-converter GET 200 with an ETag header); replaces the private duplicate `categorizeStatusCode()` with `HttpStatusFamily.toErrorCategory()` so there is a single status→category mapping.
- **`HttpResult.Success`**: tolerates absent content (`@Nullable content`, `getContent()` → `ofNullable`, null-safe `map()`) — required because a `Void` success can never carry content. Behavior for all existing non-null usage is unchanged.
- **`AbstractValidationPipeline`**: preserves the originating stage exception as `cause` when rewrapping `UrlSecurityException` (previously the chain was dropped via `e.getCause()`, which is almost always null).

### Tests

- New integration tests: `statusCodeOnly` DELETE→204, HEAD→200 (+ETag exposure), GET→200 with ETag (exercises the cache guard, asserts nothing is cached).
- New unit tests: `emptyContentIsValid()` default and Void override; pipeline cause-chain preservation.
- `./mvnw -Ppre-commit clean verify`: **5,326 tests, 0 failures, 0 skipped.**

Part 1 of 6 of the findings-remediation series from the full codebase analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxJYKt4yApyTup6bS4pjLu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxJYKt4yApyTup6bS4pjLu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status-code-only responses can now be handled cleanly for empty-body operations, including success without content.
  * Empty response handling is now explicitly supported for converters that intentionally discard bodies.

* **Bug Fixes**
  * Improved HTTP success/error classification for more consistent response handling.
  * Caching now only occurs when a response has usable content, avoiding stale or incomplete cache entries.
  * Exception chaining in URL validation now preserves the original stage error more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->