### PR TITLE
fix(security): close post-decode and header-injection validation gaps

### DIFF
--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java
@@ -91,7 +91,7 @@ public class SecurityConfigurationBuilder {
     private boolean allowNullBytes = false;
     private boolean allowControlCharacters = false;
     private boolean allowExtendedAscii = true;
-    private boolean normalizeUnicode = false;
+    private boolean normalizeUnicode = true;
 
     // General Policy defaults
     private boolean caseSensitiveComparison = false;

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java
@@ -116,7 +116,8 @@ public final class SecurityDefaults {
             "%2e%2e//", "%2e%2e\\\\", "..%2f/", "..%5c\\", "..%2f", "..%5c", "/%2e%2e/",
 
             // UTF-8 overlong encodings (common bypass attempts)
-            "..%c0%af", "..%c1%9c", "%c0%ae%c0%ae%c0%af", "%c1%8s%c1%8s%c1%81"
+            // %c0%af = overlong '/', %c1%9c = overlong '\', %c0%ae = overlong '.'
+            "..%c0%af", "..%c1%9c", "%c0%ae%c0%ae%c0%af", "%c0%ae%c0%ae%c1%9c"
     );
 
     /** Patterns indicating potential directory traversal attempts and protocol handler attacks */

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java
@@ -192,8 +192,11 @@ public final class CharacterValidationConstants {
      * Returns the appropriate character set for the specified validation type.
      *
      * <p>This method provides a centralized mapping from validation types to their
-     * corresponding RFC-compliant character sets. The returned BitSet is the actual
-     * instance (not a copy) for performance reasons and must not be modified.</p>
+     * corresponding RFC-compliant character sets. The returned BitSet is a defensive
+     * copy: {@link BitSet} is mutable, and handing out the shared constant would let
+     * any caller corrupt the allowed-character rules for every validator in the JVM.
+     * The copy is created once per call (validators call this at construction, not
+     * per validation), so the cost is negligible.</p>
      *
      * <h4>Validation Type Mappings:</h4>
      * <ul>
@@ -215,12 +218,13 @@ public final class CharacterValidationConstants {
      * @see #RFC3986_UNRESERVED
      */
     public static BitSet getCharacterSet(ValidationType type) {
-        return switch (type) {
+        BitSet characterSet = switch (type) {
             case URL_PATH -> RFC3986_PATH_CHARS;
             case PARAMETER_NAME, PARAMETER_VALUE -> RFC3986_QUERY_CHARS;
             case HEADER_NAME, HEADER_VALUE -> RFC7230_HEADER_CHARS;
             case BODY -> HTTP_BODY_CHARS;
             case COOKIE_NAME, COOKIE_VALUE -> RFC3986_UNRESERVED;
         };
+        return (BitSet) characterSet.clone();
     }
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
@@ -128,7 +128,7 @@ public final class CharacterValidationStage implements HttpSecurityValidator {
         this.allowNullBytes = config.allowNullBytes();
         this.allowControlCharacters = config.allowControlCharacters();
         this.allowExtendedAscii = config.allowExtendedAscii();
-        // Use the shared BitSet directly - it's read-only after initialization
+        // Defensive copy per stage - the shared constants cannot be corrupted through this instance
         this.allowedChars = CharacterValidationConstants.getCharacterSet(type);
 
         // Determine if percent encoding is allowed based on type
@@ -278,6 +278,13 @@ public final class CharacterValidationStage implements HttpSecurityValidator {
 
         // Control characters (1-31, excluding null which is handled above)
         if (ch <= 31) {
+            // CR/LF can never appear in header names or values - allowing them would
+            // enable HTTP response splitting / header injection, so they are rejected
+            // unconditionally regardless of allowControlCharacters
+            if ((ch == '\r' || ch == '\n') &&
+                    (validationType == ValidationType.HEADER_NAME || validationType == ValidationType.HEADER_VALUE)) {
+                return false;
+            }
             // Always allow common whitespace characters that are in the base character set
             if (allowedChars.get(ch)) {
                 return true;

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
@@ -268,6 +268,17 @@ public final class CharacterValidationStage implements HttpSecurityValidator {
     }
 
     /**
+     * Header names/values and cookie names/values all travel inside HTTP headers,
+     * so CR/LF in any of them is a response-splitting vector.
+     */
+    private boolean isHeaderOrCookieType() {
+        return validationType == ValidationType.HEADER_NAME
+                || validationType == ValidationType.HEADER_VALUE
+                || validationType == ValidationType.COOKIE_NAME
+                || validationType == ValidationType.COOKIE_VALUE;
+    }
+
+    /**
      * Checks if a character is allowed based on configuration flags and character sets.
      */
     private boolean isCharacterAllowed(char ch) {
@@ -278,11 +289,11 @@ public final class CharacterValidationStage implements HttpSecurityValidator {
 
         // Control characters (1-31, excluding null which is handled above)
         if (ch <= 31) {
-            // CR/LF can never appear in header names or values - allowing them would
-            // enable HTTP response splitting / header injection, so they are rejected
-            // unconditionally regardless of allowControlCharacters
-            if ((ch == '\r' || ch == '\n') &&
-                    (validationType == ValidationType.HEADER_NAME || validationType == ValidationType.HEADER_VALUE)) {
+            // CR/LF can never appear in header or cookie names/values - cookies are
+            // transmitted via the Cookie/Set-Cookie headers, so allowing CR/LF would
+            // enable HTTP response splitting / header injection. Rejected unconditionally
+            // regardless of allowControlCharacters.
+            if ((ch == '\r' || ch == '\n') && isHeaderOrCookieType()) {
                 return false;
             }
             // Always allow common whitespace characters that are in the base character set

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java
@@ -190,9 +190,19 @@ ValidationType validationType) implements HttpSecurityValidator {
                     .build();
         }
 
-        // Step 3: Unicode normalization with change detection
+        // Step 2.5: Re-validate security-critical characters in the DECODED output.
+        // Character validation runs before decoding, so a percent-encoded sequence
+        // (e.g. %CC%80 for a combining grave accent, or %0D%0A for CRLF) is only
+        // seen as valid percent-encoding. The decoded characters must be checked
+        // again or encoding becomes a bypass for the character rules.
+        validateDecodedCharacters(value, decoded);
+
+        // Step 3: Unicode normalization with change detection.
+        // NFKC (not NFC) is required to fold compatibility homoglyphs such as the
+        // fullwidth solidus U+FF0F to their canonical form: a change after folding
+        // indicates an input that would read differently after normalization.
         if (config.normalizeUnicode()) {
-            String normalized = Normalizer.normalize(decoded, Normalizer.Form.NFC);
+            String normalized = Normalizer.normalize(decoded, Normalizer.Form.NFKC);
             if (!decoded.equals(normalized)) {
                 // Normalization changed the string - potential attack
                 throw UrlSecurityException.builder()
@@ -207,6 +217,60 @@ ValidationType validationType) implements HttpSecurityValidator {
         }
 
         return Optional.of(decoded);
+    }
+
+    /**
+     * Validates security-critical characters in decoded output.
+     *
+     * <p>Checks applied to the decoded string:</p>
+     * <ul>
+     *   <li><strong>Null bytes</strong> - rejected unless explicitly allowed (defense in depth;
+     *       encoded {@code %00} is normally already rejected before decoding)</li>
+     *   <li><strong>Combining characters (U+0300-U+036F)</strong> - always rejected, mirroring
+     *       the raw-character rule; decoded combining marks can visually alter adjacent
+     *       characters and enable homograph attacks</li>
+     *   <li><strong>Decoded CR/LF in URL paths</strong> - rejected unless control characters are
+     *       explicitly allowed; a decoded line break in a path is a response-splitting vector.
+     *       Parameter values are exempt because encoded line breaks are legitimate form data.</li>
+     * </ul>
+     *
+     * @param originalInput The original (still encoded) input for error reporting
+     * @param decoded The decoded string to validate
+     * @throws UrlSecurityException if a security-critical character is found
+     */
+    private void validateDecodedCharacters(String originalInput, String decoded) throws UrlSecurityException {
+        for (int i = 0; i < decoded.length(); i++) {
+            char ch = decoded.charAt(i);
+
+            if (ch == '\0' && !config.allowNullBytes()) {
+                throw UrlSecurityException.builder()
+                        .failureType(UrlSecurityFailureType.NULL_BYTE_INJECTION)
+                        .validationType(validationType)
+                        .originalInput(originalInput)
+                        .detail("Decoded null byte at position " + i)
+                        .build();
+            }
+
+            if (ch >= 0x0300 && ch <= 0x036F) {
+                throw UrlSecurityException.builder()
+                        .failureType(UrlSecurityFailureType.INVALID_CHARACTER)
+                        .validationType(validationType)
+                        .originalInput(originalInput)
+                        .detail("Decoded combining character (U+" + Integer.toHexString(ch).toUpperCase()
+                                + ") at position " + i)
+                        .build();
+            }
+
+            if ((ch == '\r' || ch == '\n') && validationType == ValidationType.URL_PATH
+                    && !config.allowControlCharacters()) {
+                throw UrlSecurityException.builder()
+                        .failureType(UrlSecurityFailureType.CONTROL_CHARACTERS)
+                        .validationType(validationType)
+                        .originalInput(originalInput)
+                        .detail("Decoded line break at position " + i)
+                        .build();
+            }
+        }
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java
@@ -229,9 +229,11 @@ ValidationType validationType) implements HttpSecurityValidator {
      *   <li><strong>Combining characters (U+0300-U+036F)</strong> - always rejected, mirroring
      *       the raw-character rule; decoded combining marks can visually alter adjacent
      *       characters and enable homograph attacks</li>
-     *   <li><strong>Decoded CR/LF in URL paths</strong> - rejected unless control characters are
-     *       explicitly allowed; a decoded line break in a path is a response-splitting vector.
-     *       Parameter values are exempt because encoded line breaks are legitimate form data.</li>
+     *   <li><strong>Decoded CR/LF</strong> - always rejected for header names/values and cookie
+     *       names/values (they travel inside HTTP headers, so a decoded line break is a
+     *       response-splitting vector). For URL paths, rejected unless control characters are
+     *       explicitly allowed. Parameter values are exempt because encoded line breaks are
+     *       legitimate form data.</li>
      * </ul>
      *
      * @param originalInput The original (still encoded) input for error reporting
@@ -261,8 +263,7 @@ ValidationType validationType) implements HttpSecurityValidator {
                         .build();
             }
 
-            if ((ch == '\r' || ch == '\n') && validationType == ValidationType.URL_PATH
-                    && !config.allowControlCharacters()) {
+            if ((ch == '\r' || ch == '\n') && decodedLineBreakForbidden()) {
                 throw UrlSecurityException.builder()
                         .failureType(UrlSecurityFailureType.CONTROL_CHARACTERS)
                         .validationType(validationType)
@@ -271,6 +272,18 @@ ValidationType validationType) implements HttpSecurityValidator {
                         .build();
             }
         }
+    }
+
+    /**
+     * A decoded CR/LF is forbidden for header/cookie contexts unconditionally (response
+     * splitting), and for URL paths unless control characters are explicitly allowed.
+     */
+    private boolean decodedLineBreakForbidden() {
+        return switch (validationType) {
+            case HEADER_NAME, HEADER_VALUE, COOKIE_NAME, COOKIE_VALUE -> true;
+            case URL_PATH -> !config.allowControlCharacters();
+            case PARAMETER_NAME, PARAMETER_VALUE, BODY -> false;
+        };
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java
@@ -23,6 +23,7 @@ import de.cuioss.http.security.core.ValidationType;
 import de.cuioss.http.security.exceptions.UrlSecurityException;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -171,7 +172,9 @@ ValidationType validationType) implements HttpSecurityValidator {
             toLowercaseSet(SecurityDefaults.SUSPICIOUS_PARAMETER_NAMES);
 
     private static Set<String> toLowercaseSet(Set<String> patterns) {
-        return patterns.stream().map(String::toLowerCase).collect(Collectors.toUnmodifiableSet());
+        return patterns.stream()
+                .map(p -> p.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     /**
@@ -204,8 +207,10 @@ ValidationType validationType) implements HttpSecurityValidator {
             return Optional.of(value);
         }
 
-        // Prepare value for case-insensitive matching if needed
-        String testValue = config.caseSensitiveComparison() ? value : value.toLowerCase();
+        // Prepare value for case-insensitive matching if needed.
+        // Locale.ROOT avoids locale-specific folding (e.g. the Turkish dotless-i)
+        // that could otherwise be exploited to bypass pattern matching.
+        String testValue = config.caseSensitiveComparison() ? value : value.toLowerCase(Locale.ROOT);
 
         // Step 1: Check for path traversal patterns (applies to paths and parameters)
         if (validationType == ValidationType.URL_PATH ||

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java
@@ -24,8 +24,10 @@ import de.cuioss.http.security.exceptions.UrlSecurityException;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Pattern matching validation stage for detecting malicious attack patterns.
@@ -132,7 +134,7 @@ ValidationType validationType) implements HttpSecurityValidator {
                     \\.%2e(%2f|%5c|/|\\\\)|%2e\\.(%2f|%5c|/|\\\\)|\
                     %252e%252e(%252f|%255c)|\
                     \\.\\.(%252f|%255c)|\
-                    %c0%ae%c0%ae(%c0%af|%c1%9c|/|\\\\)|%c1%9c%c1%9c|%c1%8s|\
+                    %c0%ae%c0%ae(%c0%af|%c1%9c|/|\\\\)|%c1%9c%c1%9c|\
                     %c0%ae%c0%ae%c0%af|%c0%ae%c0%af|%c1%9c|\
                     %2e%2e//|%2e%2e\\\\\\\\""",
             Pattern.CASE_INSENSITIVE
@@ -156,6 +158,21 @@ ValidationType validationType) implements HttpSecurityValidator {
     // XSS script pattern removed - application layer responsibility.
     // Application layers have proper context for HTML/JS escaping and validation.
 
+    /**
+     * Pre-computed lowercase variants of the pattern databases. The pattern sets are
+     * constants, so lowercasing them once here avoids re-lowercasing every pattern on
+     * every validation call in case-insensitive mode (the common configuration).
+     */
+    private static final Set<String> PATH_TRAVERSAL_PATTERNS_LOWERCASE =
+            toLowercaseSet(SecurityDefaults.PATH_TRAVERSAL_PATTERNS);
+    private static final Set<String> SUSPICIOUS_PATH_PATTERNS_LOWERCASE =
+            toLowercaseSet(SecurityDefaults.SUSPICIOUS_PATH_PATTERNS);
+    private static final Set<String> SUSPICIOUS_PARAMETER_NAMES_LOWERCASE =
+            toLowercaseSet(SecurityDefaults.SUSPICIOUS_PARAMETER_NAMES);
+
+    private static Set<String> toLowercaseSet(Set<String> patterns) {
+        return patterns.stream().map(String::toLowerCase).collect(Collectors.toUnmodifiableSet());
+    }
 
     /**
      * Validates input against attack pattern databases.
@@ -228,9 +245,10 @@ ValidationType validationType) implements HttpSecurityValidator {
      */
     private void checkPathTraversalPatterns(String originalValue, String testValue) {
         // Check simple string patterns - ALWAYS fail on path traversal (security critical)
-        for (String pattern : SecurityDefaults.PATH_TRAVERSAL_PATTERNS) {
-            String checkPattern = config.caseSensitiveComparison() ? pattern : pattern.toLowerCase();
-            if (testValue.contains(checkPattern)) {
+        Set<String> patterns = config.caseSensitiveComparison()
+                ? SecurityDefaults.PATH_TRAVERSAL_PATTERNS : PATH_TRAVERSAL_PATTERNS_LOWERCASE;
+        for (String pattern : patterns) {
+            if (testValue.contains(pattern)) {
                 throw UrlSecurityException.builder()
                         .failureType(UrlSecurityFailureType.PATH_TRAVERSAL_DETECTED)
                         .validationType(validationType)
@@ -275,9 +293,10 @@ ValidationType validationType) implements HttpSecurityValidator {
      * @throws UrlSecurityException if suspicious patterns are found and policy requires failure
      */
     private void checkSuspiciousPathPatterns(String originalValue, String testValue) {
-        for (String pattern : SecurityDefaults.SUSPICIOUS_PATH_PATTERNS) {
-            String checkPattern = config.caseSensitiveComparison() ? pattern : pattern.toLowerCase();
-            if (testValue.contains(checkPattern) && config.failOnSuspiciousPatterns()) {
+        Set<String> patterns = config.caseSensitiveComparison()
+                ? SecurityDefaults.SUSPICIOUS_PATH_PATTERNS : SUSPICIOUS_PATH_PATTERNS_LOWERCASE;
+        for (String pattern : patterns) {
+            if (testValue.contains(pattern) && config.failOnSuspiciousPatterns()) {
                 throw UrlSecurityException.builder()
                         .failureType(UrlSecurityFailureType.SUSPICIOUS_PATTERN_DETECTED)
                         .validationType(validationType)
@@ -298,9 +317,10 @@ ValidationType validationType) implements HttpSecurityValidator {
      * @throws UrlSecurityException if suspicious parameter names are found and policy requires failure
      */
     private void checkSuspiciousParameterNames(String originalValue, String testValue) {
-        for (String suspiciousName : SecurityDefaults.SUSPICIOUS_PARAMETER_NAMES) {
-            String checkName = config.caseSensitiveComparison() ? suspiciousName : suspiciousName.toLowerCase();
-            if ((testValue.equals(checkName) || testValue.contains(checkName)) && config.failOnSuspiciousPatterns()) {
+        Set<String> names = config.caseSensitiveComparison()
+                ? SecurityDefaults.SUSPICIOUS_PARAMETER_NAMES : SUSPICIOUS_PARAMETER_NAMES_LOWERCASE;
+        for (String suspiciousName : names) {
+            if ((testValue.equals(suspiciousName) || testValue.contains(suspiciousName)) && config.failOnSuspiciousPatterns()) {
                 throw UrlSecurityException.builder()
                         .failureType(UrlSecurityFailureType.SUSPICIOUS_PARAMETER_NAME)
                         .validationType(validationType)

--- a/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationBuilderTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationBuilderTest.java
@@ -70,7 +70,7 @@ class SecurityConfigurationBuilderTest {
         assertFalse(config.allowNullBytes());
         assertFalse(config.allowControlCharacters());
         assertTrue(config.allowExtendedAscii());
-        assertFalse(config.normalizeUnicode());
+        assertTrue(config.normalizeUnicode()); // Enabled by default since 1.5 (NFKC)
     }
 
     @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java
@@ -199,6 +199,35 @@ class HTTPHeaderValidationPipelineTest {
             assertEquals(ValidationType.HEADER_NAME, exception.getValidationType());
             assertEquals(longHeaderName, exception.getOriginalInput());
         }
+
+        /**
+         * Regression: CR/LF must be rejected in header values even under a lenient
+         * configuration that allows control characters, since they enable HTTP
+         * response splitting / header injection.
+         */
+        @Test
+        void shouldRejectCrlfInHeaderValueEvenWhenControlCharsAllowed() {
+            SecurityConfiguration lenient = SecurityConfiguration.lenient();
+            HTTPHeaderValidationPipeline pipeline = new HTTPHeaderValidationPipeline(
+                    lenient, eventCounter, ValidationType.HEADER_VALUE);
+
+            assertThrows(UrlSecurityException.class, () ->
+                    pipeline.validate("value\r\nInjected-Header: evil"));
+            assertThrows(UrlSecurityException.class, () ->
+                    pipeline.validate("value\rInjected"));
+            assertThrows(UrlSecurityException.class, () ->
+                    pipeline.validate("value\nInjected"));
+        }
+
+        @Test
+        void shouldRejectCrlfInHeaderNameEvenWhenControlCharsAllowed() {
+            SecurityConfiguration lenient = SecurityConfiguration.lenient();
+            HTTPHeaderValidationPipeline pipeline = new HTTPHeaderValidationPipeline(
+                    lenient, eventCounter, ValidationType.HEADER_NAME);
+
+            assertThrows(UrlSecurityException.class, () ->
+                    pipeline.validate("X-Name\r\nInjected"));
+        }
     }
 
     @Nested

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java
@@ -167,6 +167,35 @@ class URLParameterValidationPipelineTest {
             assertThrows(UrlSecurityException.class, () ->
                     pipeline.validate(oversizedParam));
         }
+
+        /**
+         * Regression: a percent-encoded combining character (%CC%80 = U+0300) is valid
+         * percent-encoding before decoding, but the decoded combining mark must be
+         * rejected by the post-decode character re-validation.
+         */
+        @Test
+        void shouldRejectEncodedCombiningCharacter() {
+            UrlSecurityException exception = assertThrows(UrlSecurityException.class, () ->
+                    pipeline.validate("value%CC%80"));
+
+            assertEquals(UrlSecurityFailureType.INVALID_CHARACTER, exception.getFailureType());
+            assertEquals(ValidationType.PARAMETER_VALUE, exception.getValidationType());
+        }
+
+        /**
+         * Regression: a percent-encoded fullwidth solidus (%EF%BC%8F = U+FF0F) folds to
+         * '/' under NFKC. With normalization on by default, this homoglyph must be
+         * rejected rather than silently normalized into a path separator.
+         */
+        @Test
+        void shouldRejectEncodedFullwidthSolidusHomoglyph() {
+            assertTrue(config.normalizeUnicode(), "Default config must normalize (NFKC) for this guarantee");
+
+            UrlSecurityException exception = assertThrows(UrlSecurityException.class, () ->
+                    pipeline.validate("path%EF%BC%8F%EF%BC%8Fadmin"));
+
+            assertEquals(UrlSecurityFailureType.UNICODE_NORMALIZATION_CHANGED, exception.getFailureType());
+        }
     }
 
     @Nested

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationConstantsTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationConstantsTest.java
@@ -141,25 +141,37 @@ class CharacterValidationConstantsTest {
 
     @Test
     void shouldReturnCorrectCharacterSetForValidationType() {
-        assertSame(CharacterValidationConstants.RFC3986_PATH_CHARS,
+        assertEquals(CharacterValidationConstants.RFC3986_PATH_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.URL_PATH));
 
-        assertSame(CharacterValidationConstants.RFC3986_QUERY_CHARS,
+        assertEquals(CharacterValidationConstants.RFC3986_QUERY_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.PARAMETER_NAME));
-        assertSame(CharacterValidationConstants.RFC3986_QUERY_CHARS,
+        assertEquals(CharacterValidationConstants.RFC3986_QUERY_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.PARAMETER_VALUE));
 
-        assertSame(CharacterValidationConstants.RFC7230_HEADER_CHARS,
+        assertEquals(CharacterValidationConstants.RFC7230_HEADER_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.HEADER_NAME));
-        assertSame(CharacterValidationConstants.RFC7230_HEADER_CHARS,
+        assertEquals(CharacterValidationConstants.RFC7230_HEADER_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.HEADER_VALUE));
 
-        assertSame(CharacterValidationConstants.HTTP_BODY_CHARS,
+        assertEquals(CharacterValidationConstants.HTTP_BODY_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.BODY));
-        assertSame(CharacterValidationConstants.RFC3986_UNRESERVED,
+        assertEquals(CharacterValidationConstants.RFC3986_UNRESERVED,
                 CharacterValidationConstants.getCharacterSet(ValidationType.COOKIE_NAME));
-        assertSame(CharacterValidationConstants.RFC3986_UNRESERVED,
+        assertEquals(CharacterValidationConstants.RFC3986_UNRESERVED,
                 CharacterValidationConstants.getCharacterSet(ValidationType.COOKIE_VALUE));
+    }
+
+    @Test
+    void shouldReturnDefensiveCopies() {
+        // Mutating a returned set must not corrupt the shared constants
+        var copy = CharacterValidationConstants.getCharacterSet(ValidationType.URL_PATH);
+        assertNotSame(CharacterValidationConstants.RFC3986_PATH_CHARS, copy);
+
+        copy.set('<');
+        assertFalse(CharacterValidationConstants.RFC3986_PATH_CHARS.get('<'),
+                "Shared constant must be unaffected by mutation of the returned copy");
+        assertFalse(CharacterValidationConstants.getCharacterSet(ValidationType.URL_PATH).get('<'));
     }
 
     @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java
@@ -213,21 +213,20 @@ class DecodingStageTest {
                 .normalizeUnicode(true)
                 .build();
 
-        DecodingStage unicodeDecoder = new DecodingStage(unicodeConfig, ValidationType.URL_PATH);
+        DecodingStage unicodeDecoder = new DecodingStage(unicodeConfig, ValidationType.HEADER_VALUE);
 
-        // Create a string with decomposed Unicode that will change when normalized
-        // Using combining characters that will be normalized
-        String decomposed = "cafe\u0301"; // e + combining acute accent
-        String composed = "café"; // precomposed character
+        // Fullwidth 'A' (U+FF21) is a compatibility character that NFKC folds to 'A'.
+        // NFKC (not NFC) is required to catch this; it is not a combining mark, so it
+        // reaches the normalization step rather than the post-decode character check.
+        String compatibility = "ＡBC"; // fullwidth A + BC
+        String folded = "ABC";
 
-        // If the input changes during normalization, it should throw an exception
-        // Note: This depends on the exact Unicode composition
         UrlSecurityException exception = assertThrows(UrlSecurityException.class,
-                () -> unicodeDecoder.validate(decomposed));
+                () -> unicodeDecoder.validate(compatibility));
 
         assertEquals(UrlSecurityFailureType.UNICODE_NORMALIZATION_CHANGED, exception.getFailureType());
-        assertEquals(decomposed, exception.getOriginalInput());
-        assertEquals(Optional.of(composed), exception.getSanitizedInput());
+        assertEquals(compatibility, exception.getOriginalInput());
+        assertEquals(Optional.of(folded), exception.getSanitizedInput());
         assertTrue(exception.getDetail().isPresent());
         assertTrue(exception.getDetail().get().contains("Unicode normalization changed"));
     }
@@ -239,15 +238,48 @@ class DecodingStageTest {
                 .normalizeUnicode(false)
                 .build();
 
-        DecodingStage noUnicodeDecoder = new DecodingStage(noUnicodeConfig, ValidationType.URL_PATH);
+        DecodingStage noUnicodeDecoder = new DecodingStage(noUnicodeConfig, ValidationType.HEADER_VALUE);
 
-        // Even with decomposed Unicode, should not throw exception
-        String decomposed = "cafe\u0301";
+        // With normalization disabled the compatibility character passes through unchanged
+        String compatibility = "ＡBC";
         assertDoesNotThrow(() -> {
-            Optional<String> result = noUnicodeDecoder.validate(decomposed);
+            Optional<String> result = noUnicodeDecoder.validate(compatibility);
             assertTrue(result.isPresent());
+            assertEquals(compatibility, result.get());
             return result.get();
         });
+    }
+
+    @Test
+    @DisplayName("Should reject decoded combining characters regardless of normalization setting")
+    void shouldRejectDecodedCombiningCharacters() {
+        SecurityConfiguration noNormalize = SecurityConfiguration.builder()
+                .normalizeUnicode(false)
+                .build();
+        DecodingStage decoder = new DecodingStage(noNormalize, ValidationType.PARAMETER_VALUE);
+
+        // %CC%80 decodes to U+0300 (combining grave accent). Pre-decode this is valid
+        // percent-encoding; the decoded combining mark must still be rejected.
+        UrlSecurityException exception = assertThrows(UrlSecurityException.class,
+                () -> decoder.validate("value%CC%80"));
+
+        assertEquals(UrlSecurityFailureType.INVALID_CHARACTER, exception.getFailureType());
+        assertTrue(exception.getDetail().orElse("").contains("combining character"));
+    }
+
+    @Test
+    @DisplayName("Should reject decoded CRLF in URL paths")
+    void shouldRejectDecodedCrlfInPath() {
+        SecurityConfiguration config = SecurityConfiguration.builder()
+                .normalizeUnicode(false)
+                .build();
+        DecodingStage decoder = new DecodingStage(config, ValidationType.URL_PATH);
+
+        // %0D%0A decodes to CRLF - a response-splitting vector in a path
+        UrlSecurityException exception = assertThrows(UrlSecurityException.class,
+                () -> decoder.validate("/path%0D%0AInjected: header"));
+
+        assertEquals(UrlSecurityFailureType.CONTROL_CHARACTERS, exception.getFailureType());
     }
 
     @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java
@@ -283,6 +283,23 @@ class DecodingStageTest {
     }
 
     @Test
+    @DisplayName("Should reject decoded CRLF in header and cookie contexts even when control chars allowed")
+    void shouldRejectDecodedCrlfInHeaderAndCookieContexts() {
+        SecurityConfiguration lenient = SecurityConfiguration.lenient(); // allowControlCharacters=true
+
+        for (ValidationType type : new ValidationType[]{
+                ValidationType.HEADER_NAME, ValidationType.HEADER_VALUE,
+                ValidationType.COOKIE_NAME, ValidationType.COOKIE_VALUE}) {
+            DecodingStage decoder = new DecodingStage(lenient, type);
+            UrlSecurityException exception = assertThrows(UrlSecurityException.class,
+                    () -> decoder.validate("value%0D%0AInjected"),
+                    "Decoded CRLF must be rejected for " + type);
+            assertEquals(UrlSecurityFailureType.CONTROL_CHARACTERS, exception.getFailureType(),
+                    "Failure type must be CONTROL_CHARACTERS for " + type);
+        }
+    }
+
+    @Test
     @DisplayName("Should preserve validation type in exceptions")
     void shouldPreserveValidationType() {
         DecodingStage[] decoders = {


### PR DESCRIPTION
## Summary

Part 3 of 6 of the findings-remediation series. Closes a cluster of encoding-based bypasses in the validation core. These are behavior-changing security fixes — the attack and legitimate-input databases (the false-positive safety net) all still pass unchanged.

### CR/LF header injection

CR/LF were not in the RFC7230 header BitSet and fell through to `return allowControlCharacters`. Under a lenient config (`allowControlCharacters=true`) they were permitted in header names and values — an HTTP response-splitting / header-injection vector. **CR/LF are now rejected unconditionally in headers**, regardless of configuration.

### Post-decode character re-validation

`CharacterValidationStage` runs *before* `DecodingStage`, so a percent-encoded sequence was only ever inspected as valid percent-encoding — the decoded character was never re-scanned. `DecodingStage` now re-validates the decoded output for:
- **null bytes** (defense in depth),
- **combining marks U+0300–U+036F** — `%CC%80` decodes to a lone combining grave that previously passed, and
- **CR/LF in URL paths** — `%0D%0A` in a path is a response-splitting vector.

### NFKC normalization, on by default

Normalization was NFC and off by default. NFC doesn't fold compatibility homoglyphs; **NFKC** folds e.g. the fullwidth solidus U+FF0F → `/`. An encoded homoglyph (`%EF%BC%8F`) is now caught by the normalization-change check instead of silently canonicalizing into a path separator in a downstream layer. `normalizeUnicode` now defaults to `true`.

### Smaller items

- Fixed the non-hex `%c1%8s` typo in both `ENCODED_TRAVERSAL_PATTERN` and `PATH_TRAVERSAL_PATTERNS` (an `s` is not a hex digit, so those literals could never match real traffic) — replaced with the correct overlong `\` sequence.
- `PatternMatchingStage` now precomputes the lowercased pattern sets once instead of lowercasing ~30 constant patterns on every validation call (doubled for URL paths, which run the stage twice).
- `CharacterValidationConstants.getCharacterSet()` returns a defensive `BitSet` copy — the shared mutable constants can no longer be corrupted through the accessor.

### Behavior-change note

`normalizeUnicode` default flips to `true`; inputs that change under NFKC now fail with `UNICODE_NORMALIZATION_CHANGED`. Two `DecodingStageTest` cases that asserted the old NFC/off behavior were updated to the NFKC case (fullwidth compatibility character); no attack-database or legitimate-input case regressed.

### Tests

- New pipeline-level regression tests: CRLF in header name/value under lenient config, encoded combining char, encoded fullwidth homoglyph.
- New `DecodingStage` unit tests for decoded combining/CRLF rejection and the NFKC fold; new `CharacterValidationConstants` defensive-copy test.
- `./mvnw -Ppre-commit clean verify`: **5,276 tests, 0 failures, 0 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxJYKt4yApyTup6bS4pjLu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxJYKt4yApyTup6bS4pjLu)_