### PR TITLE
fix(security): reconcile config presets and remove unenforced settings

### DIFF
--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
@@ -193,6 +193,7 @@ boolean failOnSuspiciousPatterns
      */
     public boolean isLenient() {
         return allowDoubleEncoding &&
+                !allowNullBytes &&
                 allowControlCharacters &&
                 allowExtendedAscii &&
                 !normalizeUnicode &&

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
@@ -73,6 +73,9 @@ package de.cuioss.http.security.config;
  * @since 1.0
  * @see SecurityConfigurationBuilder
  */
+// S107: The canonical constructor has many parameters by design - construction
+// happens through SecurityConfigurationBuilder; the record only carries the data
+@SuppressWarnings("java:S107")
 public record SecurityConfiguration(
 int maxPathLength,
 boolean allowDoubleEncoding,

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
@@ -15,38 +15,26 @@
  */
 package de.cuioss.http.security.config;
 
-import org.jspecify.annotations.Nullable;
-
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 /**
- * Immutable class representing security configuration for HTTP validation.
+ * Immutable record representing security configuration for HTTP validation.
  *
- * <p>This class encapsulates all security policies and settings needed to configure
- * HTTP security validators. It provides a type-safe, immutable configuration object
- * that can be shared across multiple validation operations.</p>
+ * <p>This record encapsulates all security policies and settings that are enforced by the
+ * validation stages and pipelines of this library. It provides a type-safe, immutable
+ * configuration object that can be shared across multiple validation operations.</p>
+ *
+ * <p>Every setting in this record is consumed by at least one validation stage. Settings
+ * that would require request-level context (parameter counts, header counts, allow/block
+ * lists, cookie attribute requirements) are intentionally not part of this configuration:
+ * the validation pipelines operate on single values and cannot enforce them. Enforce such
+ * policies at the application layer, optionally using the reference constants in
+ * {@link SecurityDefaults}.</p>
  *
  * <h3>Design Principles</h3>
  * <ul>
  *   <li><strong>Immutability</strong> - Configuration cannot be modified once created</li>
  *   <li><strong>Type Safety</strong> - Strongly typed configuration parameters</li>
- *   <li><strong>Complete Coverage</strong> - Covers all aspects of HTTP security validation</li>
+ *   <li><strong>Honest Surface</strong> - Every setting is enforced by the validation pipeline</li>
  *   <li><strong>Composability</strong> - Easy to combine with builder patterns</li>
- *   <li><strong>Performance</strong> - Pre-processes sets for O(1) case-insensitive lookups</li>
- * </ul>
- *
- * <h3>Configuration Categories</h3>
- * <ul>
- *   <li><strong>Path Security</strong> - Path traversal prevention, allowed patterns</li>
- *   <li><strong>Parameter Security</strong> - Query parameter validation rules</li>
- *   <li><strong>Header Security</strong> - HTTP header validation policies</li>
- *   <li><strong>Cookie Security</strong> - Cookie validation and security requirements</li>
- *   <li><strong>Body Security</strong> - Request/response body validation settings</li>
- *   <li><strong>Encoding Security</strong> - URL encoding and character validation</li>
- *   <li><strong>Length Limits</strong> - Size restrictions for various HTTP components</li>
- *   <li><strong>General Policies</strong> - Cross-cutting security concerns</li>
  * </ul>
  *
  * <h3>Usage Examples</h3>
@@ -54,116 +42,63 @@ import java.util.stream.Collectors;
  * // Create with builder
  * SecurityConfiguration config = SecurityConfiguration.builder()
  *     .maxPathLength(2048)
- *     .allowPathTraversal(false)
- *     .maxParameterCount(100)
- *     .requireSecureCookies(true)
+ *     .normalizeUnicode(true)
  *     .build();
- *
- * // Use in validation
- * PathValidator validator = new PathValidator(config);
- * validator.validate("/api/users/123");
  *
  * // Create restrictive configuration
  * SecurityConfiguration strict = SecurityConfiguration.strict();
  *
- * // Create permissive configuration
+ * // Create permissive configuration (trusted environments only)
  * SecurityConfiguration lenient = SecurityConfiguration.lenient();
  * </pre>
  *
  * Implements: Task C1 from HTTP verification specification
  *
+ * @param maxPathLength Maximum allowed URL path length in characters (positive)
+ * @param allowDoubleEncoding Whether double URL encoding (e.g. {@code %252e}) is allowed
+ * @param maxParameterNameLength Maximum allowed parameter name length in characters (positive)
+ * @param maxParameterValueLength Maximum allowed parameter value length in characters (positive)
+ * @param maxHeaderNameLength Maximum allowed header name length in characters (positive)
+ * @param maxHeaderValueLength Maximum allowed header value length in characters (positive)
+ * @param maxCookieNameLength Maximum allowed cookie name length in characters (positive)
+ * @param maxCookieValueLength Maximum allowed cookie value length in characters (positive)
+ * @param maxBodySize Maximum allowed body size in bytes (non-negative)
+ * @param allowNullBytes Whether null bytes are allowed in content
+ * @param allowControlCharacters Whether control characters are allowed in content
+ * @param allowExtendedAscii Whether extended ASCII (128-255) and applicable Unicode characters are allowed
+ * @param normalizeUnicode Whether Unicode normalization should be performed during decoding
+ * @param caseSensitiveComparison Whether string comparisons are case-sensitive
+ * @param failOnSuspiciousPatterns Whether validation fails on suspicious (non-attack) patterns
+ *
  * @since 1.0
  * @see SecurityConfigurationBuilder
  */
-@SuppressWarnings("javaarchitecture:S7027")
-public final class SecurityConfiguration {
-
-    // Path Security
-    private final int maxPathLength;
-    private final boolean allowPathTraversal;
-    private final boolean allowDoubleEncoding;
-
-    // Parameter Security
-    private final int maxParameterCount;
-    private final int maxParameterNameLength;
-    private final int maxParameterValueLength;
-
-    // Header Security
-    private final int maxHeaderCount;
-    private final int maxHeaderNameLength;
-    private final int maxHeaderValueLength;
-    private final @Nullable Set<String> allowedHeaderNames;
-    private final Set<String> blockedHeaderNames;
-
-    // Cookie Security
-    private final int maxCookieCount;
-    private final int maxCookieNameLength;
-    private final int maxCookieValueLength;
-    private final boolean requireSecureCookies;
-    private final boolean requireHttpOnlyCookies;
-
-    // Body Security
-    private final long maxBodySize;
-    private final @Nullable Set<String> allowedContentTypes;
-    private final Set<String> blockedContentTypes;
-
-    // Encoding Security
-    private final boolean allowNullBytes;
-    private final boolean allowControlCharacters;
-    private final boolean allowExtendedAscii;
-    private final boolean normalizeUnicode;
-
-    // General Policies
-    private final boolean caseSensitiveComparison;
-    private final boolean failOnSuspiciousPatterns;
-    private final boolean logSecurityViolations;
-
-    // Pre-processed lowercase sets for O(1) case-insensitive lookups
-    // Only populated when caseSensitiveComparison is false
-    private final @Nullable Set<String> allowedHeaderNamesLowercase;
-    private final Set<String> blockedHeaderNamesLowercase;
-    private final @Nullable Set<String> allowedContentTypesLowercase;
-    private final Set<String> blockedContentTypesLowercase;
+public record SecurityConfiguration(
+int maxPathLength,
+boolean allowDoubleEncoding,
+int maxParameterNameLength,
+int maxParameterValueLength,
+int maxHeaderNameLength,
+int maxHeaderValueLength,
+int maxCookieNameLength,
+int maxCookieValueLength,
+long maxBodySize,
+boolean allowNullBytes,
+boolean allowControlCharacters,
+boolean allowExtendedAscii,
+boolean normalizeUnicode,
+boolean caseSensitiveComparison,
+boolean failOnSuspiciousPatterns
+) {
 
     /**
-     * Creates a SecurityConfiguration with validation of constraints.
+     * Validates configuration constraints.
+     *
+     * @throws IllegalArgumentException if any length limit is invalid
      */
-    @SuppressWarnings({"java:S107", "java:S3776"}) // S107: Constructor has many parameters by design - using Builder pattern for construction
-    // S3776: Cognitive complexity is from necessary validation in security-critical code
-    SecurityConfiguration(
-            int maxPathLength,
-            boolean allowPathTraversal,
-            boolean allowDoubleEncoding,
-            int maxParameterCount,
-            int maxParameterNameLength,
-            int maxParameterValueLength,
-            int maxHeaderCount,
-            int maxHeaderNameLength,
-            int maxHeaderValueLength,
-            @Nullable Set<String> allowedHeaderNames,
-            Set<String> blockedHeaderNames,
-            int maxCookieCount,
-            int maxCookieNameLength,
-            int maxCookieValueLength,
-            boolean requireSecureCookies,
-            boolean requireHttpOnlyCookies,
-            long maxBodySize,
-            @Nullable Set<String> allowedContentTypes,
-            Set<String> blockedContentTypes,
-            boolean allowNullBytes,
-            boolean allowControlCharacters,
-            boolean allowExtendedAscii,
-            boolean normalizeUnicode,
-            boolean caseSensitiveComparison,
-            boolean failOnSuspiciousPatterns,
-            boolean logSecurityViolations) {
-
-        // Validate length limits are positive
+    public SecurityConfiguration {
         if (maxPathLength <= 0) {
             throw new IllegalArgumentException("maxPathLength must be positive, got: " + maxPathLength);
-        }
-        if (maxParameterCount < 0) {
-            throw new IllegalArgumentException("maxParameterCount must be non-negative, got: " + maxParameterCount);
         }
         if (maxParameterNameLength <= 0) {
             throw new IllegalArgumentException("maxParameterNameLength must be positive, got: " + maxParameterNameLength);
@@ -171,17 +106,11 @@ public final class SecurityConfiguration {
         if (maxParameterValueLength <= 0) {
             throw new IllegalArgumentException("maxParameterValueLength must be positive, got: " + maxParameterValueLength);
         }
-        if (maxHeaderCount < 0) {
-            throw new IllegalArgumentException("maxHeaderCount must be non-negative, got: " + maxHeaderCount);
-        }
         if (maxHeaderNameLength <= 0) {
             throw new IllegalArgumentException("maxHeaderNameLength must be positive, got: " + maxHeaderNameLength);
         }
         if (maxHeaderValueLength <= 0) {
             throw new IllegalArgumentException("maxHeaderValueLength must be positive, got: " + maxHeaderValueLength);
-        }
-        if (maxCookieCount < 0) {
-            throw new IllegalArgumentException("maxCookieCount must be non-negative, got: " + maxCookieCount);
         }
         if (maxCookieNameLength <= 0) {
             throw new IllegalArgumentException("maxCookieNameLength must be positive, got: " + maxCookieNameLength);
@@ -191,64 +120,6 @@ public final class SecurityConfiguration {
         }
         if (maxBodySize < 0) {
             throw new IllegalArgumentException("maxBodySize must be non-negative, got: " + maxBodySize);
-        }
-
-        // Assign final fields
-        this.maxPathLength = maxPathLength;
-        this.allowPathTraversal = allowPathTraversal;
-        this.allowDoubleEncoding = allowDoubleEncoding;
-        this.maxParameterCount = maxParameterCount;
-        this.maxParameterNameLength = maxParameterNameLength;
-        this.maxParameterValueLength = maxParameterValueLength;
-        this.maxHeaderCount = maxHeaderCount;
-        this.maxHeaderNameLength = maxHeaderNameLength;
-        this.maxHeaderValueLength = maxHeaderValueLength;
-        this.maxCookieCount = maxCookieCount;
-        this.maxCookieNameLength = maxCookieNameLength;
-        this.maxCookieValueLength = maxCookieValueLength;
-        this.requireSecureCookies = requireSecureCookies;
-        this.requireHttpOnlyCookies = requireHttpOnlyCookies;
-        this.maxBodySize = maxBodySize;
-        this.allowNullBytes = allowNullBytes;
-        this.allowControlCharacters = allowControlCharacters;
-        this.allowExtendedAscii = allowExtendedAscii;
-        this.normalizeUnicode = normalizeUnicode;
-        this.caseSensitiveComparison = caseSensitiveComparison;
-        this.failOnSuspiciousPatterns = failOnSuspiciousPatterns;
-        this.logSecurityViolations = logSecurityViolations;
-
-        // Ensure sets are immutable and non-null
-        this.allowedHeaderNames = allowedHeaderNames != null ?
-                Set.copyOf(allowedHeaderNames) : null;
-        this.blockedHeaderNames = Set.copyOf(blockedHeaderNames);
-        this.allowedContentTypes = allowedContentTypes != null ?
-                Set.copyOf(allowedContentTypes) : null;
-        this.blockedContentTypes = Set.copyOf(blockedContentTypes);
-
-        // Pre-process sets for case-insensitive comparison if needed
-        // This optimization changes lookups from O(n) to O(1) average case
-        if (!caseSensitiveComparison) {
-            // Convert all strings to lowercase for case-insensitive lookups
-            this.allowedHeaderNamesLowercase = this.allowedHeaderNames != null ?
-                    this.allowedHeaderNames.stream()
-                            .map(String::toLowerCase)
-                            .collect(Collectors.toUnmodifiableSet()) : null;
-            this.blockedHeaderNamesLowercase = this.blockedHeaderNames.stream()
-                    .map(String::toLowerCase)
-                    .collect(Collectors.toUnmodifiableSet());
-            this.allowedContentTypesLowercase = this.allowedContentTypes != null ?
-                    this.allowedContentTypes.stream()
-                            .map(String::toLowerCase)
-                            .collect(Collectors.toUnmodifiableSet()) : null;
-            this.blockedContentTypesLowercase = this.blockedContentTypes.stream()
-                    .map(String::toLowerCase)
-                    .collect(Collectors.toUnmodifiableSet());
-        } else {
-            // Not needed for case-sensitive comparison
-            this.allowedHeaderNamesLowercase = null;
-            this.blockedHeaderNamesLowercase = Set.of();
-            this.allowedContentTypesLowercase = null;
-            this.blockedContentTypesLowercase = Set.of();
         }
     }
 
@@ -265,178 +136,40 @@ public final class SecurityConfiguration {
      * Creates a strict security configuration with tight restrictions.
      * This configuration prioritizes security over compatibility.
      *
+     * <p>Delegates to {@link SecurityDefaults#STRICT_CONFIGURATION}, the single
+     * source of truth for preset semantics.</p>
+     *
      * @return A SecurityConfiguration with strict security policies
      */
     public static SecurityConfiguration strict() {
-        return builder()
-                // Path Security - very restrictive
-                .maxPathLength(1024)
-                .allowPathTraversal(false)
-                .allowDoubleEncoding(false)
-
-                // Parameter Security - strict limits
-                .maxParameterCount(50)
-                .maxParameterNameLength(100)
-                .maxParameterValueLength(1024)
-
-                // Header Security - conservative limits
-                .maxHeaderCount(50)
-                .maxHeaderNameLength(100)
-                .maxHeaderValueLength(4096)
-
-                // Cookie Security - require all security flags
-                .maxCookieCount(20)
-                .maxCookieNameLength(100)
-                .maxCookieValueLength(4096)
-                .requireSecureCookies(true)
-                .requireHttpOnlyCookies(true)
-
-                // Body Security - reasonable limit
-                .maxBodySize(10_485_760) // 10MB
-
-                // Encoding Security - no dangerous characters
-                .allowNullBytes(false)
-                .allowControlCharacters(false)
-                .allowExtendedAscii(false)
-                .normalizeUnicode(true)
-
-                // General Policies - maximum security
-                .caseSensitiveComparison(true)
-                .failOnSuspiciousPatterns(true)
-                .logSecurityViolations(true)
-
-                .build();
+        return SecurityDefaults.STRICT_CONFIGURATION;
     }
 
     /**
      * Creates a lenient security configuration for maximum compatibility.
      * This configuration should only be used in trusted environments.
      *
+     * <p>Delegates to {@link SecurityDefaults#LENIENT_CONFIGURATION}, the single
+     * source of truth for preset semantics. Note that even the lenient preset
+     * never permits null bytes; path traversal is always blocked by the
+     * validation stages regardless of configuration.</p>
+     *
      * @return A SecurityConfiguration with permissive policies
      */
     public static SecurityConfiguration lenient() {
-        return builder()
-                // Path Security - permissive
-                .maxPathLength(8192)
-                .allowPathTraversal(true) // WARNING: Security risk
-                .allowDoubleEncoding(true)
-
-                // Parameter Security - generous limits
-                .maxParameterCount(1000)
-                .maxParameterNameLength(512)
-                .maxParameterValueLength(8192)
-
-                // Header Security - large limits
-                .maxHeaderCount(200)
-                .maxHeaderNameLength(512)
-                .maxHeaderValueLength(16384)
-
-                // Cookie Security - no requirements
-                .maxCookieCount(100)
-                .maxCookieNameLength(512)
-                .maxCookieValueLength(8192)
-                .requireSecureCookies(false)
-                .requireHttpOnlyCookies(false)
-
-                // Body Security - large limit
-                .maxBodySize(104_857_600) // 100MB
-
-                // Encoding Security - allow everything
-                .allowNullBytes(true)
-                .allowControlCharacters(true)
-                .allowExtendedAscii(true)
-                .normalizeUnicode(false)
-
-                // General Policies - minimal security
-                .caseSensitiveComparison(false)
-                .failOnSuspiciousPatterns(false)
-                .logSecurityViolations(false)
-
-                .build();
+        return SecurityDefaults.LENIENT_CONFIGURATION;
     }
 
     /**
      * Creates a security configuration with default balanced settings.
      *
+     * <p>Delegates to {@link SecurityDefaults#DEFAULT_CONFIGURATION}, which is
+     * identical to {@code builder().build()}.</p>
+     *
      * @return A SecurityConfiguration with default security policies
      */
     public static SecurityConfiguration defaults() {
-        return builder().build();
-    }
-
-    /**
-     * Checks if the configuration allows a specific header name.
-     *
-     * @param headerName The header name to check (null returns false)
-     * @return true if the header is allowed, false if blocked or null
-     */
-    public boolean isHeaderAllowed(@Nullable String headerName) {
-        return isAllowed(headerName, allowedHeaderNames, blockedHeaderNames,
-                allowedHeaderNamesLowercase, blockedHeaderNamesLowercase);
-    }
-
-    /**
-     * Checks if the configuration allows a specific content type.
-     *
-     * @param contentType The content type to check (null returns false)
-     * @return true if the content type is allowed, false if blocked or null
-     */
-    public boolean isContentTypeAllowed(@Nullable String contentType) {
-        return isAllowed(contentType, allowedContentTypes, blockedContentTypes,
-                allowedContentTypesLowercase, blockedContentTypesLowercase);
-    }
-
-    /**
-     * Helper method to check if a value is allowed based on allow and block lists.
-     * For case-insensitive comparison, uses pre-processed lowercase sets for O(1) lookups
-     * instead of O(n) stream operations.
-     *
-     * @param value The value to check (null returns false)
-     * @param allowedSet The set of allowed values (null means all allowed)
-     * @param blockedSet The set of blocked values
-     * @param allowedSetLowercase Pre-processed lowercase allowed set (used when case-insensitive)
-     * @param blockedSetLowercase Pre-processed lowercase blocked set (used when case-insensitive)
-     * @return true if the value is allowed, false if blocked or null
-     */
-    private boolean isAllowed(@Nullable String value,
-            @Nullable Set<String> allowedSet,
-            Set<String> blockedSet,
-            @Nullable Set<String> allowedSetLowercase,
-            Set<String> blockedSetLowercase) {
-        if (value == null) {
-            return false;
-        }
-
-        // For case-sensitive comparison, use original sets with O(1) contains
-        if (caseSensitiveComparison) {
-            // Check blocked list first
-            if (blockedSet.contains(value)) {
-                return false;
-            }
-            // If there's an allow list, check it
-            if (allowedSet != null) {
-                return allowedSet.contains(value);
-            }
-            // No allow list means all values are allowed (except blocked ones)
-            return true;
-        }
-
-        // For case-insensitive comparison, use pre-processed lowercase sets
-        // This provides O(1) average case performance instead of O(n)
-        String valueLowercase = value.toLowerCase();
-
-        // Check blocked list first using O(1) contains
-        if (blockedSetLowercase.contains(valueLowercase)) {
-            return false;
-        }
-
-        // If there's an allow list, check it using O(1) contains
-        if (allowedSetLowercase != null) {
-            return allowedSetLowercase.contains(valueLowercase);
-        }
-
-        // No allow list means all values are allowed (except blocked ones)
-        return true;
+        return SecurityDefaults.DEFAULT_CONFIGURATION;
     }
 
     /**
@@ -445,8 +178,7 @@ public final class SecurityConfiguration {
      * @return true if this configuration uses strict security policies
      */
     public boolean isStrict() {
-        return !allowPathTraversal &&
-                !allowDoubleEncoding &&
+        return !allowDoubleEncoding &&
                 !allowNullBytes &&
                 !allowControlCharacters &&
                 !allowExtendedAscii &&
@@ -460,198 +192,10 @@ public final class SecurityConfiguration {
      * @return true if this configuration uses lenient security policies
      */
     public boolean isLenient() {
-        return allowPathTraversal &&
-                allowDoubleEncoding &&
-                allowNullBytes &&
+        return allowDoubleEncoding &&
                 allowControlCharacters &&
                 allowExtendedAscii &&
                 !normalizeUnicode &&
                 !failOnSuspiciousPatterns;
-    }
-
-    // Getters for all fields
-
-    public int maxPathLength() {
-        return maxPathLength;
-    }
-
-    public boolean allowPathTraversal() {
-        return allowPathTraversal;
-    }
-
-    public boolean allowDoubleEncoding() {
-        return allowDoubleEncoding;
-    }
-
-    public int maxParameterCount() {
-        return maxParameterCount;
-    }
-
-    public int maxParameterNameLength() {
-        return maxParameterNameLength;
-    }
-
-    public int maxParameterValueLength() {
-        return maxParameterValueLength;
-    }
-
-    public int maxHeaderCount() {
-        return maxHeaderCount;
-    }
-
-    public int maxHeaderNameLength() {
-        return maxHeaderNameLength;
-    }
-
-    public int maxHeaderValueLength() {
-        return maxHeaderValueLength;
-    }
-
-    public @Nullable Set<String> allowedHeaderNames() {
-        return allowedHeaderNames;
-    }
-
-    public Set<String> blockedHeaderNames() {
-        return blockedHeaderNames;
-    }
-
-    public int maxCookieCount() {
-        return maxCookieCount;
-    }
-
-    public int maxCookieNameLength() {
-        return maxCookieNameLength;
-    }
-
-    public int maxCookieValueLength() {
-        return maxCookieValueLength;
-    }
-
-    public boolean requireSecureCookies() {
-        return requireSecureCookies;
-    }
-
-    public boolean requireHttpOnlyCookies() {
-        return requireHttpOnlyCookies;
-    }
-
-    public long maxBodySize() {
-        return maxBodySize;
-    }
-
-    public @Nullable Set<String> allowedContentTypes() {
-        return allowedContentTypes;
-    }
-
-    public Set<String> blockedContentTypes() {
-        return blockedContentTypes;
-    }
-
-    public boolean allowNullBytes() {
-        return allowNullBytes;
-    }
-
-    public boolean allowControlCharacters() {
-        return allowControlCharacters;
-    }
-
-    public boolean allowExtendedAscii() {
-        return allowExtendedAscii;
-    }
-
-    public boolean normalizeUnicode() {
-        return normalizeUnicode;
-    }
-
-    public boolean caseSensitiveComparison() {
-        return caseSensitiveComparison;
-    }
-
-    public boolean failOnSuspiciousPatterns() {
-        return failOnSuspiciousPatterns;
-    }
-
-    public boolean logSecurityViolations() {
-        return logSecurityViolations;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (!(obj instanceof SecurityConfiguration other)) return false;
-
-        return maxPathLength == other.maxPathLength &&
-                allowPathTraversal == other.allowPathTraversal &&
-                allowDoubleEncoding == other.allowDoubleEncoding &&
-                maxParameterCount == other.maxParameterCount &&
-                maxParameterNameLength == other.maxParameterNameLength &&
-                maxParameterValueLength == other.maxParameterValueLength &&
-                maxHeaderCount == other.maxHeaderCount &&
-                maxHeaderNameLength == other.maxHeaderNameLength &&
-                maxHeaderValueLength == other.maxHeaderValueLength &&
-                maxCookieCount == other.maxCookieCount &&
-                maxCookieNameLength == other.maxCookieNameLength &&
-                maxCookieValueLength == other.maxCookieValueLength &&
-                requireSecureCookies == other.requireSecureCookies &&
-                requireHttpOnlyCookies == other.requireHttpOnlyCookies &&
-                maxBodySize == other.maxBodySize &&
-                allowNullBytes == other.allowNullBytes &&
-                allowControlCharacters == other.allowControlCharacters &&
-                allowExtendedAscii == other.allowExtendedAscii &&
-                normalizeUnicode == other.normalizeUnicode &&
-                caseSensitiveComparison == other.caseSensitiveComparison &&
-                failOnSuspiciousPatterns == other.failOnSuspiciousPatterns &&
-                logSecurityViolations == other.logSecurityViolations &&
-                Objects.equals(allowedHeaderNames, other.allowedHeaderNames) &&
-                Objects.equals(blockedHeaderNames, other.blockedHeaderNames) &&
-                Objects.equals(allowedContentTypes, other.allowedContentTypes) &&
-                Objects.equals(blockedContentTypes, other.blockedContentTypes);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-                maxPathLength, allowPathTraversal, allowDoubleEncoding,
-                maxParameterCount, maxParameterNameLength, maxParameterValueLength,
-                maxHeaderCount, maxHeaderNameLength, maxHeaderValueLength,
-                allowedHeaderNames, blockedHeaderNames,
-                maxCookieCount, maxCookieNameLength, maxCookieValueLength,
-                requireSecureCookies, requireHttpOnlyCookies,
-                maxBodySize, allowedContentTypes, blockedContentTypes,
-                allowNullBytes, allowControlCharacters, allowExtendedAscii, normalizeUnicode,
-                caseSensitiveComparison, failOnSuspiciousPatterns, logSecurityViolations
-        );
-    }
-
-    @Override
-    public String toString() {
-        return "SecurityConfiguration{" +
-                "maxPathLength=" + maxPathLength +
-                ", allowPathTraversal=" + allowPathTraversal +
-                ", allowDoubleEncoding=" + allowDoubleEncoding +
-                ", maxParameterCount=" + maxParameterCount +
-                ", maxParameterNameLength=" + maxParameterNameLength +
-                ", maxParameterValueLength=" + maxParameterValueLength +
-                ", maxHeaderCount=" + maxHeaderCount +
-                ", maxHeaderNameLength=" + maxHeaderNameLength +
-                ", maxHeaderValueLength=" + maxHeaderValueLength +
-                ", allowedHeaderNames=" + allowedHeaderNames +
-                ", blockedHeaderNames=" + blockedHeaderNames +
-                ", maxCookieCount=" + maxCookieCount +
-                ", maxCookieNameLength=" + maxCookieNameLength +
-                ", maxCookieValueLength=" + maxCookieValueLength +
-                ", requireSecureCookies=" + requireSecureCookies +
-                ", requireHttpOnlyCookies=" + requireHttpOnlyCookies +
-                ", maxBodySize=" + maxBodySize +
-                ", allowedContentTypes=" + allowedContentTypes +
-                ", blockedContentTypes=" + blockedContentTypes +
-                ", allowNullBytes=" + allowNullBytes +
-                ", allowControlCharacters=" + allowControlCharacters +
-                ", allowExtendedAscii=" + allowExtendedAscii +
-                ", normalizeUnicode=" + normalizeUnicode +
-                ", caseSensitiveComparison=" + caseSensitiveComparison +
-                ", failOnSuspiciousPatterns=" + failOnSuspiciousPatterns +
-                ", logSecurityViolations=" + logSecurityViolations +
-                '}';
     }
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java
@@ -15,12 +15,6 @@
  */
 package de.cuioss.http.security.config;
 
-import org.jspecify.annotations.Nullable;
-
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
-
 /**
  * Builder class for constructing {@link SecurityConfiguration} instances with fluent API.
  *
@@ -43,21 +37,15 @@ import java.util.Set;
  * // Custom configuration
  * SecurityConfiguration custom = SecurityConfiguration.builder()
  *     .maxPathLength(2048)
- *     .allowPathTraversal(false)
- *     .maxParameterCount(50)
- *     .requireSecureCookies(true)
- *     .addBlockedHeaderName("X-Debug")
- *     .addAllowedContentType("application/json")
- *     .addAllowedContentType("text/plain")
+ *     .maxParameterValueLength(1024)
+ *     .normalizeUnicode(true)
  *     .build();
  *
- * // Chain multiple settings
+ * // Chain encoding settings in one call
  * SecurityConfiguration strict = SecurityConfiguration.builder()
- *     .pathSecurity(1024, false)
- *     .cookieSecurity(true, true, 10, 64, 512)
- *     .bodySecurity(1024 * 1024, Set.of("application/json"))
+ *     .maxPathLength(1024)
  *     .encoding(false, false, false, true)
- *     .policies(true, true, true)
+ *     .failOnSuspiciousPatterns(true)
  *     .build();
  * </pre>
  *
@@ -66,12 +54,11 @@ import java.util.Set;
  * security without being overly restrictive:</p>
  * <ul>
  *   <li>Path length: 4096 characters</li>
- *   <li>Parameter count: 100</li>
- *   <li>Header count: 50</li>
- *   <li>Cookie count: 20</li>
+ *   <li>Parameter name/value length: 128 / 2048 characters</li>
+ *   <li>Header name/value length: 128 / 2048 characters</li>
+ *   <li>Cookie name/value length: 128 / 2048 characters</li>
  *   <li>Body size: 5MB</li>
- *   <li>Path traversal: disabled</li>
- *   <li>Cookie security flags: recommended but not required</li>
+ *   <li>Null bytes and control characters: blocked</li>
  * </ul>
  *
  * Implements: Task C2 from HTTP verification specification
@@ -83,32 +70,22 @@ public class SecurityConfigurationBuilder {
 
     // Path Security defaults
     private int maxPathLength = 4096;
-    private boolean allowPathTraversal = false;
     private boolean allowDoubleEncoding = false;
 
     // Parameter Security defaults
-    private int maxParameterCount = 100;
     private int maxParameterNameLength = 128;
     private int maxParameterValueLength = 2048;
 
     // Header Security defaults
-    private int maxHeaderCount = 50;
     private int maxHeaderNameLength = 128;
     private int maxHeaderValueLength = 2048;
-    private @Nullable Set<String> allowedHeaderNames = null;
-    private Set<String> blockedHeaderNames = new HashSet<>();
 
     // Cookie Security defaults
-    private int maxCookieCount = 20;
     private int maxCookieNameLength = 128;
     private int maxCookieValueLength = 2048;
-    private boolean requireSecureCookies = false;
-    private boolean requireHttpOnlyCookies = false;
 
     // Body Security defaults
     private long maxBodySize = 5L * 1024 * 1024; // 5MB
-    private @Nullable Set<String> allowedContentTypes = null;
-    private Set<String> blockedContentTypes = new HashSet<>();
 
     // Encoding Security defaults
     private boolean allowNullBytes = false;
@@ -119,7 +96,6 @@ public class SecurityConfigurationBuilder {
     // General Policy defaults
     private boolean caseSensitiveComparison = false;
     private boolean failOnSuspiciousPatterns = false;
-    private boolean logSecurityViolations = true;
 
     /**
      * Package-private constructor for internal use.
@@ -146,17 +122,6 @@ public class SecurityConfigurationBuilder {
     }
 
     /**
-     * Sets whether path traversal patterns (../) are allowed.
-     *
-     * @param allow true to allow path traversal, false to block it
-     * @return This builder for method chaining
-     */
-    public SecurityConfigurationBuilder allowPathTraversal(boolean allow) {
-        this.allowPathTraversal = allow;
-        return this;
-    }
-
-    /**
      * Sets whether double URL encoding is allowed.
      *
      * @param allow true to allow double encoding, false to block it
@@ -167,33 +132,7 @@ public class SecurityConfigurationBuilder {
         return this;
     }
 
-    /**
-     * Configures path security settings in one call.
-     *
-     * @param maxLength Maximum path length
-     * @param allowTraversal Whether to allow path traversal
-     * @return This builder for method chaining
-     */
-    public SecurityConfigurationBuilder pathSecurity(int maxLength, boolean allowTraversal) {
-        return maxPathLength(maxLength).allowPathTraversal(allowTraversal);
-    }
-
     // === Parameter Security Methods ===
-
-    /**
-     * Sets the maximum number of query parameters allowed.
-     *
-     * @param maxCount Maximum parameter count (must be non-negative)
-     * @return This builder for method chaining
-     * @throws IllegalArgumentException if maxCount is negative
-     */
-    public SecurityConfigurationBuilder maxParameterCount(int maxCount) {
-        if (maxCount < 0) {
-            throw new IllegalArgumentException("maxParameterCount must be non-negative, got: " + maxCount);
-        }
-        this.maxParameterCount = maxCount;
-        return this;
-    }
 
     /**
      * Sets the maximum length for parameter names.
@@ -225,36 +164,7 @@ public class SecurityConfigurationBuilder {
         return this;
     }
 
-    /**
-     * Configures parameter security settings in one call.
-     *
-     * @param maxCount Maximum parameter count
-     * @param maxNameLength Maximum parameter name length
-     * @param maxValueLength Maximum parameter value length
-     * @return This builder for method chaining
-     */
-    public SecurityConfigurationBuilder parameterSecurity(int maxCount, int maxNameLength, int maxValueLength) {
-        return maxParameterCount(maxCount)
-                .maxParameterNameLength(maxNameLength)
-                .maxParameterValueLength(maxValueLength);
-    }
-
     // === Header Security Methods ===
-
-    /**
-     * Sets the maximum number of HTTP headers allowed.
-     *
-     * @param maxCount Maximum header count (must be non-negative)
-     * @return This builder for method chaining
-     * @throws IllegalArgumentException if maxCount is negative
-     */
-    public SecurityConfigurationBuilder maxHeaderCount(int maxCount) {
-        if (maxCount < 0) {
-            throw new IllegalArgumentException("maxHeaderCount must be non-negative, got: " + maxCount);
-        }
-        this.maxHeaderCount = maxCount;
-        return this;
-    }
 
     /**
      * Sets the maximum length for header names.
@@ -286,90 +196,7 @@ public class SecurityConfigurationBuilder {
         return this;
     }
 
-    /**
-     * Adds a header name to the allowed list. If the allowed list is null,
-     * this method initializes it with the given header name.
-     *
-     * @param headerName Header name to allow (must not be null)
-     * @return This builder for method chaining
-     * @throws NullPointerException if headerName is null
-     */
-    public SecurityConfigurationBuilder addAllowedHeaderName(String headerName) {
-        Objects.requireNonNull(headerName, "headerName must not be null");
-        if (allowedHeaderNames == null) {
-            allowedHeaderNames = new HashSet<>();
-        }
-        allowedHeaderNames.add(headerName);
-        return this;
-    }
-
-    /**
-     * Sets the complete list of allowed header names.
-     *
-     * @param headerNames Set of allowed header names (null means all allowed)
-     * @return This builder for method chaining
-     */
-    public SecurityConfigurationBuilder allowedHeaderNames(@Nullable Set<String> headerNames) {
-        this.allowedHeaderNames = headerNames != null ? new HashSet<>(headerNames) : null;
-        return this;
-    }
-
-    /**
-     * Adds a header name to the blocked list.
-     *
-     * @param headerName Header name to block (must not be null)
-     * @return This builder for method chaining
-     * @throws NullPointerException if headerName is null
-     */
-    public SecurityConfigurationBuilder addBlockedHeaderName(String headerName) {
-        Objects.requireNonNull(headerName, "headerName must not be null");
-        blockedHeaderNames.add(headerName);
-        return this;
-    }
-
-    /**
-     * Sets the complete list of blocked header names.
-     *
-     * @param headerNames Set of blocked header names (must not be null)
-     * @return This builder for method chaining
-     * @throws NullPointerException if headerNames is null
-     */
-    public SecurityConfigurationBuilder blockedHeaderNames(Set<String> headerNames) {
-        Objects.requireNonNull(headerNames, "headerNames must not be null");
-        this.blockedHeaderNames = new HashSet<>(headerNames);
-        return this;
-    }
-
-    /**
-     * Configures header security settings in one call.
-     *
-     * @param maxCount Maximum header count
-     * @param maxNameLength Maximum header name length
-     * @param maxValueLength Maximum header value length
-     * @return This builder for method chaining
-     */
-    public SecurityConfigurationBuilder headerSecurity(int maxCount, int maxNameLength, int maxValueLength) {
-        return maxHeaderCount(maxCount)
-                .maxHeaderNameLength(maxNameLength)
-                .maxHeaderValueLength(maxValueLength);
-    }
-
     // === Cookie Security Methods ===
-
-    /**
-     * Sets the maximum number of cookies allowed.
-     *
-     * @param maxCount Maximum cookie count (must be non-negative)
-     * @return This builder for method chaining
-     * @throws IllegalArgumentException if maxCount is negative
-     */
-    public SecurityConfigurationBuilder maxCookieCount(int maxCount) {
-        if (maxCount < 0) {
-            throw new IllegalArgumentException("maxCookieCount must be non-negative, got: " + maxCount);
-        }
-        this.maxCookieCount = maxCount;
-        return this;
-    }
 
     /**
      * Sets the maximum length for cookie names.
@@ -401,47 +228,6 @@ public class SecurityConfigurationBuilder {
         return this;
     }
 
-    /**
-     * Sets whether all cookies must have the Secure flag.
-     *
-     * @param require true to require Secure flag on all cookies
-     * @return This builder for method chaining
-     */
-    public SecurityConfigurationBuilder requireSecureCookies(boolean require) {
-        this.requireSecureCookies = require;
-        return this;
-    }
-
-    /**
-     * Sets whether all cookies must have the HttpOnly flag.
-     *
-     * @param require true to require HttpOnly flag on all cookies
-     * @return This builder for method chaining
-     */
-    public SecurityConfigurationBuilder requireHttpOnlyCookies(boolean require) {
-        this.requireHttpOnlyCookies = require;
-        return this;
-    }
-
-    /**
-     * Configures cookie security settings in one call.
-     *
-     * @param requireSecure Whether to require Secure flag
-     * @param requireHttpOnly Whether to require HttpOnly flag
-     * @param maxCount Maximum cookie count
-     * @param maxNameLength Maximum cookie name length
-     * @param maxValueLength Maximum cookie value length
-     * @return This builder for method chaining
-     */
-    public SecurityConfigurationBuilder cookieSecurity(boolean requireSecure, boolean requireHttpOnly,
-            int maxCount, int maxNameLength, int maxValueLength) {
-        return requireSecureCookies(requireSecure)
-                .requireHttpOnlyCookies(requireHttpOnly)
-                .maxCookieCount(maxCount)
-                .maxCookieNameLength(maxNameLength)
-                .maxCookieValueLength(maxValueLength);
-    }
-
     // === Body Security Methods ===
 
     /**
@@ -457,71 +243,6 @@ public class SecurityConfigurationBuilder {
         }
         this.maxBodySize = maxSize;
         return this;
-    }
-
-    /**
-     * Adds a content type to the allowed list. If the allowed list is null,
-     * this method initializes it with the given content type.
-     *
-     * @param contentType Content type to allow (must not be null)
-     * @return This builder for method chaining
-     * @throws NullPointerException if contentType is null
-     */
-    public SecurityConfigurationBuilder addAllowedContentType(String contentType) {
-        Objects.requireNonNull(contentType, "contentType must not be null");
-        if (allowedContentTypes == null) {
-            allowedContentTypes = new HashSet<>();
-        }
-        allowedContentTypes.add(contentType);
-        return this;
-    }
-
-    /**
-     * Sets the complete list of allowed content types.
-     *
-     * @param contentTypes Set of allowed content types (null means all allowed)
-     * @return This builder for method chaining
-     */
-    public SecurityConfigurationBuilder allowedContentTypes(@Nullable Set<String> contentTypes) {
-        this.allowedContentTypes = contentTypes != null ? new HashSet<>(contentTypes) : null;
-        return this;
-    }
-
-    /**
-     * Adds a content type to the blocked list.
-     *
-     * @param contentType Content type to block (must not be null)
-     * @return This builder for method chaining
-     * @throws NullPointerException if contentType is null
-     */
-    public SecurityConfigurationBuilder addBlockedContentType(String contentType) {
-        Objects.requireNonNull(contentType, "contentType must not be null");
-        blockedContentTypes.add(contentType);
-        return this;
-    }
-
-    /**
-     * Sets the complete list of blocked content types.
-     *
-     * @param contentTypes Set of blocked content types (must not be null)
-     * @return This builder for method chaining
-     * @throws NullPointerException if contentTypes is null
-     */
-    public SecurityConfigurationBuilder blockedContentTypes(Set<String> contentTypes) {
-        Objects.requireNonNull(contentTypes, "contentTypes must not be null");
-        this.blockedContentTypes = new HashSet<>(contentTypes);
-        return this;
-    }
-
-    /**
-     * Configures body security settings in one call.
-     *
-     * @param maxSize Maximum body size
-     * @param allowedTypes Set of allowed content types (null = all allowed)
-     * @return This builder for method chaining
-     */
-    public SecurityConfigurationBuilder bodySecurity(long maxSize, @Nullable Set<String> allowedTypes) {
-        return maxBodySize(maxSize).allowedContentTypes(allowedTypes);
     }
 
     // === Encoding Security Methods ===
@@ -560,7 +281,6 @@ public class SecurityConfigurationBuilder {
         this.allowExtendedAscii = allow;
         return this;
     }
-
 
     /**
      * Sets whether Unicode normalization should be performed.
@@ -615,31 +335,6 @@ public class SecurityConfigurationBuilder {
     }
 
     /**
-     * Sets whether to log security violations.
-     *
-     * @param log true to enable logging, false to disable
-     * @return This builder for method chaining
-     */
-    public SecurityConfigurationBuilder logSecurityViolations(boolean log) {
-        this.logSecurityViolations = log;
-        return this;
-    }
-
-    /**
-     * Configures general policy settings in one call.
-     *
-     * @param caseSensitive Whether comparisons are case-sensitive
-     * @param failOnSuspicious Whether to fail on suspicious patterns
-     * @param logViolations Whether to log security violations
-     * @return This builder for method chaining
-     */
-    public SecurityConfigurationBuilder policies(boolean caseSensitive, boolean failOnSuspicious, boolean logViolations) {
-        return caseSensitiveComparison(caseSensitive)
-                .failOnSuspiciousPatterns(failOnSuspicious)
-                .logSecurityViolations(logViolations);
-    }
-
-    /**
      * Builds the SecurityConfiguration with the current settings.
      *
      * @return A new immutable SecurityConfiguration instance
@@ -647,13 +342,13 @@ public class SecurityConfigurationBuilder {
      */
     public SecurityConfiguration build() {
         return new SecurityConfiguration(
-                maxPathLength, allowPathTraversal, allowDoubleEncoding,
-                maxParameterCount, maxParameterNameLength, maxParameterValueLength,
-                maxHeaderCount, maxHeaderNameLength, maxHeaderValueLength, allowedHeaderNames, blockedHeaderNames,
-                maxCookieCount, maxCookieNameLength, maxCookieValueLength, requireSecureCookies, requireHttpOnlyCookies,
-                maxBodySize, allowedContentTypes, blockedContentTypes,
+                maxPathLength, allowDoubleEncoding,
+                maxParameterNameLength, maxParameterValueLength,
+                maxHeaderNameLength, maxHeaderValueLength,
+                maxCookieNameLength, maxCookieValueLength,
+                maxBodySize,
                 allowNullBytes, allowControlCharacters, allowExtendedAscii, normalizeUnicode,
-                caseSensitiveComparison, failOnSuspiciousPatterns, logSecurityViolations
+                caseSensitiveComparison, failOnSuspiciousPatterns
         );
     }
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java
@@ -313,23 +313,14 @@ public final class SecurityDefaults {
      * <p>Single source of truth for strict preset semantics -
      * {@link SecurityConfiguration#strict()} delegates to this constant.</p>
      */
-    public static final SecurityConfiguration STRICT_CONFIGURATION = SecurityConfiguration.builder()
-            .maxPathLength(MAX_PATH_LENGTH_STRICT)
-            .allowDoubleEncoding(false)
-            .maxParameterNameLength(MAX_PARAMETER_NAME_LENGTH_STRICT)
-            .maxParameterValueLength(MAX_PARAMETER_VALUE_LENGTH_STRICT)
-            .maxHeaderNameLength(MAX_HEADER_NAME_LENGTH_STRICT)
-            .maxHeaderValueLength(MAX_HEADER_VALUE_LENGTH_STRICT)
-            .maxCookieNameLength(MAX_COOKIE_NAME_LENGTH_STRICT)
-            .maxCookieValueLength(MAX_COOKIE_VALUE_LENGTH_STRICT)
-            .maxBodySize(MAX_BODY_SIZE_STRICT)
-            .allowNullBytes(false)
-            .allowControlCharacters(false)
-            .allowExtendedAscii(false)
-            .normalizeUnicode(true)
-            .caseSensitiveComparison(true)
-            .failOnSuspiciousPatterns(true)
-            .build();
+    public static final SecurityConfiguration STRICT_CONFIGURATION = new SecurityConfiguration(
+            MAX_PATH_LENGTH_STRICT, false,
+            MAX_PARAMETER_NAME_LENGTH_STRICT, MAX_PARAMETER_VALUE_LENGTH_STRICT,
+            MAX_HEADER_NAME_LENGTH_STRICT, MAX_HEADER_VALUE_LENGTH_STRICT,
+            MAX_COOKIE_NAME_LENGTH_STRICT, MAX_COOKIE_VALUE_LENGTH_STRICT,
+            MAX_BODY_SIZE_STRICT,
+            false, false, false, true, // no null bytes, no control chars, no extended ASCII, normalize Unicode
+            true, true); // case-sensitive comparison, fail on suspicious patterns
 
     /**
      * Configuration preset for balanced security and usability.
@@ -338,23 +329,7 @@ public final class SecurityDefaults {
      * {@link SecurityConfiguration#defaults()} delegates to this constant.
      * Identical to {@code SecurityConfiguration.builder().build()}.</p>
      */
-    public static final SecurityConfiguration DEFAULT_CONFIGURATION = SecurityConfiguration.builder()
-            .maxPathLength(MAX_PATH_LENGTH_DEFAULT)
-            .allowDoubleEncoding(false)
-            .maxParameterNameLength(MAX_PARAMETER_NAME_LENGTH_DEFAULT)
-            .maxParameterValueLength(MAX_PARAMETER_VALUE_LENGTH_DEFAULT)
-            .maxHeaderNameLength(MAX_HEADER_NAME_LENGTH_DEFAULT)
-            .maxHeaderValueLength(MAX_HEADER_VALUE_LENGTH_DEFAULT)
-            .maxCookieNameLength(MAX_COOKIE_NAME_LENGTH_DEFAULT)
-            .maxCookieValueLength(MAX_COOKIE_VALUE_LENGTH_DEFAULT)
-            .maxBodySize(MAX_BODY_SIZE_DEFAULT)
-            .allowNullBytes(false)
-            .allowControlCharacters(false)
-            .allowExtendedAscii(true)
-            .normalizeUnicode(false)
-            .caseSensitiveComparison(false)
-            .failOnSuspiciousPatterns(false)
-            .build();
+    public static final SecurityConfiguration DEFAULT_CONFIGURATION = SecurityConfiguration.builder().build();
 
     /**
      * Configuration preset for maximum compatibility.
@@ -364,21 +339,12 @@ public final class SecurityDefaults {
      * Even this preset never permits null bytes; path traversal is always
      * blocked by the validation stages regardless of configuration.</p>
      */
-    public static final SecurityConfiguration LENIENT_CONFIGURATION = SecurityConfiguration.builder()
-            .maxPathLength(MAX_PATH_LENGTH_LENIENT)
-            .allowDoubleEncoding(true)
-            .maxParameterNameLength(MAX_PARAMETER_NAME_LENGTH_LENIENT)
-            .maxParameterValueLength(MAX_PARAMETER_VALUE_LENGTH_LENIENT)
-            .maxHeaderNameLength(MAX_HEADER_NAME_LENGTH_LENIENT)
-            .maxHeaderValueLength(MAX_HEADER_VALUE_LENGTH_LENIENT)
-            .maxCookieNameLength(MAX_COOKIE_NAME_LENGTH_LENIENT)
-            .maxCookieValueLength(MAX_COOKIE_VALUE_LENGTH_LENIENT)
-            .maxBodySize(MAX_BODY_SIZE_LENIENT)
-            .allowNullBytes(false) // Still don't allow this
-            .allowControlCharacters(true)
-            .allowExtendedAscii(true)
-            .normalizeUnicode(false)
-            .caseSensitiveComparison(false)
-            .failOnSuspiciousPatterns(false)
-            .build();
+    public static final SecurityConfiguration LENIENT_CONFIGURATION = new SecurityConfiguration(
+            MAX_PATH_LENGTH_LENIENT, true,
+            MAX_PARAMETER_NAME_LENGTH_LENIENT, MAX_PARAMETER_VALUE_LENGTH_LENIENT,
+            MAX_HEADER_NAME_LENGTH_LENIENT, MAX_HEADER_VALUE_LENGTH_LENIENT,
+            MAX_COOKIE_NAME_LENGTH_LENIENT, MAX_COOKIE_VALUE_LENGTH_LENIENT,
+            MAX_BODY_SIZE_LENIENT,
+            false, true, true, false, // no null bytes (never allowed), control chars, extended ASCII, no normalization
+            false, false); // case-insensitive comparison, no suspicious-pattern failures
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java
@@ -35,21 +35,32 @@ import java.util.Set;
  * <h3>Constant Categories</h3>
  * <ul>
  *   <li><strong>Length Limits</strong> - Maximum sizes for various HTTP components</li>
- *   <li><strong>Count Limits</strong> - Maximum quantities for collections</li>
+ *   <li><strong>Count Limits</strong> - Maximum quantities for collections (advisory, see below)</li>
  *   <li><strong>Security Patterns</strong> - Common attack patterns to detect</li>
  *   <li><strong>Content Types</strong> - Standard MIME types and their security implications</li>
  *   <li><strong>Character Sets</strong> - Character validation patterns</li>
  *   <li><strong>Configuration Presets</strong> - Pre-built configurations for common scenarios</li>
  * </ul>
  *
+ * <h3>Advisory Constants</h3>
+ * <p>The count limits (parameter/header/cookie counts) and header/content-type
+ * classification sets are <strong>reference values for application-layer enforcement</strong>.
+ * The validation pipelines in this library operate on single values and therefore cannot
+ * enforce request-level policies such as counts or header allow/block lists - enforce
+ * those in your request-processing layer using these constants as recommended values.</p>
+ *
  * <h3>Usage Examples</h3>
  * <pre>
  * // Use constants in configuration
  * SecurityConfiguration config = SecurityConfiguration.builder()
  *     .maxPathLength(SecurityDefaults.MAX_PATH_LENGTH_DEFAULT)
- *     .maxParameterCount(SecurityDefaults.MAX_PARAMETER_COUNT_DEFAULT)
- *     .blockedContentTypes(SecurityDefaults.DANGEROUS_CONTENT_TYPES)
+ *     .maxParameterValueLength(SecurityDefaults.MAX_PARAMETER_VALUE_LENGTH_DEFAULT)
  *     .build();
+ *
+ * // Use advisory constants for application-layer enforcement
+ * if (request.getParameterMap().size() > SecurityDefaults.MAX_PARAMETER_COUNT_DEFAULT) {
+ *     // reject request
+ * }
  *
  * // Check against limits
  * if (path.length() > SecurityDefaults.MAX_PATH_LENGTH_STRICT) {
@@ -296,88 +307,78 @@ public final class SecurityDefaults {
 
     // ========== SIZE LIMITS FOR DIFFERENT SECURITY LEVELS ==========
 
-    /** Configuration preset for strict security requirements */
+    /**
+     * Configuration preset for strict security requirements.
+     *
+     * <p>Single source of truth for strict preset semantics -
+     * {@link SecurityConfiguration#strict()} delegates to this constant.</p>
+     */
     public static final SecurityConfiguration STRICT_CONFIGURATION = SecurityConfiguration.builder()
             .maxPathLength(MAX_PATH_LENGTH_STRICT)
-            .allowPathTraversal(false)
             .allowDoubleEncoding(false)
-            .maxParameterCount(MAX_PARAMETER_COUNT_STRICT)
             .maxParameterNameLength(MAX_PARAMETER_NAME_LENGTH_STRICT)
             .maxParameterValueLength(MAX_PARAMETER_VALUE_LENGTH_STRICT)
-            .maxHeaderCount(MAX_HEADER_COUNT_STRICT)
             .maxHeaderNameLength(MAX_HEADER_NAME_LENGTH_STRICT)
             .maxHeaderValueLength(MAX_HEADER_VALUE_LENGTH_STRICT)
-            .blockedHeaderNames(DANGEROUS_HEADER_NAMES)
-            .maxCookieCount(MAX_COOKIE_COUNT_STRICT)
             .maxCookieNameLength(MAX_COOKIE_NAME_LENGTH_STRICT)
             .maxCookieValueLength(MAX_COOKIE_VALUE_LENGTH_STRICT)
-            .requireSecureCookies(true)
-            .requireHttpOnlyCookies(true)
             .maxBodySize(MAX_BODY_SIZE_STRICT)
-            .allowedContentTypes(SAFE_CONTENT_TYPES)
             .allowNullBytes(false)
             .allowControlCharacters(false)
             .allowExtendedAscii(false)
             .normalizeUnicode(true)
             .caseSensitiveComparison(true)
             .failOnSuspiciousPatterns(true)
-            .logSecurityViolations(true)
             .build();
 
-    /** Configuration preset for balanced security and usability */
+    /**
+     * Configuration preset for balanced security and usability.
+     *
+     * <p>Single source of truth for default preset semantics -
+     * {@link SecurityConfiguration#defaults()} delegates to this constant.
+     * Identical to {@code SecurityConfiguration.builder().build()}.</p>
+     */
     public static final SecurityConfiguration DEFAULT_CONFIGURATION = SecurityConfiguration.builder()
             .maxPathLength(MAX_PATH_LENGTH_DEFAULT)
-            .allowPathTraversal(false)
             .allowDoubleEncoding(false)
-            .maxParameterCount(MAX_PARAMETER_COUNT_DEFAULT)
             .maxParameterNameLength(MAX_PARAMETER_NAME_LENGTH_DEFAULT)
             .maxParameterValueLength(MAX_PARAMETER_VALUE_LENGTH_DEFAULT)
-            .maxHeaderCount(MAX_HEADER_COUNT_DEFAULT)
             .maxHeaderNameLength(MAX_HEADER_NAME_LENGTH_DEFAULT)
             .maxHeaderValueLength(MAX_HEADER_VALUE_LENGTH_DEFAULT)
-            .blockedHeaderNames(DEBUG_HEADER_NAMES)
-            .maxCookieCount(MAX_COOKIE_COUNT_DEFAULT)
             .maxCookieNameLength(MAX_COOKIE_NAME_LENGTH_DEFAULT)
             .maxCookieValueLength(MAX_COOKIE_VALUE_LENGTH_DEFAULT)
-            .requireSecureCookies(false)
-            .requireHttpOnlyCookies(false)
             .maxBodySize(MAX_BODY_SIZE_DEFAULT)
-            .blockedContentTypes(DANGEROUS_CONTENT_TYPES)
             .allowNullBytes(false)
             .allowControlCharacters(false)
             .allowExtendedAscii(true)
             .normalizeUnicode(false)
             .caseSensitiveComparison(false)
             .failOnSuspiciousPatterns(false)
-            .logSecurityViolations(true)
             .build();
 
-    /** Configuration preset for maximum compatibility */
+    /**
+     * Configuration preset for maximum compatibility.
+     *
+     * <p>Single source of truth for lenient preset semantics -
+     * {@link SecurityConfiguration#lenient()} delegates to this constant.
+     * Even this preset never permits null bytes; path traversal is always
+     * blocked by the validation stages regardless of configuration.</p>
+     */
     public static final SecurityConfiguration LENIENT_CONFIGURATION = SecurityConfiguration.builder()
             .maxPathLength(MAX_PATH_LENGTH_LENIENT)
-            .allowPathTraversal(false) // Still don't allow this
             .allowDoubleEncoding(true)
-            .maxParameterCount(MAX_PARAMETER_COUNT_LENIENT)
             .maxParameterNameLength(MAX_PARAMETER_NAME_LENGTH_LENIENT)
             .maxParameterValueLength(MAX_PARAMETER_VALUE_LENGTH_LENIENT)
-            .maxHeaderCount(MAX_HEADER_COUNT_LENIENT)
             .maxHeaderNameLength(MAX_HEADER_NAME_LENGTH_LENIENT)
             .maxHeaderValueLength(MAX_HEADER_VALUE_LENGTH_LENIENT)
-            // No blocked headers in lenient mode
-            .maxCookieCount(MAX_COOKIE_COUNT_LENIENT)
             .maxCookieNameLength(MAX_COOKIE_NAME_LENGTH_LENIENT)
             .maxCookieValueLength(MAX_COOKIE_VALUE_LENGTH_LENIENT)
-            .requireSecureCookies(false)
-            .requireHttpOnlyCookies(false)
             .maxBodySize(MAX_BODY_SIZE_LENIENT)
-            // Only block the most dangerous content types
-            .blockedContentTypes(Set.of("application/x-executable", "application/x-msdos-program"))
             .allowNullBytes(false) // Still don't allow this
             .allowControlCharacters(true)
             .allowExtendedAscii(true)
             .normalizeUnicode(false)
             .caseSensitiveComparison(false)
             .failOnSuspiciousPatterns(false)
-            .logSecurityViolations(true)
             .build();
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationBuilderTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationBuilderTest.java
@@ -17,8 +17,6 @@ package de.cuioss.http.security.config;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -31,7 +29,6 @@ class SecurityConfigurationBuilderTest {
         SecurityConfiguration config = SecurityConfiguration.builder().build();
 
         assertEquals(4096, config.maxPathLength());
-        assertFalse(config.allowPathTraversal());
         assertFalse(config.allowDoubleEncoding());
     }
 
@@ -39,7 +36,6 @@ class SecurityConfigurationBuilderTest {
     void shouldCreateBuilderWithDefaultParameterSettings() {
         SecurityConfiguration config = SecurityConfiguration.builder().build();
 
-        assertEquals(100, config.maxParameterCount());
         assertEquals(128, config.maxParameterNameLength());
         assertEquals(2048, config.maxParameterValueLength());
     }
@@ -48,31 +44,23 @@ class SecurityConfigurationBuilderTest {
     void shouldCreateBuilderWithDefaultHeaderSettings() {
         SecurityConfiguration config = SecurityConfiguration.builder().build();
 
-        assertEquals(50, config.maxHeaderCount());
         assertEquals(128, config.maxHeaderNameLength());
         assertEquals(2048, config.maxHeaderValueLength());
-        assertNull(config.allowedHeaderNames());
-        assertTrue(config.blockedHeaderNames().isEmpty());
     }
 
     @Test
     void shouldCreateBuilderWithDefaultCookieSettings() {
         SecurityConfiguration config = SecurityConfiguration.builder().build();
 
-        assertEquals(20, config.maxCookieCount());
         assertEquals(128, config.maxCookieNameLength());
         assertEquals(2048, config.maxCookieValueLength());
-        assertFalse(config.requireSecureCookies());
-        assertFalse(config.requireHttpOnlyCookies());
     }
 
     @Test
     void shouldCreateBuilderWithDefaultBodySettings() {
         SecurityConfiguration config = SecurityConfiguration.builder().build();
 
-        assertEquals(5 * 1024 * 1024, config.maxBodySize());
-        assertNull(config.allowedContentTypes());
-        assertTrue(config.blockedContentTypes().isEmpty());
+        assertEquals(5L * 1024 * 1024, config.maxBodySize());
     }
 
     @Test
@@ -91,346 +79,105 @@ class SecurityConfigurationBuilderTest {
 
         assertFalse(config.caseSensitiveComparison());
         assertFalse(config.failOnSuspiciousPatterns());
-        assertTrue(config.logSecurityViolations());
     }
 
     @Test
     void shouldSetPathSecuritySettings() {
         SecurityConfiguration config = SecurityConfiguration.builder()
-                .maxPathLength(2048)
-                .allowPathTraversal(true)
+                .maxPathLength(1024)
                 .allowDoubleEncoding(true)
                 .build();
 
-        assertEquals(2048, config.maxPathLength());
-        assertTrue(config.allowPathTraversal());
-        assertTrue(config.allowDoubleEncoding());
-    }
-
-    @Test
-    void shouldSetPathSecurityInOneCall() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .pathSecurity(1024, true)
-                .build();
-
         assertEquals(1024, config.maxPathLength());
-        assertTrue(config.allowPathTraversal());
+        assertTrue(config.allowDoubleEncoding());
     }
 
     @Test
     @SuppressWarnings("java:S5778")
     void shouldValidatePathLengthPositive() {
-        var builder1 = SecurityConfiguration.builder();
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                builder1.maxPathLength(0));
-        assertTrue(thrown.getMessage().contains("maxPathLength must be positive"));
+        var builder = SecurityConfiguration.builder();
 
-        var builder2 = SecurityConfiguration.builder();
-        IllegalArgumentException thrown2 = assertThrows(IllegalArgumentException.class, () ->
-                builder2.maxPathLength(-1));
-        assertTrue(thrown2.getMessage().contains("maxPathLength must be positive"));
+        assertThrows(IllegalArgumentException.class, () -> builder.maxPathLength(0));
+        assertThrows(IllegalArgumentException.class, () -> builder.maxPathLength(-1));
     }
 
     @Test
     void shouldSetParameterSecuritySettings() {
         SecurityConfiguration config = SecurityConfiguration.builder()
-                .maxParameterCount(50)
                 .maxParameterNameLength(64)
-                .maxParameterValueLength(1024)
+                .maxParameterValueLength(512)
                 .build();
 
-        assertEquals(50, config.maxParameterCount());
         assertEquals(64, config.maxParameterNameLength());
-        assertEquals(1024, config.maxParameterValueLength());
-    }
-
-    @Test
-    void shouldSetParameterSecurityInOneCall() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .parameterSecurity(30, 32, 512)
-                .build();
-
-        assertEquals(30, config.maxParameterCount());
-        assertEquals(32, config.maxParameterNameLength());
         assertEquals(512, config.maxParameterValueLength());
     }
 
     @Test
     @SuppressWarnings("java:S5778")
     void shouldValidateParameterConstraints() {
-        // Parameter count can be 0
-        SecurityConfiguration.builder().maxParameterCount(0);
+        var builder = SecurityConfiguration.builder();
 
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxParameterCount(-1));
-        assertTrue(thrown.getMessage().contains("maxParameterCount must be non-negative"));
-
-        IllegalArgumentException thrown2 = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxParameterNameLength(0));
-        assertTrue(thrown2.getMessage().contains("maxParameterNameLength must be positive"));
-
-        IllegalArgumentException thrown3 = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxParameterValueLength(0));
-        assertTrue(thrown3.getMessage().contains("maxParameterValueLength must be positive"));
+        assertThrows(IllegalArgumentException.class, () -> builder.maxParameterNameLength(0));
+        assertThrows(IllegalArgumentException.class, () -> builder.maxParameterValueLength(0));
     }
 
     @Test
     void shouldSetHeaderSecuritySettings() {
         SecurityConfiguration config = SecurityConfiguration.builder()
-                .maxHeaderCount(30)
                 .maxHeaderNameLength(64)
                 .maxHeaderValueLength(1024)
                 .build();
 
-        assertEquals(30, config.maxHeaderCount());
         assertEquals(64, config.maxHeaderNameLength());
         assertEquals(1024, config.maxHeaderValueLength());
     }
 
     @Test
-    void shouldSetHeaderSecurityInOneCall() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .headerSecurity(25, 32, 512)
-                .build();
-
-        assertEquals(25, config.maxHeaderCount());
-        assertEquals(32, config.maxHeaderNameLength());
-        assertEquals(512, config.maxHeaderValueLength());
-    }
-
-    @Test
-    void shouldManageAllowedHeaderNames() {
-        SecurityConfigurationBuilder builder = SecurityConfiguration.builder();
-
-        SecurityConfiguration config = builder
-                .addAllowedHeaderName("Authorization")
-                .addAllowedHeaderName("Content-Type")
-                .build();
-
-        assertNotNull(config.allowedHeaderNames());
-        var allowedHeaders = config.allowedHeaderNames();
-        assertNotNull(allowedHeaders);
-        assertEquals(2, allowedHeaders.size());
-        assertTrue(allowedHeaders.contains("Authorization"));
-        assertTrue(allowedHeaders.contains("Content-Type"));
-    }
-
-    @Test
-    void shouldSetAllowedHeaderNamesAsSet() {
-        Set<String> headers = Set.of("X-Custom", "Authorization");
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .allowedHeaderNames(headers)
-                .build();
-
-        var allowedHeaders = config.allowedHeaderNames();
-        assertNotNull(allowedHeaders);
-        assertEquals(2, allowedHeaders.size());
-        assertTrue(allowedHeaders.contains("X-Custom"));
-        assertTrue(allowedHeaders.contains("Authorization"));
-    }
-
-    @Test
-    void shouldManageBlockedHeaderNames() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .addBlockedHeaderName("X-Debug")
-                .addBlockedHeaderName("X-Internal")
-                .build();
-
-        assertEquals(2, config.blockedHeaderNames().size());
-        assertTrue(config.blockedHeaderNames().contains("X-Debug"));
-        assertTrue(config.blockedHeaderNames().contains("X-Internal"));
-    }
-
-    @Test
-    void shouldSetBlockedHeaderNamesAsSet() {
-        Set<String> headers = Set.of("X-Test", "X-Debug");
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .blockedHeaderNames(headers)
-                .build();
-
-        assertEquals(2, config.blockedHeaderNames().size());
-        assertTrue(config.blockedHeaderNames().contains("X-Test"));
-        assertTrue(config.blockedHeaderNames().contains("X-Debug"));
-    }
-
-    @Test
     @SuppressWarnings("java:S5778")
     void shouldValidateHeaderConstraints() {
-        // Header count can be 0
-        SecurityConfiguration.builder().maxHeaderCount(0);
+        var builder = SecurityConfiguration.builder();
 
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxHeaderCount(-1));
-        assertTrue(thrown.getMessage().contains("maxHeaderCount must be non-negative"));
-
-        IllegalArgumentException thrown2 = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxHeaderNameLength(0));
-        assertTrue(thrown2.getMessage().contains("maxHeaderNameLength must be positive"));
-
-        IllegalArgumentException thrown3 = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxHeaderValueLength(0));
-        assertTrue(thrown3.getMessage().contains("maxHeaderValueLength must be positive"));
-    }
-
-    @Test
-    @SuppressWarnings("java:S5778")
-    void shouldRejectNullHeaderNames() {
-        assertThrows(NullPointerException.class, () ->
-                SecurityConfiguration.builder().addAllowedHeaderName(null));
-
-        assertThrows(NullPointerException.class, () ->
-                SecurityConfiguration.builder().addBlockedHeaderName(null));
-
-        assertThrows(NullPointerException.class, () ->
-                SecurityConfiguration.builder().blockedHeaderNames(null));
+        assertThrows(IllegalArgumentException.class, () -> builder.maxHeaderNameLength(0));
+        assertThrows(IllegalArgumentException.class, () -> builder.maxHeaderValueLength(-5));
     }
 
     @Test
     void shouldSetCookieSecuritySettings() {
         SecurityConfiguration config = SecurityConfiguration.builder()
-                .maxCookieCount(15)
                 .maxCookieNameLength(64)
-                .maxCookieValueLength(1024)
-                .requireSecureCookies(true)
-                .requireHttpOnlyCookies(true)
+                .maxCookieValueLength(512)
                 .build();
 
-        assertEquals(15, config.maxCookieCount());
         assertEquals(64, config.maxCookieNameLength());
-        assertEquals(1024, config.maxCookieValueLength());
-        assertTrue(config.requireSecureCookies());
-        assertTrue(config.requireHttpOnlyCookies());
-    }
-
-    @Test
-    void shouldSetCookieSecurityInOneCall() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .cookieSecurity(true, true, 10, 32, 512)
-                .build();
-
-        assertTrue(config.requireSecureCookies());
-        assertTrue(config.requireHttpOnlyCookies());
-        assertEquals(10, config.maxCookieCount());
-        assertEquals(32, config.maxCookieNameLength());
         assertEquals(512, config.maxCookieValueLength());
     }
 
     @Test
     @SuppressWarnings("java:S5778")
     void shouldValidateCookieConstraints() {
-        // Cookie count can be 0
-        SecurityConfiguration.builder().maxCookieCount(0);
+        var builder = SecurityConfiguration.builder();
 
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxCookieCount(-1));
-        assertTrue(thrown.getMessage().contains("maxCookieCount must be non-negative"));
-
-        IllegalArgumentException thrown2 = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxCookieNameLength(0));
-        assertTrue(thrown2.getMessage().contains("maxCookieNameLength must be positive"));
-
-        IllegalArgumentException thrown3 = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxCookieValueLength(0));
-        assertTrue(thrown3.getMessage().contains("maxCookieValueLength must be positive"));
+        assertThrows(IllegalArgumentException.class, () -> builder.maxCookieNameLength(0));
+        assertThrows(IllegalArgumentException.class, () -> builder.maxCookieValueLength(0));
     }
 
     @Test
     void shouldSetBodySecuritySettings() {
         SecurityConfiguration config = SecurityConfiguration.builder()
-                .maxBodySize(2 * 1024 * 1024)
-                .build();
-
-        assertEquals(2 * 1024 * 1024, config.maxBodySize());
-    }
-
-    @Test
-    void shouldManageAllowedContentTypes() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .addAllowedContentType("application/json")
-                .addAllowedContentType("text/plain")
-                .build();
-
-        var allowedTypes = config.allowedContentTypes();
-        assertNotNull(allowedTypes);
-        assertEquals(2, allowedTypes.size());
-        assertTrue(allowedTypes.contains("application/json"));
-        assertTrue(allowedTypes.contains("text/plain"));
-    }
-
-    @Test
-    void shouldSetAllowedContentTypesAsSet() {
-        Set<String> contentTypes = Set.of("application/xml", "text/html");
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .allowedContentTypes(contentTypes)
-                .build();
-
-        var allowedTypes = config.allowedContentTypes();
-        assertNotNull(allowedTypes);
-        assertEquals(2, allowedTypes.size());
-        assertTrue(allowedTypes.contains("application/xml"));
-        assertTrue(allowedTypes.contains("text/html"));
-    }
-
-    @Test
-    void shouldManageBlockedContentTypes() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .addBlockedContentType("application/x-executable")
-                .addBlockedContentType("text/x-script")
-                .build();
-
-        assertEquals(2, config.blockedContentTypes().size());
-        assertTrue(config.blockedContentTypes().contains("application/x-executable"));
-        assertTrue(config.blockedContentTypes().contains("text/x-script"));
-    }
-
-    @Test
-    void shouldSetBlockedContentTypesAsSet() {
-        Set<String> contentTypes = Set.of("application/octet-stream", "text/x-shellscript");
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .blockedContentTypes(contentTypes)
-                .build();
-
-        assertEquals(2, config.blockedContentTypes().size());
-        assertTrue(config.blockedContentTypes().contains("application/octet-stream"));
-        assertTrue(config.blockedContentTypes().contains("text/x-shellscript"));
-    }
-
-    @Test
-    void shouldSetBodySecurityInOneCall() {
-        Set<String> allowedTypes = Set.of("application/json", "text/plain");
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .bodySecurity(1024 * 1024, allowedTypes)
+                .maxBodySize(1024 * 1024)
                 .build();
 
         assertEquals(1024 * 1024, config.maxBodySize());
-        var configAllowedTypes = config.allowedContentTypes();
-        assertNotNull(configAllowedTypes);
-        assertEquals(2, configAllowedTypes.size());
-        assertTrue(configAllowedTypes.contains("application/json"));
     }
 
     @Test
     @SuppressWarnings("java:S5778")
     void shouldValidateBodySizeNonNegative() {
-        // Body size can be 0
-        SecurityConfiguration.builder().maxBodySize(0);
+        var builder = SecurityConfiguration.builder();
 
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxBodySize(-1));
-        assertTrue(thrown.getMessage().contains("maxBodySize must be non-negative"));
-    }
-
-    @Test
-    @SuppressWarnings("java:S5778")
-    void shouldRejectNullContentTypes() {
-        assertThrows(NullPointerException.class, () ->
-                SecurityConfiguration.builder().addAllowedContentType(null));
-
-        assertThrows(NullPointerException.class, () ->
-                SecurityConfiguration.builder().addBlockedContentType(null));
-
-        assertThrows(NullPointerException.class, () ->
-                SecurityConfiguration.builder().blockedContentTypes(null));
+        assertThrows(IllegalArgumentException.class, () -> builder.maxBodySize(-1));
+        // Zero is allowed (blocks all bodies)
+        assertDoesNotThrow(() -> builder.maxBodySize(0));
     }
 
     @Test
