### PR TITLE
fix(client): enforce the TLS floor on HTTPS connections

### DIFF
--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java
@@ -112,6 +112,12 @@ public final class HttpHandler {
     private final URL url;
     @Getter
     private final @Nullable SSLContext sslContext;
+    // Retained so asBuilder() can preserve a caller-configured TLS floor. For HTTP
+    // handlers this holds the default provider and is never used (no TLS).
+    // Excluded from equals/toString: it is an implementation detail derivable from configuration.
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private final SecureSSLContextProvider secureSSLContextProvider;
     @Getter
     private final int connectionTimeoutSeconds;
     @Getter
@@ -123,6 +129,8 @@ public final class HttpHandler {
         this.uri = uri;
         this.url = url;
         this.sslContext = null;
+        // Unused for HTTP; holds a default so asBuilder() has a non-null value to carry
+        this.secureSSLContextProvider = new SecureSSLContextProvider();
         this.connectionTimeoutSeconds = connectionTimeoutSeconds;
         this.readTimeoutSeconds = readTimeoutSeconds;
 
@@ -133,11 +141,12 @@ public final class HttpHandler {
     }
 
     // Constructor for HTTPS URIs (SSL context required)
-    private HttpHandler(URI uri, URL url, SSLContext sslContext, String[] enabledProtocols,
+    private HttpHandler(URI uri, URL url, SSLContext sslContext, SecureSSLContextProvider secureSSLContextProvider,
             int connectionTimeoutSeconds, int readTimeoutSeconds) {
         this.uri = uri;
         this.url = url;
         this.sslContext = sslContext;
+        this.secureSSLContextProvider = secureSSLContextProvider;
         this.connectionTimeoutSeconds = connectionTimeoutSeconds;
         this.readTimeoutSeconds = readTimeoutSeconds;
 
@@ -145,7 +154,7 @@ public final class HttpHandler {
         // Pin the enabled TLS protocols so the configured minimum version is a hard
         // floor on the wire, not merely the context's default protocol object.
         SSLParameters sslParameters = new SSLParameters();
-        sslParameters.setProtocols(enabledProtocols);
+        sslParameters.setProtocols(secureSSLContextProvider.getEnabledProtocols());
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(connectionTimeoutSeconds))
                 .sslContext(sslContext)
@@ -182,7 +191,8 @@ public final class HttpHandler {
         return builder()
                 .connectionTimeoutSeconds(connectionTimeoutSeconds)
                 .readTimeoutSeconds(readTimeoutSeconds)
-                .sslContext(sslContext);
+                .sslContext(sslContext)
+                .tlsVersions(secureSSLContextProvider);
     }
 
     /**
@@ -421,8 +431,7 @@ public final class HttpHandler {
                 SecureSSLContextProvider actualSecureSSLContextProvider = secureSSLContextProvider != null ?
                         secureSSLContextProvider : new SecureSSLContextProvider();
                 SSLContext secureContext = actualSecureSSLContextProvider.getOrCreateSecureSSLContext(sslContext);
-                String[] enabledProtocols = actualSecureSSLContextProvider.getEnabledProtocols();
-                return new HttpHandler(uri, verifiedUrl, secureContext, enabledProtocols,
+                return new HttpHandler(uri, verifiedUrl, secureContext, actualSecureSSLContextProvider,
                         actualConnectionTimeoutSeconds, actualReadTimeoutSeconds);
             } else {
                 // For HTTP, no SSL context needed

--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java
@@ -26,6 +26,7 @@ import lombok.ToString;
 import org.jspecify.annotations.Nullable;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -132,7 +133,8 @@ public final class HttpHandler {
     }
 
     // Constructor for HTTPS URIs (SSL context required)
-    private HttpHandler(URI uri, URL url, SSLContext sslContext, int connectionTimeoutSeconds, int readTimeoutSeconds) {
+    private HttpHandler(URI uri, URL url, SSLContext sslContext, String[] enabledProtocols,
+            int connectionTimeoutSeconds, int readTimeoutSeconds) {
         this.uri = uri;
         this.url = url;
         this.sslContext = sslContext;
@@ -140,10 +142,14 @@ public final class HttpHandler {
         this.readTimeoutSeconds = readTimeoutSeconds;
 
         // JDK 11+ HttpClient enables hostname verification by default.
-        // We intentionally omit explicit SSLParameters to preserve caller flexibility.
+        // Pin the enabled TLS protocols so the configured minimum version is a hard
+        // floor on the wire, not merely the context's default protocol object.
+        SSLParameters sslParameters = new SSLParameters();
+        sslParameters.setProtocols(enabledProtocols);
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(connectionTimeoutSeconds))
                 .sslContext(sslContext)
+                .sslParameters(sslParameters)
                 .build();
     }
 
@@ -411,11 +417,13 @@ public final class HttpHandler {
 
             // Use appropriate constructor based on scheme
             if ("https".equalsIgnoreCase(uri.getScheme())) {
-                // For HTTPS, create or validate SSL context
+                // For HTTPS, create or validate SSL context and pin the enabled protocols
                 SecureSSLContextProvider actualSecureSSLContextProvider = secureSSLContextProvider != null ?
                         secureSSLContextProvider : new SecureSSLContextProvider();
                 SSLContext secureContext = actualSecureSSLContextProvider.getOrCreateSecureSSLContext(sslContext);
-                return new HttpHandler(uri, verifiedUrl, secureContext, actualConnectionTimeoutSeconds, actualReadTimeoutSeconds);
+                String[] enabledProtocols = actualSecureSSLContextProvider.getEnabledProtocols();
+                return new HttpHandler(uri, verifiedUrl, secureContext, enabledProtocols,
+                        actualConnectionTimeoutSeconds, actualReadTimeoutSeconds);
             } else {
                 // For HTTP, no SSL context needed
                 return new HttpHandler(uri, verifiedUrl, actualConnectionTimeoutSeconds, actualReadTimeoutSeconds);

--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/SecureSSLContextProvider.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/SecureSSLContextProvider.java
@@ -146,6 +146,29 @@ public record SecureSSLContextProvider(String minimumTlsVersion) {
     }
 
     /**
+     * Returns the concrete TLS protocol versions that must be enabled on a connection
+     * to enforce this instance's minimum version as a hard floor.
+     * <p>
+     * An {@link SSLContext} created with a protocol string only governs the context's
+     * <em>default</em> protocol object; it does not by itself prevent the JVM from
+     * negotiating an older enabled protocol. Applying these versions via
+     * {@code SSLParameters.setProtocols(...)} on the client makes the floor real.
+     * <ul>
+     *   <li>Minimum {@link #TLS_V1_3} → {@code [TLSv1.3]}</li>
+     *   <li>Minimum {@link #TLS_V1_2} or generic {@link #TLS} → {@code [TLSv1.2, TLSv1.3]}</li>
+     * </ul>
+     *
+     * @return the ordered array of enabled protocol versions (never empty)
+     */
+    public String[] getEnabledProtocols() {
+        if (TLS_V1_3.equals(minimumTlsVersion)) {
+            return new String[]{TLS_V1_3};
+        }
+        // TLS_V1_2 and generic TLS both enforce a 1.2 floor with 1.3 available
+        return new String[]{TLS_V1_2, TLS_V1_3};
+    }
+
+    /**
      * Creates a secure SSLContext configured with the minimum TLS version set for this instance.
      * <p>
      * This method:
@@ -183,11 +206,16 @@ public record SecureSSLContextProvider(String minimumTlsVersion) {
      *   <li>If the provided SSLContext is not null, checks if its protocol is secure</li>
      *   <li>If the protocol is secure, returns the provided SSLContext</li>
      *   <li>If the protocol is not secure, creates a new secure SSLContext</li>
-     *   <li>If an exception occurs during validation or creation, falls back to the provided SSLContext or the default SSLContext</li>
+     *   <li>If a secure context cannot be created, fails hard with {@link IllegalStateException}</li>
      * </ol>
+     * <p>
+     * Note that the returned context's reported protocol is only part of the guarantee:
+     * {@link HttpHandler} additionally pins the enabled protocols via
+     * {@link #getEnabledProtocols()} so that the minimum version is enforced on the wire.
      *
      * @param sslContext the SSLContext to validate, may be null
      * @return a secure SSLContext, either the validated input or a newly created one (never null)
+     * @throws IllegalStateException if a secure SSLContext cannot be created
      */
     public SSLContext getOrCreateSecureSSLContext(@Nullable SSLContext sslContext) {
         try {

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerTest.java
@@ -181,6 +181,21 @@ class HttpHandlerTest {
         }
 
         @Test
+        @DisplayName("asBuilder should preserve the configured TLS floor")
+        void asBuilderShouldPreserveTlsFloor() {
+            HttpHandler handler = HttpHandler.builder()
+                    .url(VALID_URL)
+                    .tlsVersions(new SecureSSLContextProvider(SecureSSLContextProvider.TLS_V1_3))
+                    .build();
+
+            HttpHandler cloned = handler.asBuilder().url(VALID_URL).build();
+
+            String[] protocols = cloned.createHttpClient().sslParameters().getProtocols();
+            assertArrayEquals(new String[]{SecureSSLContextProvider.TLS_V1_3}, protocols,
+                    "Cloning via asBuilder() must not silently revert the TLS floor");
+        }
+
+        @Test
         @DisplayName("Should prepend https:// to URL without scheme")
         void shouldPrependHttpsToUrlWithoutScheme() {
             String urlWithoutScheme = "example.com";

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerTest.java
@@ -155,6 +155,32 @@ class HttpHandlerTest {
         }
 
         @Test
+        @DisplayName("HTTPS client should pin enabled TLS protocols to the configured floor")
+        void shouldPinEnabledTlsProtocolsOnHttpsClient() {
+            HttpHandler handler = HttpHandler.builder()
+                    .url(VALID_URL) // https://
+                    .build();
+
+            String[] protocols = handler.createHttpClient().sslParameters().getProtocols();
+            assertNotNull(protocols, "SSLParameters protocols must be pinned, not left to JVM defaults");
+            assertArrayEquals(
+                    new String[]{SecureSSLContextProvider.TLS_V1_2, SecureSSLContextProvider.TLS_V1_3},
+                    protocols);
+        }
+
+        @Test
+        @DisplayName("HTTPS client with TLS 1.3 minimum should enable only TLS 1.3")
+        void shouldPinTls13OnlyWhenMinimumIsTls13() {
+            HttpHandler handler = HttpHandler.builder()
+                    .url(VALID_URL)
+                    .tlsVersions(new SecureSSLContextProvider(SecureSSLContextProvider.TLS_V1_3))
+                    .build();
+
+            String[] protocols = handler.createHttpClient().sslParameters().getProtocols();
+            assertArrayEquals(new String[]{SecureSSLContextProvider.TLS_V1_3}, protocols);
+        }
+
+        @Test
         @DisplayName("Should prepend https:// to URL without scheme")
         void shouldPrependHttpsToUrlWithoutScheme() {
             String urlWithoutScheme = "example.com";

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/SecureSSLContextProviderTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/SecureSSLContextProviderTest.java
@@ -105,6 +105,47 @@ class SecureSSLContextProviderTest {
     }
 
     @Test
+    @DisplayName("Should enable TLS 1.2 and 1.3 when minimum is TLS 1.2")
+    void shouldEnableTls12AndTls13ForDefaultMinimum() {
+        String[] protocols = new SecureSSLContextProvider().getEnabledProtocols();
+
+        assertArrayEquals(
+                new String[]{SecureSSLContextProvider.TLS_V1_2, SecureSSLContextProvider.TLS_V1_3},
+                protocols);
+    }
+
+    @Test
+    @DisplayName("Should enable TLS 1.2 and 1.3 when minimum is generic TLS")
+    void shouldEnableTls12AndTls13ForGenericTls() {
+        String[] protocols = new SecureSSLContextProvider(SecureSSLContextProvider.TLS).getEnabledProtocols();
+
+        assertArrayEquals(
+                new String[]{SecureSSLContextProvider.TLS_V1_2, SecureSSLContextProvider.TLS_V1_3},
+                protocols);
+    }
+
+    @Test
+    @DisplayName("Should enable only TLS 1.3 when minimum is TLS 1.3")
+    void shouldEnableOnlyTls13ForTls13Minimum() {
+        String[] protocols = new SecureSSLContextProvider(SecureSSLContextProvider.TLS_V1_3).getEnabledProtocols();
+
+        assertArrayEquals(new String[]{SecureSSLContextProvider.TLS_V1_3}, protocols);
+    }
+
+    @Test
+    @DisplayName("Enabled protocols must never include a forbidden version")
+    void enabledProtocolsMustExcludeForbiddenVersions() {
+        for (String minimum : SecureSSLContextProvider.ALLOWED_TLS_VERSIONS) {
+            String[] protocols = new SecureSSLContextProvider(minimum).getEnabledProtocols();
+            assertTrue(protocols.length > 0);
+            for (String protocol : protocols) {
+                assertFalse(SecureSSLContextProvider.FORBIDDEN_TLS_VERSIONS.contains(protocol),
+                        "Enabled protocols for minimum " + minimum + " must not contain forbidden " + protocol);
+            }
+        }
+    }
+
+    @Test
     @DisplayName("Should have no overlap between allowed and forbidden versions")
     void shouldHaveNoOverlapBetweenAllowedAndForbidden() {
         for (String allowed : SecureSSLContextProvider.ALLOWED_TLS_VERSIONS) {


### PR DESCRIPTION
## Summary

Part 4 of 6 of the findings-remediation series. Makes the "minimum TLS version" an actual floor on the wire instead of a nominal setting.

### The gap

`SecureSSLContextProvider` restricts the `SSLContext.getInstance(...)` protocol string and rejects TLS 1.0/1.1/SSLv3 by name — but that only governs the context's *default protocol object*. `HttpHandler` never called `SSLParameters.setProtocols(...)`, so the negotiated protocol set fell back to the JVM defaults. A caller-supplied context reporting generic `"TLS"` passed validation as "secure" while potentially allowing an older negotiated protocol.

### Fix

- **`SecureSSLContextProvider.getEnabledProtocols()`** (new): maps the minimum version to the concrete versions to enable — `[TLSv1.3]` for a 1.3 minimum, `[TLSv1.2, TLSv1.3]` for a 1.2 or generic-TLS minimum. Never includes a forbidden version.
- **`HttpHandler`** now builds `SSLParameters` with those protocols and applies them to the HTTPS `HttpClient` via `.sslParameters(...)`. The floor is now enforced on every connection, and a generic-`TLS` context is held to a real 1.2 floor.
- Corrected the stale `getOrCreateSecureSSLContext` Javadoc, which still described a fallback that was replaced by a fail-hard `IllegalStateException`.

### Tests

- `getEnabledProtocols()` mappings for all three minimums, plus an invariant that no enabled protocol is ever a forbidden version.
- Handler tests read `handler.createHttpClient().sslParameters().getProtocols()` back and assert it matches the configured floor (default → `[TLSv1.2, TLSv1.3]`, TLS 1.3 minimum → `[TLSv1.3]`) — proving the pinning is actually applied to the client, not just computed.
- `./mvnw -Ppre-commit clean verify`: **5,283 tests, 0 failures, 0 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxJYKt4yApyTup6bS4pjLu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxJYKt4yApyTup6bS4pjLu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTPS connections now consistently use the configured TLS version floor when establishing secure connections.
  * Preserved TLS settings when rebuilding request handlers, preventing silent fallback to weaker defaults.
* **Tests**
  * Added coverage for TLS protocol selection across supported minimum versions.
  * Expanded validation to ensure enabled protocols are always non-empty and never include forbidden versions.
* **Documentation**
  * Clarified how secure connection settings are applied and enforced during HTTPS communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->