@@ -451,13 +198,13 @@ class SecurityConfigurationBuilderTest {
     @Test
     void shouldSetEncodingSecurityInOneCall() {
         SecurityConfiguration config = SecurityConfiguration.builder()
-                .encoding(true, false, true, false)
+                .encoding(true, true, false, true)
                 .build();
 
         assertTrue(config.allowNullBytes());
-        assertFalse(config.allowControlCharacters());
-        assertTrue(config.allowExtendedAscii());
-        assertFalse(config.normalizeUnicode());
+        assertTrue(config.allowControlCharacters());
+        assertFalse(config.allowExtendedAscii());
+        assertTrue(config.normalizeUnicode());
     }
 
     @Test
@@ -465,113 +212,55 @@ class SecurityConfigurationBuilderTest {
         SecurityConfiguration config = SecurityConfiguration.builder()
                 .caseSensitiveComparison(true)
                 .failOnSuspiciousPatterns(true)
-                .logSecurityViolations(false)
                 .build();
 
         assertTrue(config.caseSensitiveComparison());
         assertTrue(config.failOnSuspiciousPatterns());
-        assertFalse(config.logSecurityViolations());
-    }
-
-    @Test
-    void shouldSetPoliciesInOneCall() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .policies(true, false, true)
-                .build();
-
-        assertTrue(config.caseSensitiveComparison());
-        assertFalse(config.failOnSuspiciousPatterns());
-        assertTrue(config.logSecurityViolations());
     }
 
     @Test
     void shouldSupportMethodChaining() {
         SecurityConfiguration config = SecurityConfiguration.builder()
-                .maxPathLength(1024)
-                .allowPathTraversal(false)
-                .maxParameterCount(50)
-                .requireSecureCookies(true)
+                .maxPathLength(2048)
+                .allowDoubleEncoding(false)
+                .maxParameterNameLength(64)
+                .maxParameterValueLength(1024)
+                .maxHeaderNameLength(64)
+                .maxHeaderValueLength(2048)
+                .maxCookieNameLength(64)
+                .maxCookieValueLength(1024)
+                .maxBodySize(2L * 1024 * 1024)
                 .allowNullBytes(false)
+                .allowControlCharacters(false)
+                .allowExtendedAscii(false)
+                .normalizeUnicode(true)
                 .caseSensitiveComparison(true)
+                .failOnSuspiciousPatterns(true)
                 .build();
 
-        assertEquals(1024, config.maxPathLength());
-        assertFalse(config.allowPathTraversal());
-        assertEquals(50, config.maxParameterCount());
-        assertTrue(config.requireSecureCookies());
-        assertFalse(config.allowNullBytes());
-        assertTrue(config.caseSensitiveComparison());
-    }
-
-    @Test
-    void shouldCreateComplexConfiguration() {
-        Set<String> allowedHeaders = Set.of("Authorization", "Content-Type", "X-Custom");
-        Set<String> blockedHeaders = Set.of("X-Debug", "X-Internal", "X-Admin");
-        Set<String> allowedContentTypes = Set.of("application/json", "text/plain", "text/html");
-        Set<String> blockedContentTypes = Set.of("application/x-executable", "text/x-script");
-
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .pathSecurity(2048, false)
-                .parameterSecurity(75, 100, 1500)
-                .headerSecurity(40, 100, 1500)
-                .allowedHeaderNames(allowedHeaders)
-                .blockedHeaderNames(blockedHeaders)
-                .cookieSecurity(true, true, 15, 100, 1500)
-                .bodySecurity(3 * 1024 * 1024, allowedContentTypes)
-                .blockedContentTypes(blockedContentTypes)
-                .encoding(false, false, true, true)
-                .policies(false, true, true)
-                .build();
-
-        // Verify all settings
         assertEquals(2048, config.maxPathLength());
-        assertFalse(config.allowPathTraversal());
-        assertEquals(75, config.maxParameterCount());
-        assertEquals(100, config.maxParameterNameLength());
-        assertEquals(1500, config.maxParameterValueLength());
-        assertEquals(40, config.maxHeaderCount());
-        var configAllowedHeaders = config.allowedHeaderNames();
-        assertNotNull(configAllowedHeaders);
-        assertEquals(3, configAllowedHeaders.size());
-        assertEquals(3, config.blockedHeaderNames().size());
-        assertTrue(config.requireSecureCookies());
-        assertTrue(config.requireHttpOnlyCookies());
-        assertEquals(3 * 1024 * 1024, config.maxBodySize());
-        var configAllowedTypes = config.allowedContentTypes();
-        assertNotNull(configAllowedTypes);
-        assertEquals(3, configAllowedTypes.size());
-        assertEquals(2, config.blockedContentTypes().size());
-        assertFalse(config.allowNullBytes());
-        assertTrue(config.allowExtendedAscii());
+        assertEquals(64, config.maxParameterNameLength());
+        assertEquals(1024, config.maxParameterValueLength());
+        assertEquals(64, config.maxHeaderNameLength());
+        assertEquals(2048, config.maxHeaderValueLength());
+        assertEquals(64, config.maxCookieNameLength());
+        assertEquals(1024, config.maxCookieValueLength());
+        assertEquals(2L * 1024 * 1024, config.maxBodySize());
+        assertFalse(config.allowExtendedAscii());
         assertTrue(config.normalizeUnicode());
-        assertFalse(config.caseSensitiveComparison());
+        assertTrue(config.caseSensitiveComparison());
         assertTrue(config.failOnSuspiciousPatterns());
-        assertTrue(config.logSecurityViolations());
+        assertTrue(config.isStrict());
     }
 
     @Test
-    void shouldHandleNullAllowedSets() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .allowedHeaderNames(null)
-                .allowedContentTypes(null)
-                .build();
+    void builtConfigurationsShouldBeIndependent() {
+        var builder = SecurityConfiguration.builder().maxPathLength(1000);
+        SecurityConfiguration first = builder.build();
+        builder.maxPathLength(2000);
+        SecurityConfiguration second = builder.build();
 
-        assertNull(config.allowedHeaderNames());
-        assertNull(config.allowedContentTypes());
-    }
-
-    @Test
-    void shouldPreventModificationOfBuilderSetsAfterBuilding() {
-        SecurityConfigurationBuilder builder = SecurityConfiguration.builder();
-        builder.addBlockedHeaderName("X-Test");
-
-        SecurityConfiguration config = builder.build();
-
-        // Adding more items to builder shouldn't affect already built configuration
-        builder.addBlockedHeaderName("X-Modified");
-
-        assertEquals(1, config.blockedHeaderNames().size());
-        assertTrue(config.blockedHeaderNames().contains("X-Test"));
-        assertFalse(config.blockedHeaderNames().contains("X-Modified"));
+        assertEquals(1000, first.maxPathLength());
+        assertEquals(2000, second.maxPathLength());
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
@@ -208,31 +208,26 @@ class SecurityConfigurationTest {
 
     @Test
     void recordConstructorShouldValidateConstraints() {
-        // Direct record construction must enforce the same constraints as the builder
+        // Direct record construction must enforce the same constraints as the builder;
+        // each call violates exactly one guard (path, param name/value, header
+        // name/value, cookie name/value lengths, body size)
+        assertConstructorRejects(0, 128, 2048, 128, 2048, 128, 2048, 1024);
+        assertConstructorRejects(4096, 0, 2048, 128, 2048, 128, 2048, 1024);
+        assertConstructorRejects(4096, 128, 0, 128, 2048, 128, 2048, 1024);
+        assertConstructorRejects(4096, 128, 2048, 0, 2048, 128, 2048, 1024);
+        assertConstructorRejects(4096, 128, 2048, 128, 0, 128, 2048, 1024);
+        assertConstructorRejects(4096, 128, 2048, 128, 2048, 0, 2048, 1024);
+        assertConstructorRejects(4096, 128, 2048, 128, 2048, 128, 0, 1024);
+        assertConstructorRejects(4096, 128, 2048, 128, 2048, 128, 2048, -1);
+    }
+
+    @SuppressWarnings("java:S107")
+    private static void assertConstructorRejects(int pathLength, int paramNameLength, int paramValueLength,
+            int headerNameLength, int headerValueLength, int cookieNameLength, int cookieValueLength, long bodySize) {
         assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
-                0, false, 128, 2048, 128, 2048, 128, 2048, 1024,
-                false, false, true, false, false, false));
-        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
-                4096, false, 128, 2048, 128, 2048, 128, 2048, -1,
-                false, false, true, false, false, false));
-        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
-                4096, false, 0, 2048, 128, 2048, 128, 2048, 1024,
-                false, false, true, false, false, false));
-        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
-                4096, false, 128, 0, 128, 2048, 128, 2048, 1024,
-                false, false, true, false, false, false));
-        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
-                4096, false, 128, 2048, 0, 2048, 128, 2048, 1024,
-                false, false, true, false, false, false));
-        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
-                4096, false, 128, 2048, 128, 0, 128, 2048, 1024,
-                false, false, true, false, false, false));
-        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
-                4096, false, 128, 2048, 128, 2048, 0, 2048, 1024,
-                false, false, true, false, false, false));
-        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
-                4096, false, 128, 2048, 128, 2048, 128, 0, 1024,
-                false, false, true, false, false, false));
+                pathLength, false, paramNameLength, paramValueLength,
+                headerNameLength, headerValueLength, cookieNameLength, cookieValueLength,
+                bodySize, false, false, true, false, false, false));
     }
 
     @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
@@ -22,9 +22,6 @@ import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -37,15 +34,13 @@ class SecurityConfigurationTest {
     void shouldCreateConfigurationWithBuilder() {
         SecurityConfiguration config = SecurityConfiguration.builder()
                 .maxPathLength(2048)
-                .allowPathTraversal(false)
-                .maxParameterCount(50)
-                .requireSecureCookies(true)
+                .maxParameterValueLength(512)
+                .normalizeUnicode(true)
                 .build();
 
         assertEquals(2048, config.maxPathLength());
-        assertFalse(config.allowPathTraversal());
-        assertEquals(50, config.maxParameterCount());
-        assertTrue(config.requireSecureCookies());
+        assertEquals(512, config.maxParameterValueLength());
+        assertTrue(config.normalizeUnicode());
     }
 
     @Test
@@ -53,15 +48,13 @@ class SecurityConfigurationTest {
         SecurityConfiguration config = SecurityConfiguration.strict();
 
         assertEquals(1024, config.maxPathLength());
-        assertFalse(config.allowPathTraversal());
         assertFalse(config.allowDoubleEncoding());
-        assertEquals(50, config.maxParameterCount());
-        assertTrue(config.requireSecureCookies());
-        assertTrue(config.requireHttpOnlyCookies());
         assertFalse(config.allowNullBytes());
         assertFalse(config.allowControlCharacters());
+        assertFalse(config.allowExtendedAscii());
+        assertTrue(config.normalizeUnicode());
+        assertTrue(config.caseSensitiveComparison());
         assertTrue(config.failOnSuspiciousPatterns());
-        assertTrue(config.logSecurityViolations());
     }
 
     @Test
@@ -69,15 +62,12 @@ class SecurityConfigurationTest {
         SecurityConfiguration config = SecurityConfiguration.lenient();
 
         assertEquals(8192, config.maxPathLength());
-        assertTrue(config.allowPathTraversal()); // WARNING: Security risk
         assertTrue(config.allowDoubleEncoding());
-        assertEquals(1000, config.maxParameterCount());
-        assertFalse(config.requireSecureCookies());
-        assertFalse(config.requireHttpOnlyCookies());
-        assertTrue(config.allowNullBytes()); // Lenient allows null bytes
+        assertFalse(config.allowNullBytes()); // Null bytes are never allowed, even in lenient mode
         assertTrue(config.allowControlCharacters());
+        assertTrue(config.allowExtendedAscii());
+        assertFalse(config.normalizeUnicode());
         assertFalse(config.failOnSuspiciousPatterns());
-        assertFalse(config.logSecurityViolations()); // Lenient doesn't log violations
     }
 
     @Test
@@ -85,15 +75,25 @@ class SecurityConfigurationTest {
         SecurityConfiguration config = SecurityConfiguration.defaults();
 
         assertEquals(4096, config.maxPathLength());
-        assertFalse(config.allowPathTraversal());
         assertFalse(config.allowDoubleEncoding());
-        assertEquals(100, config.maxParameterCount());
-        assertFalse(config.requireSecureCookies());
-        assertFalse(config.requireHttpOnlyCookies());
         assertFalse(config.allowNullBytes());
         assertFalse(config.allowControlCharacters());
+        assertTrue(config.allowExtendedAscii());
         assertFalse(config.failOnSuspiciousPatterns());
-        assertTrue(config.logSecurityViolations());
+    }
+
+    @Test
+    void presetFactoriesShouldDelegateToSecurityDefaults() {
+        // Single source of truth: factory methods and SecurityDefaults constants
+        // must be identical - they were divergent before 1.5
+        assertSame(SecurityDefaults.STRICT_CONFIGURATION, SecurityConfiguration.strict());
+        assertSame(SecurityDefaults.DEFAULT_CONFIGURATION, SecurityConfiguration.defaults());
+        assertSame(SecurityDefaults.LENIENT_CONFIGURATION, SecurityConfiguration.lenient());
+    }
+
+    @Test
+    void defaultsShouldEqualPlainBuilderResult() {
+        assertEquals(SecurityConfiguration.builder().build(), SecurityConfiguration.defaults());
     }
 
     @ParameterizedTest
@@ -119,23 +119,6 @@ class SecurityConfigurationTest {
         public Class<Integer> getType() {
             return Integer.class;
         }
-    }
-
-    @Test
-    void shouldAllowZeroParameterCount() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .maxParameterCount(0)
-                .build();
-        assertEquals(0, config.maxParameterCount());
-    }
-
-    @ParameterizedTest
-    @TypeGeneratorSource(value = NegativeIntegerGenerator.class, count = 5)
-    @SuppressWarnings("java:S5778")
-    void shouldValidateNonNegativeParameterCount(Integer negativeValue) {
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxParameterCount(negativeValue).build());
-        assertTrue(thrown.getMessage().contains("maxParameterCount must be non-negative"));
     }
 
     static class NegativeIntegerGenerator implements TypedGenerator<Integer> {
@@ -170,21 +153,6 @@ class SecurityConfigurationTest {
         assertTrue(thrown.getMessage().contains("maxParameterValueLength must be positive"));
     }
 
-    @Test
-    void shouldAllowZeroHeaderCount() {
-        SecurityConfiguration config = SecurityConfiguration.builder().maxHeaderCount(0).build();
-        assertEquals(0, config.maxHeaderCount());
-    }
-
-    @ParameterizedTest
-    @TypeGeneratorSource(value = NegativeIntegerGenerator.class, count = 3)
-    @SuppressWarnings("java:S5778")
-    void shouldValidateNonNegativeHeaderCount(Integer negativeValue) {
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxHeaderCount(negativeValue).build());
-        assertTrue(thrown.getMessage().contains("maxHeaderCount must be non-negative"));
-    }
-
     @ParameterizedTest
     @TypeGeneratorSource(value = InvalidPositiveIntegerGenerator.class, count = 3)
     @SuppressWarnings("java:S5778")
@@ -201,21 +169,6 @@ class SecurityConfigurationTest {
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
                 SecurityConfiguration.builder().maxHeaderValueLength(invalidValue).build());
         assertTrue(thrown.getMessage().contains("maxHeaderValueLength must be positive"));
-    }
-
-    @Test
-    void shouldAllowZeroCookieCount() {
-        SecurityConfiguration config = SecurityConfiguration.builder().maxCookieCount(0).build();
-        assertEquals(0, config.maxCookieCount());
-    }
-
-    @ParameterizedTest
-    @TypeGeneratorSource(value = NegativeIntegerGenerator.class, count = 3)
-    @SuppressWarnings("java:S5778")
-    void shouldValidateNonNegativeCookieCount(Integer negativeValue) {
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxCookieCount(negativeValue).build());
-        assertTrue(thrown.getMessage().contains("maxCookieCount must be non-negative"));
     }
 
     @ParameterizedTest
@@ -254,255 +207,63 @@ class SecurityConfigurationTest {
     }
 
     @Test
-    void shouldHandleNullAllowedHeaderNames() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .allowedHeaderNames(null)
-                .build();
-
-        assertNull(config.allowedHeaderNames());
-    }
-
-    @Test
-    void shouldMakeImmutableCopiesOfSets() {
-        Set<String> mutableHeaders = new HashSet<>();
-        mutableHeaders.add("X-Test");
-
-        Set<String> mutableContentTypes = new HashSet<>();
-        mutableContentTypes.add("text/test");
-
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .blockedHeaderNames(mutableHeaders)
-                .blockedContentTypes(mutableContentTypes)
-                .build();
-
-        // Modify original sets
-        mutableHeaders.add("X-Modified");
-        mutableContentTypes.add("text/modified");
-
-        // Configuration should be unaffected
-        assertEquals(1, config.blockedHeaderNames().size());
-        assertTrue(config.blockedHeaderNames().contains("X-Test"));
-        assertFalse(config.blockedHeaderNames().contains("X-Modified"));
-
-        assertEquals(1, config.blockedContentTypes().size());
-        assertTrue(config.blockedContentTypes().contains("text/test"));
-        assertFalse(config.blockedContentTypes().contains("text/modified"));
-    }
-
-    @Test
-    void shouldCheckIfHeaderIsAllowed() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .allowedHeaderNames(Set.of("X-Allowed", "Authorization"))
-                .blockedHeaderNames(Set.of("X-Blocked", "X-Debug"))
-                .build();
-
-        assertTrue(config.isHeaderAllowed("X-Allowed"));
-        assertTrue(config.isHeaderAllowed("Authorization"));
-        assertFalse(config.isHeaderAllowed("X-Blocked"));
-        assertFalse(config.isHeaderAllowed("X-Debug"));
-        assertFalse(config.isHeaderAllowed("X-Other")); // Not in allow list
-        assertFalse(config.isHeaderAllowed(null));
-    }
-
-    @Test
-    void shouldCheckHeadersWhenOnlyBlockListExists() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .blockedHeaderNames(Set.of("X-Blocked", "X-Debug"))
-                .build();
-
-        assertTrue(config.isHeaderAllowed("X-Allowed")); // Not blocked, no allow list
-        assertFalse(config.isHeaderAllowed("X-Blocked"));
-        assertFalse(config.isHeaderAllowed("X-Debug"));
-        assertTrue(config.isHeaderAllowed("Authorization")); // Not blocked
-    }
-
-    @Test
-    void shouldCheckHeadersCaseInsensitively() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .allowedHeaderNames(Set.of("X-ALLOWED"))
-                .blockedHeaderNames(Set.of("X-BLOCKED"))
-                .caseSensitiveComparison(false)
-                .build();
-
-        assertTrue(config.isHeaderAllowed("x-allowed"));
-        assertTrue(config.isHeaderAllowed("X-allowed"));
-        assertFalse(config.isHeaderAllowed("x-blocked"));
-        assertFalse(config.isHeaderAllowed("X-blocked"));
-    }
-
-    @Test
-    void shouldCheckHeadersCaseSensitively() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .blockedHeaderNames(Set.of("X-Blocked"))
-                .caseSensitiveComparison(true)
-                .build();
-
-        assertTrue(config.isHeaderAllowed("X-Allowed")); // Not blocked, no allow list
-        assertTrue(config.isHeaderAllowed("x-allowed")); // Not blocked, no allow list
-        assertFalse(config.isHeaderAllowed("X-Blocked")); // Exact match blocked
-        assertTrue(config.isHeaderAllowed("x-blocked")); // Wrong case, so allowed
-    }
-
-    @Test
-    void shouldCheckIfContentTypeIsAllowed() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .allowedContentTypes(Set.of("application/json", "text/plain"))
-                .blockedContentTypes(Set.of("application/x-executable", "text/x-script"))
-                .build();
-
-        assertTrue(config.isContentTypeAllowed("application/json"));
-        assertTrue(config.isContentTypeAllowed("text/plain"));
-        assertFalse(config.isContentTypeAllowed("application/x-executable"));
-        assertFalse(config.isContentTypeAllowed("text/x-script"));
-        assertFalse(config.isContentTypeAllowed("text/html")); // Not in allow list
-        assertFalse(config.isContentTypeAllowed(null));
-    }
-
-    @Test
-    void shouldCheckContentTypeWhenOnlyBlockListExists() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .blockedContentTypes(Set.of("application/x-executable"))
-                .build();
-
-        assertTrue(config.isContentTypeAllowed("application/json")); // Not blocked, no allow list
-        assertFalse(config.isContentTypeAllowed("application/x-executable"));
-        assertTrue(config.isContentTypeAllowed("text/plain")); // Not blocked
+    void recordConstructorShouldValidateConstraints() {
+        // Direct record construction must enforce the same constraints as the builder
+        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
+                0, false, 128, 2048, 128, 2048, 128, 2048, 1024,
+                false, false, true, false, false, false));
+        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
+                4096, false, 128, 2048, 128, 2048, 128, 2048, -1,
+                false, false, true, false, false, false));
     }
 
     @Test
     void shouldDetectStrictConfiguration() {
         SecurityConfiguration strict = SecurityConfiguration.strict();
         assertTrue(strict.isStrict());
-
-        SecurityConfiguration lenient = SecurityConfiguration.lenient();
-        assertFalse(lenient.isStrict());
-
-        SecurityConfiguration defaults = SecurityConfiguration.defaults();
-        assertFalse(defaults.isStrict());
+        assertFalse(strict.isLenient());
     }
 
     @Test
     void shouldDetectLenientConfiguration() {
         SecurityConfiguration lenient = SecurityConfiguration.lenient();
         assertTrue(lenient.isLenient());
-
-        SecurityConfiguration strict = SecurityConfiguration.strict();
-        assertFalse(strict.isLenient());
-
-        SecurityConfiguration defaults = SecurityConfiguration.defaults();
-        assertFalse(defaults.isLenient()); // Default is balanced
+        assertFalse(lenient.isStrict());
     }
 
-    // Note: with* methods are no longer available after converting from record to class
-    // The class is now fully immutable and configurations must be created via the builder
+    @Test
+    void defaultConfigurationShouldBeNeitherStrictNorLenient() {
+        SecurityConfiguration defaults = SecurityConfiguration.defaults();
+        assertFalse(defaults.isStrict());
+        assertFalse(defaults.isLenient());
+    }
 
     @Test
     void shouldSupportEquality() {
         SecurityConfiguration config1 = SecurityConfiguration.builder()
                 .maxPathLength(2048)
-                .allowPathTraversal(false)
+                .normalizeUnicode(true)
                 .build();
-
         SecurityConfiguration config2 = SecurityConfiguration.builder()
                 .maxPathLength(2048)
-                .allowPathTraversal(false)
+                .normalizeUnicode(true)
                 .build();
-
-        SecurityConfiguration config3 = SecurityConfiguration.builder()
+        SecurityConfiguration different = SecurityConfiguration.builder()
                 .maxPathLength(1024)
-                .allowPathTraversal(false)
+                .normalizeUnicode(true)
                 .build();
 
         assertEquals(config1, config2);
-        assertNotEquals(config1, config3);
         assertEquals(config1.hashCode(), config2.hashCode());
+        assertNotEquals(config1, different);
     }
 
     @Test
     void shouldSupportToString() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .maxPathLength(2048)
-                .allowPathTraversal(false)
-                .requireSecureCookies(true)
-                .build();
+        String result = SecurityConfiguration.defaults().toString();
 
-        String string = config.toString();
-        assertTrue(string.contains("2048"));
-        assertTrue(string.contains("false"));
-        assertTrue(string.contains("true"));
-    }
-
-    @Test
-    void shouldHandleEmptySets() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .allowedHeaderNames(Set.of())
-                .blockedHeaderNames(Set.of())
-                .allowedContentTypes(Set.of())
-                .blockedContentTypes(Set.of())
-                .build();
-
-        assertTrue(config.allowedHeaderNames() != null && config.allowedHeaderNames().isEmpty());
-        assertTrue(config.blockedHeaderNames().isEmpty());
-        assertTrue(config.allowedContentTypes() != null && config.allowedContentTypes().isEmpty());
-        assertTrue(config.blockedContentTypes().isEmpty());
-    }
-
-    @Test
-    void shouldHandleComplexScenarios() {
-        // Configuration with mixed allow/block lists
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .allowedHeaderNames(Set.of("Content-Type", "Authorization", "X-Custom"))
-                .blockedHeaderNames(Set.of("X-Debug", "X-Internal"))
-                .allowedContentTypes(Set.of("application/json", "text/plain"))
-                .blockedContentTypes(Set.of("application/x-executable"))
-                .caseSensitiveComparison(false)
-                .build();
-
-        // Headers
-        assertTrue(config.isHeaderAllowed("content-type")); // Case insensitive
-        assertTrue(config.isHeaderAllowed("AUTHORIZATION"));
-        assertFalse(config.isHeaderAllowed("x-debug")); // Blocked
-        assertFalse(config.isHeaderAllowed("Accept")); // Not in allow list
-
-        // Content types
-        assertTrue(config.isContentTypeAllowed("APPLICATION/JSON")); // Case insensitive
-        assertFalse(config.isContentTypeAllowed("application/x-executable")); // Blocked
-        assertFalse(config.isContentTypeAllowed("text/html")); // Not in allow list
-    }
-
-    @Test
-    @SuppressWarnings("java:S5778")
-    void shouldPreserveImmutabilityOfReturnedSets() {
-        SecurityConfiguration config = SecurityConfiguration.builder()
-                .blockedHeaderNames(Set.of("X-Test"))
-                .build();
-
-        assertThrows(UnsupportedOperationException.class, () ->
-                config.blockedHeaderNames().add("X-Modified"));
-    }
-
-    @Test
-    void lenientConfigurationShouldBeIdentifiedAsLenient() {
-        // Test that lenient().isLenient() returns true
-        SecurityConfiguration lenientConfig = SecurityConfiguration.lenient();
-
-        // Verify the lenient configuration has expected settings
-        assertTrue(lenientConfig.allowPathTraversal(),
-                "Lenient config should allow path traversal");
-        assertTrue(lenientConfig.allowDoubleEncoding(),
-                "Lenient config should allow double encoding");
-        assertTrue(lenientConfig.isLenient(),
-                "SecurityConfiguration.lenient().isLenient() should return true");
-    }
-
-    @Test
-    void strictConfigurationShouldNotBeIdentifiedAsLenient() {
-        // Test that strict().isLenient() returns false
-        SecurityConfiguration strictConfig = SecurityConfiguration.strict();
-
-        assertFalse(strictConfig.allowPathTraversal(),
-                "Strict config should not allow path traversal");
-        assertFalse(strictConfig.isLenient(),
-                "SecurityConfiguration.strict().isLenient() should return false");
+        assertNotNull(result);
+        assertTrue(result.contains("maxPathLength"));
+        assertTrue(result.contains("4096"));
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
@@ -15,19 +15,19 @@
  */
 package de.cuioss.http.security.config;
 
-import de.cuioss.test.generator.Generators;
-import de.cuioss.test.generator.TypedGenerator;
-import de.cuioss.test.generator.junit.EnableGeneratorController;
-import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test for {@link SecurityConfiguration}
  */
-@EnableGeneratorController
 class SecurityConfigurationTest {
 
     @Test
@@ -96,97 +96,40 @@ class SecurityConfigurationTest {
         assertEquals(SecurityConfiguration.builder().build(), SecurityConfiguration.defaults());
     }
 
+    /**
+     * Every length setter rejects non-positive values with a descriptive message.
+     * Covers the builder guards; the record constructor guards are covered by
+     * {@link #recordConstructorShouldValidateConstraints()}.
+     */
     @ParameterizedTest
-    @TypeGeneratorSource(value = InvalidPositiveIntegerGenerator.class, count = 5)
-    @SuppressWarnings("java:S5778")
-    void shouldValidatePositivePathLength(Integer invalidValue) {
+    @MethodSource("lengthSetters")
+    void lengthSettersShouldRejectNonPositiveValues(
+            String property, BiFunction<SecurityConfigurationBuilder, Integer, SecurityConfigurationBuilder> setter) {
         var builder = SecurityConfiguration.builder();
 
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                builder.maxPathLength(invalidValue));
-        assertTrue(thrown.getMessage().contains("maxPathLength must be positive"));
+        IllegalArgumentException zero = assertThrows(IllegalArgumentException.class, () -> setter.apply(builder, 0));
+        assertTrue(zero.getMessage().contains(property + " must be positive"));
+
+        IllegalArgumentException negative = assertThrows(IllegalArgumentException.class, () -> setter.apply(builder, -10));
+        assertTrue(negative.getMessage().contains(property + " must be positive"));
     }
 
-    static class InvalidPositiveIntegerGenerator implements TypedGenerator<Integer> {
-        private final TypedGenerator<Integer> gen = Generators.fixedValues(Integer.class, 0, -1, -100, -999, -1000000);
-
-        @Override
-        public Integer next() {
-            return gen.next();
-        }
-
-        @Override
-        public Class<Integer> getType() {
-            return Integer.class;
-        }
-    }
-
-    static class NegativeIntegerGenerator implements TypedGenerator<Integer> {
-        private final TypedGenerator<Integer> gen = Generators.fixedValues(Integer.class, -1, -10, -100, -999, -1000000);
-
-        @Override
-        public Integer next() {
-            return gen.next();
-        }
-
-        @Override
-        public Class<Integer> getType() {
-            return Integer.class;
-        }
-    }
-
-    @ParameterizedTest
-    @TypeGeneratorSource(value = InvalidPositiveIntegerGenerator.class, count = 3)
-    @SuppressWarnings("java:S5778")
-    void shouldValidatePositiveParameterNameLength(Integer invalidValue) {
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxParameterNameLength(invalidValue).build());
-        assertTrue(thrown.getMessage().contains("maxParameterNameLength must be positive"));
-    }
-
-    @ParameterizedTest
-    @TypeGeneratorSource(value = InvalidPositiveIntegerGenerator.class, count = 3)
-    @SuppressWarnings("java:S5778")
-    void shouldValidatePositiveParameterValueLength(Integer invalidValue) {
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxParameterValueLength(invalidValue).build());
-        assertTrue(thrown.getMessage().contains("maxParameterValueLength must be positive"));
-    }
-
-    @ParameterizedTest
-    @TypeGeneratorSource(value = InvalidPositiveIntegerGenerator.class, count = 3)
-    @SuppressWarnings("java:S5778")
-    void shouldValidatePositiveHeaderNameLength(Integer invalidValue) {
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxHeaderNameLength(invalidValue).build());
-        assertTrue(thrown.getMessage().contains("maxHeaderNameLength must be positive"));
-    }
-
-    @ParameterizedTest
-    @TypeGeneratorSource(value = InvalidPositiveIntegerGenerator.class, count = 3)
-    @SuppressWarnings("java:S5778")
-    void shouldValidatePositiveHeaderValueLength(Integer invalidValue) {
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxHeaderValueLength(invalidValue).build());
-        assertTrue(thrown.getMessage().contains("maxHeaderValueLength must be positive"));
-    }
-
-    @ParameterizedTest
-    @TypeGeneratorSource(value = InvalidPositiveIntegerGenerator.class, count = 3)
-    @SuppressWarnings("java:S5778")
-    void shouldValidatePositiveCookieNameLength(Integer invalidValue) {
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxCookieNameLength(invalidValue).build());
-        assertTrue(thrown.getMessage().contains("maxCookieNameLength must be positive"));
-    }
-
-    @ParameterizedTest
-    @TypeGeneratorSource(value = InvalidPositiveIntegerGenerator.class, count = 3)
-    @SuppressWarnings("java:S5778")
-    void shouldValidatePositiveCookieValueLength(Integer invalidValue) {
-        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxCookieValueLength(invalidValue).build());
-        assertTrue(thrown.getMessage().contains("maxCookieValueLength must be positive"));
+    static Stream<Arguments> lengthSetters() {
+        return Stream.of(
+                Arguments.of("maxPathLength",
+                        (BiFunction<SecurityConfigurationBuilder, Integer, SecurityConfigurationBuilder>) SecurityConfigurationBuilder::maxPathLength),
+                Arguments.of("maxParameterNameLength",
+                        (BiFunction<SecurityConfigurationBuilder, Integer, SecurityConfigurationBuilder>) SecurityConfigurationBuilder::maxParameterNameLength),
+                Arguments.of("maxParameterValueLength",
+                        (BiFunction<SecurityConfigurationBuilder, Integer, SecurityConfigurationBuilder>) SecurityConfigurationBuilder::maxParameterValueLength),
+                Arguments.of("maxHeaderNameLength",
+                        (BiFunction<SecurityConfigurationBuilder, Integer, SecurityConfigurationBuilder>) SecurityConfigurationBuilder::maxHeaderNameLength),
+                Arguments.of("maxHeaderValueLength",
+                        (BiFunction<SecurityConfigurationBuilder, Integer, SecurityConfigurationBuilder>) SecurityConfigurationBuilder::maxHeaderValueLength),
+                Arguments.of("maxCookieNameLength",
+                        (BiFunction<SecurityConfigurationBuilder, Integer, SecurityConfigurationBuilder>) SecurityConfigurationBuilder::maxCookieNameLength),
+                Arguments.of("maxCookieValueLength",
+                        (BiFunction<SecurityConfigurationBuilder, Integer, SecurityConfigurationBuilder>) SecurityConfigurationBuilder::maxCookieValueLength));
     }
 
     @Test
@@ -197,12 +140,11 @@ class SecurityConfigurationTest {
         assertEquals(0, config.maxBodySize());
     }
 
-    @ParameterizedTest
-    @TypeGeneratorSource(value = NegativeIntegerGenerator.class, count = 3)
+    @Test
     @SuppressWarnings("java:S5778")
-    void shouldValidateNonNegativeBodySize(Integer negativeValue) {
+    void shouldValidateNonNegativeBodySize() {
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-                SecurityConfiguration.builder().maxBodySize(negativeValue).build());
+                SecurityConfiguration.builder().maxBodySize(-1).build());
         assertTrue(thrown.getMessage().contains("maxBodySize must be non-negative"));
     }
 
@@ -231,21 +173,6 @@ class SecurityConfigurationTest {
     }
 
     @Test
-    void configurationAllowingNullBytesShouldNotBeLenient() {
-        // Contract: lenient never permits null bytes
-        SecurityConfiguration withNullBytes = SecurityConfiguration.builder()
-                .allowDoubleEncoding(true)
-                .allowNullBytes(true)
-                .allowControlCharacters(true)
-                .allowExtendedAscii(true)
-                .normalizeUnicode(false)
-                .failOnSuspiciousPatterns(false)
-                .build();
-
-        assertFalse(withNullBytes.isLenient());
-    }
-
-    @Test
     void shouldDetectStrictConfiguration() {
         SecurityConfiguration strict = SecurityConfiguration.strict();
         assertTrue(strict.isStrict());
@@ -264,6 +191,42 @@ class SecurityConfigurationTest {
         SecurityConfiguration defaults = SecurityConfiguration.defaults();
         assertFalse(defaults.isStrict());
         assertFalse(defaults.isLenient());
+    }
+
+    @Test
+    void nearStrictVariantsShouldNotBeStrict() {
+        // Each variant flips exactly one of the strict-defining settings
+        assertFalse(strictBuilder().allowDoubleEncoding(true).build().isStrict());
+        assertFalse(strictBuilder().allowNullBytes(true).build().isStrict());
+        assertFalse(strictBuilder().allowControlCharacters(true).build().isStrict());
+        assertFalse(strictBuilder().allowExtendedAscii(true).build().isStrict());
+        assertFalse(strictBuilder().normalizeUnicode(false).build().isStrict());
+        assertFalse(strictBuilder().failOnSuspiciousPatterns(false).build().isStrict());
+    }
+
+    @Test
+    void nearLenientVariantsShouldNotBeLenient() {
+        // Each variant flips exactly one of the lenient-defining settings;
+        // in particular, allowing null bytes must disqualify a config from lenient
+        assertFalse(lenientBuilder().allowDoubleEncoding(false).build().isLenient());
+        assertFalse(lenientBuilder().allowNullBytes(true).build().isLenient());
+        assertFalse(lenientBuilder().allowControlCharacters(false).build().isLenient());
+        assertFalse(lenientBuilder().allowExtendedAscii(false).build().isLenient());
+        assertFalse(lenientBuilder().normalizeUnicode(true).build().isLenient());
+        assertFalse(lenientBuilder().failOnSuspiciousPatterns(true).build().isLenient());
+    }
+
+    private static SecurityConfigurationBuilder strictBuilder() {
+        return SecurityConfiguration.builder()
+                .encoding(false, false, false, true)
+                .failOnSuspiciousPatterns(true);
+    }
+
+    private static SecurityConfigurationBuilder lenientBuilder() {
+        return SecurityConfiguration.builder()
+                .allowDoubleEncoding(true)
+                .encoding(false, true, true, false)
+                .failOnSuspiciousPatterns(false);
     }
 
     @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
@@ -215,6 +215,39 @@ class SecurityConfigurationTest {
         assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
                 4096, false, 128, 2048, 128, 2048, 128, 2048, -1,
                 false, false, true, false, false, false));
+        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
+                4096, false, 0, 2048, 128, 2048, 128, 2048, 1024,
+                false, false, true, false, false, false));
+        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
+                4096, false, 128, 0, 128, 2048, 128, 2048, 1024,
+                false, false, true, false, false, false));
+        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
+                4096, false, 128, 2048, 0, 2048, 128, 2048, 1024,
+                false, false, true, false, false, false));
+        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
+                4096, false, 128, 2048, 128, 0, 128, 2048, 1024,
+                false, false, true, false, false, false));
+        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
+                4096, false, 128, 2048, 128, 2048, 0, 2048, 1024,
+                false, false, true, false, false, false));
+        assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
+                4096, false, 128, 2048, 128, 2048, 128, 0, 1024,
+                false, false, true, false, false, false));
+    }
+
+    @Test
+    void configurationAllowingNullBytesShouldNotBeLenient() {
+        // Contract: lenient never permits null bytes
+        SecurityConfiguration withNullBytes = SecurityConfiguration.builder()
+                .allowDoubleEncoding(true)
+                .allowNullBytes(true)
+                .allowControlCharacters(true)
+                .allowExtendedAscii(true)
+                .normalizeUnicode(false)
+                .failOnSuspiciousPatterns(false)
+                .build();
+
+        assertFalse(withNullBytes.isLenient());
     }
 
     @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java
@@ -230,7 +230,7 @@ class SecurityDefaultsTest {
         assertTrue(SecurityDefaults.STRICT_CONFIGURATION.isStrict());
         assertFalse(SecurityDefaults.DEFAULT_CONFIGURATION.isStrict());
         assertFalse(SecurityDefaults.DEFAULT_CONFIGURATION.isLenient());
-        assertFalse(SecurityDefaults.LENIENT_CONFIGURATION.isLenient()); // Not fully lenient - still blocks path traversal and null bytes
+        assertTrue(SecurityDefaults.LENIENT_CONFIGURATION.isLenient());
     }
 
     @Test
@@ -238,15 +238,18 @@ class SecurityDefaultsTest {
         SecurityConfiguration strict = SecurityDefaults.STRICT_CONFIGURATION;
 
         assertEquals(SecurityDefaults.MAX_PATH_LENGTH_STRICT, strict.maxPathLength());
-        assertEquals(SecurityDefaults.MAX_PARAMETER_COUNT_STRICT, strict.maxParameterCount());
-        assertEquals(SecurityDefaults.MAX_HEADER_COUNT_STRICT, strict.maxHeaderCount());
-        assertEquals(SecurityDefaults.MAX_COOKIE_COUNT_STRICT, strict.maxCookieCount());
+        assertEquals(SecurityDefaults.MAX_PARAMETER_NAME_LENGTH_STRICT, strict.maxParameterNameLength());
+        assertEquals(SecurityDefaults.MAX_PARAMETER_VALUE_LENGTH_STRICT, strict.maxParameterValueLength());
+        assertEquals(SecurityDefaults.MAX_HEADER_NAME_LENGTH_STRICT, strict.maxHeaderNameLength());
+        assertEquals(SecurityDefaults.MAX_HEADER_VALUE_LENGTH_STRICT, strict.maxHeaderValueLength());
+        assertEquals(SecurityDefaults.MAX_COOKIE_NAME_LENGTH_STRICT, strict.maxCookieNameLength());
+        assertEquals(SecurityDefaults.MAX_COOKIE_VALUE_LENGTH_STRICT, strict.maxCookieValueLength());
         assertEquals(SecurityDefaults.MAX_BODY_SIZE_STRICT, strict.maxBodySize());
 
-        assertFalse(strict.allowPathTraversal());
         assertFalse(strict.allowDoubleEncoding());
-        assertTrue(strict.requireSecureCookies());
-        assertTrue(strict.requireHttpOnlyCookies());
+        assertFalse(strict.allowNullBytes());
+        assertFalse(strict.allowControlCharacters());
+        assertTrue(strict.normalizeUnicode());
     }
 
     @Test
@@ -254,15 +257,18 @@ class SecurityDefaultsTest {
         SecurityConfiguration defaults = SecurityDefaults.DEFAULT_CONFIGURATION;
 
         assertEquals(SecurityDefaults.MAX_PATH_LENGTH_DEFAULT, defaults.maxPathLength());
-        assertEquals(SecurityDefaults.MAX_PARAMETER_COUNT_DEFAULT, defaults.maxParameterCount());
-        assertEquals(SecurityDefaults.MAX_HEADER_COUNT_DEFAULT, defaults.maxHeaderCount());
-        assertEquals(SecurityDefaults.MAX_COOKIE_COUNT_DEFAULT, defaults.maxCookieCount());
+        assertEquals(SecurityDefaults.MAX_PARAMETER_NAME_LENGTH_DEFAULT, defaults.maxParameterNameLength());
+        assertEquals(SecurityDefaults.MAX_PARAMETER_VALUE_LENGTH_DEFAULT, defaults.maxParameterValueLength());
+        assertEquals(SecurityDefaults.MAX_HEADER_NAME_LENGTH_DEFAULT, defaults.maxHeaderNameLength());
+        assertEquals(SecurityDefaults.MAX_HEADER_VALUE_LENGTH_DEFAULT, defaults.maxHeaderValueLength());
         assertEquals(SecurityDefaults.MAX_BODY_SIZE_DEFAULT, defaults.maxBodySize());
 
-        assertFalse(defaults.allowPathTraversal());
         assertFalse(defaults.allowDoubleEncoding());
-        assertFalse(defaults.requireSecureCookies());
-        assertFalse(defaults.requireHttpOnlyCookies());
+        assertFalse(defaults.allowNullBytes());
+        assertFalse(defaults.allowControlCharacters());
+
+        // The default preset must be identical to plain builder defaults
+        assertEquals(SecurityConfiguration.builder().build(), defaults);
     }
 
     @Test
@@ -270,15 +276,15 @@ class SecurityDefaultsTest {
         SecurityConfiguration lenient = SecurityDefaults.LENIENT_CONFIGURATION;
 
         assertEquals(SecurityDefaults.MAX_PATH_LENGTH_LENIENT, lenient.maxPathLength());
-        assertEquals(SecurityDefaults.MAX_PARAMETER_COUNT_LENIENT, lenient.maxParameterCount());
-        assertEquals(SecurityDefaults.MAX_HEADER_COUNT_LENIENT, lenient.maxHeaderCount());
-        assertEquals(SecurityDefaults.MAX_COOKIE_COUNT_LENIENT, lenient.maxCookieCount());
+        assertEquals(SecurityDefaults.MAX_PARAMETER_NAME_LENGTH_LENIENT, lenient.maxParameterNameLength());
+        assertEquals(SecurityDefaults.MAX_PARAMETER_VALUE_LENGTH_LENIENT, lenient.maxParameterValueLength());
+        assertEquals(SecurityDefaults.MAX_HEADER_NAME_LENGTH_LENIENT, lenient.maxHeaderNameLength());
+        assertEquals(SecurityDefaults.MAX_HEADER_VALUE_LENGTH_LENIENT, lenient.maxHeaderValueLength());
         assertEquals(SecurityDefaults.MAX_BODY_SIZE_LENIENT, lenient.maxBodySize());
 
-        assertFalse(lenient.allowPathTraversal()); // Still not allowed
         assertTrue(lenient.allowDoubleEncoding());
-        assertFalse(lenient.requireSecureCookies());
-        assertFalse(lenient.requireHttpOnlyCookies());
+        assertFalse(lenient.allowNullBytes()); // Never allowed, even in lenient mode
+        assertTrue(lenient.allowControlCharacters());
     }
 
     @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/URLLengthLimitAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/URLLengthLimitAttackTest.java
@@ -92,7 +92,6 @@ class URLLengthLimitAttackTest {
                 .maxParameterValueLength(256) // Further reduced from 512
                 .maxHeaderNameLength(64)      // Reduced from default 128
                 .maxHeaderValueLength(256)    // Further reduced from 512
-                .allowPathTraversal(false)
                 .allowDoubleEncoding(false)
                 .build();
         eventCounter = new SecurityEventCounter();


### PR DESCRIPTION
## Summary

Part 2 of 6 of the findings-remediation series. Fixes the two highest-confusion findings in the security configuration model.

### Problem 1: Two divergent preset surfaces with opposite semantics

`SecurityConfiguration.lenient()` set `allowPathTraversal(true)` and `allowNullBytes(true)`, while `SecurityDefaults.LENIENT_CONFIGURATION` set both to `false` ("Still don't allow this"). Same name, opposite security posture. `strict()` vs `STRICT_CONFIGURATION` also disagreed (10 MB vs 1 MB body limit, different extended-ASCII policy).

**Fix:** the factory methods (`strict()`, `lenient()`, `defaults()`) now delegate to the `SecurityDefaults` constants — a single source of truth — adopting the safer semantics: null bytes are never allowed, and `defaults()` is identical to `builder().build()`.

### Problem 2: ~40% of the config surface was never enforced

These settings were stored, validated, included in equals/hashCode/toString — and read by **no validation stage** (verified by grep across main sources):

`allowPathTraversal` (traversal is hard-blocked by `PatternMatchingStage`/`NormalizationStage` regardless), `maxParameterCount`, `maxHeaderCount`, `maxCookieCount`, `requireSecureCookies`, `requireHttpOnlyCookies`, `logSecurityViolations`, `allowedHeaderNames`/`blockedHeaderNames`, `allowedContentTypes`/`blockedContentTypes` (+ `isHeaderAllowed`/`isContentTypeAllowed` and the precomputed lowercase lookup sets).

**Fix:** removed. Dead security knobs create false confidence — a user setting `requireSecureCookies(true)` got no enforcement whatsoever. Request-level policies (counts, allow/block lists) fundamentally can't be enforced by single-value validation pipelines; the `SecurityDefaults` count/content-type constants remain and are now documented as **advisory values for application-layer enforcement**.

### Refactoring enabled by the cleanup

`SecurityConfiguration` is now a **record** (15 components, all enforced): generated equals/hashCode/toString replace ~200 hand-maintained lines, and the compact constructor keeps all constraint validation. Accessor names are unchanged (they were already record-style), so consuming code — including all validation stages — needed no changes.

### Breaking change note

This removes public API (builder setters, accessors, grouped convenience setters referencing dead knobs) on the 1.5-SNAPSHOT line. Callers of removed setters get a compile error rather than a silent no-op — which is the point.

### Tests

- Config test suite rewritten against the honest surface, including new preset-delegation identity tests and record-constructor validation tests.
- New regression test: `defaults()` ≡ `builder().build()`; lenient preset never allows null bytes.
- `./mvnw -Ppre-commit clean verify`: **5,285 tests, 0 failures, 0 skipped.** Net **−1,300 lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxJYKt4yApyTup6bS4pjLu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxJYKt4yApyTup6bS4pjLu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Security configuration is now immutable, with the presets centered on core length and character-policy constraints.
  * Simplified the configuration builder by removing many previously tunable controls and allow/block options.
  * Updated strict/default/lenient presets to align with the reduced configuration surface.
* **Bug Fixes**
  * Invalid security settings now fail fast during configuration creation.
* **Tests**
  * Updated and streamlined test coverage to match the revised builder surface and preset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->