### PR TITLE
fix(security): validation & config remediation (F-04/05/06/07/08/11/12/13/14/18)

### DIFF
--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
@@ -74,6 +74,13 @@ package de.cuioss.http.security.config;
  *        parameter values use the lossless NFC form.
  * @param caseSensitiveComparison Whether string comparisons are case-sensitive
  * @param failOnSuspiciousPatterns Whether validation fails on suspicious (non-attack) patterns
+ * @param requireSecureCookies Whether cookies must carry the {@code Secure} attribute
+ *        (enforced by {@code CookiePrefixValidationStage.validateCookie}). Opt-in, default
+ *        {@code false}. Meaningful only for attribute-bearing (Set-Cookie) cookies, not for
+ *        request {@code Cookie}-header {@code name=value} pairs.
+ * @param requireHttpOnlyCookies Whether cookies must carry the {@code HttpOnly} attribute
+ *        (enforced by {@code CookiePrefixValidationStage.validateCookie}). Opt-in, default
+ *        {@code false}. Meaningful only for attribute-bearing (Set-Cookie) cookies.
  *
  * @since 1.0
  * @see SecurityConfigurationBuilder
@@ -96,7 +103,9 @@ boolean allowControlCharacters,
 boolean allowExtendedAscii,
 boolean normalizeUnicode,
 boolean caseSensitiveComparison,
-boolean failOnSuspiciousPatterns
+boolean failOnSuspiciousPatterns,
+boolean requireSecureCookies,
+boolean requireHttpOnlyCookies
 ) {
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
@@ -15,6 +15,8 @@
  */
 package de.cuioss.http.security.config;
 
+import java.util.Set;
+
 /**
  * Immutable record representing security configuration for HTTP validation.
  *
@@ -86,6 +88,14 @@ package de.cuioss.http.security.config;
  *        {@code RequestCollectionValidator})
  * @param maxCookieCount Maximum number of request cookies (positive; enforced by
  *        {@code RequestCollectionValidator})
+ * @param allowedHeaderNames Case-insensitive allow-list of header names; empty means allow-all.
+ *        Enforced by {@code AllowBlockListStage} in the header-name pipeline.
+ * @param blockedHeaderNames Case-insensitive block-list of header names (takes precedence over
+ *        the allow-list). Enforced by {@code AllowBlockListStage} in the header-name pipeline.
+ * @param allowedContentTypes Case-insensitive allow-list of content types; empty means allow-all.
+ *        Enforced by the content-type validator ({@code AllowBlockListStage}).
+ * @param blockedContentTypes Case-insensitive block-list of content types (takes precedence over
+ *        the allow-list). Enforced by the content-type validator ({@code AllowBlockListStage}).
  *
  * @since 1.0
  * @see SecurityConfigurationBuilder
@@ -113,7 +123,11 @@ boolean requireSecureCookies,
 boolean requireHttpOnlyCookies,
 int maxParameterCount,
 int maxHeaderCount,
-int maxCookieCount
+int maxCookieCount,
+Set<String> allowedHeaderNames,
+Set<String> blockedHeaderNames,
+Set<String> allowedContentTypes,
+Set<String> blockedContentTypes
 ) {
 
     /**
@@ -155,6 +169,11 @@ int maxCookieCount
         if (maxCookieCount <= 0) {
             throw new IllegalArgumentException("maxCookieCount must be positive, got: " + maxCookieCount);
         }
+        // Defensive, null-tolerant immutable copies of the allow/block lists.
+        allowedHeaderNames = allowedHeaderNames == null ? Set.of() : Set.copyOf(allowedHeaderNames);
+        blockedHeaderNames = blockedHeaderNames == null ? Set.of() : Set.copyOf(blockedHeaderNames);
+        allowedContentTypes = allowedContentTypes == null ? Set.of() : Set.copyOf(allowedContentTypes);
+        blockedContentTypes = blockedContentTypes == null ? Set.of() : Set.copyOf(blockedContentTypes);
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
@@ -66,7 +66,12 @@ package de.cuioss.http.security.config;
  * @param allowNullBytes Whether null bytes are allowed in content
  * @param allowControlCharacters Whether control characters are allowed in content
  * @param allowExtendedAscii Whether extended ASCII (128-255) and applicable Unicode characters are allowed
- * @param normalizeUnicode Whether Unicode normalization should be performed during decoding
+ * @param normalizeUnicode Whether Unicode normalization is applied during decoding. When enabled,
+ *        input is canonicalized (normalize-and-continue: the canonical form flows to downstream
+ *        stages) and rejected only when a compatibility/canonical fold introduces a structurally
+ *        significant separator (e.g. fullwidth solidus {@code U+FF0F} &rarr; {@code /}); benign
+ *        folds of legitimate international text are preserved, not rejected. Paths use NFKC,
+ *        parameter values use the lossless NFC form.
  * @param caseSensitiveComparison Whether string comparisons are case-sensitive
  * @param failOnSuspiciousPatterns Whether validation fails on suspicious (non-attack) patterns
  *

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
@@ -22,12 +22,11 @@ package de.cuioss.http.security.config;
  * validation stages and pipelines of this library. It provides a type-safe, immutable
  * configuration object that can be shared across multiple validation operations.</p>
  *
- * <p>Every setting in this record is consumed by at least one validation stage. Settings
- * that would require request-level context (parameter counts, header counts, allow/block
- * lists, cookie attribute requirements) are intentionally not part of this configuration:
- * the validation pipelines operate on single values and cannot enforce them. Enforce such
- * policies at the application layer, optionally using the reference constants in
- * {@link SecurityDefaults}.</p>
+ * <p>Every setting in this record is enforced. Single-value settings are consumed by the
+ * validation stages/pipelines; request-level settings that need collection or attribute
+ * context are enforced by dedicated validators: parameter/header/cookie <em>counts</em> by
+ * {@code RequestCollectionValidator}, and cookie {@code Secure}/{@code HttpOnly} requirements
+ * by {@code CookiePrefixValidationStage.validateCookie}.</p>
  *
  * <h3>Design Principles</h3>
  * <ul>
@@ -81,6 +80,12 @@ package de.cuioss.http.security.config;
  * @param requireHttpOnlyCookies Whether cookies must carry the {@code HttpOnly} attribute
  *        (enforced by {@code CookiePrefixValidationStage.validateCookie}). Opt-in, default
  *        {@code false}. Meaningful only for attribute-bearing (Set-Cookie) cookies.
+ * @param maxParameterCount Maximum number of request parameters (positive; enforced by the
+ *        collection-level {@code RequestCollectionValidator}, not a single-value pipeline)
+ * @param maxHeaderCount Maximum number of request headers (positive; enforced by
+ *        {@code RequestCollectionValidator})
+ * @param maxCookieCount Maximum number of request cookies (positive; enforced by
+ *        {@code RequestCollectionValidator})
  *
  * @since 1.0
  * @see SecurityConfigurationBuilder
@@ -105,7 +110,10 @@ boolean normalizeUnicode,
 boolean caseSensitiveComparison,
 boolean failOnSuspiciousPatterns,
 boolean requireSecureCookies,
-boolean requireHttpOnlyCookies
+boolean requireHttpOnlyCookies,
+int maxParameterCount,
+int maxHeaderCount,
+int maxCookieCount
 ) {
 
     /**
@@ -137,6 +145,15 @@ boolean requireHttpOnlyCookies
         }
         if (maxBodySize < 0) {
             throw new IllegalArgumentException("maxBodySize must be non-negative, got: " + maxBodySize);
+        }
+        if (maxParameterCount <= 0) {
+            throw new IllegalArgumentException("maxParameterCount must be positive, got: " + maxParameterCount);
+        }
+        if (maxHeaderCount <= 0) {
+            throw new IllegalArgumentException("maxHeaderCount must be positive, got: " + maxHeaderCount);
+        }
+        if (maxCookieCount <= 0) {
+            throw new IllegalArgumentException("maxCookieCount must be positive, got: " + maxCookieCount);
         }
     }
 

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java
@@ -15,6 +15,10 @@
  */
 package de.cuioss.http.security.config;
 
+import org.jspecify.annotations.Nullable;
+
+import java.util.Set;
+
 /**
  * Builder class for constructing {@link SecurityConfiguration} instances with fluent API.
  *
@@ -105,6 +109,12 @@ public class SecurityConfigurationBuilder {
     private int maxParameterCount = SecurityDefaults.MAX_PARAMETER_COUNT_DEFAULT;
     private int maxHeaderCount = SecurityDefaults.MAX_HEADER_COUNT_DEFAULT;
     private int maxCookieCount = SecurityDefaults.MAX_COOKIE_COUNT_DEFAULT;
+
+    // Allow/block list defaults (empty = allow-all / block-none; enforced by AllowBlockListStage)
+    private Set<String> allowedHeaderNames = Set.of();
+    private Set<String> blockedHeaderNames = Set.of();
+    private Set<String> allowedContentTypes = Set.of();
+    private Set<String> blockedContentTypes = Set.of();
 
     /**
      * Package-private constructor for internal use.
@@ -434,6 +444,56 @@ public class SecurityConfigurationBuilder {
         return this;
     }
 
+    // === Header / Content-Type Allow-Block List Methods ===
+
+    /**
+     * Sets the case-insensitive allow-list of header names. An empty set (the default) means
+     * allow-all. Enforced by {@code AllowBlockListStage} in the header-name pipeline.
+     *
+     * @param headerNames allowed header names (null is treated as empty)
+     * @return This builder for method chaining
+     */
+    public SecurityConfigurationBuilder allowedHeaderNames(@Nullable Set<String> headerNames) {
+        this.allowedHeaderNames = headerNames == null ? Set.of() : Set.copyOf(headerNames);
+        return this;
+    }
+
+    /**
+     * Sets the case-insensitive block-list of header names (takes precedence over the allow-list).
+     * Enforced by {@code AllowBlockListStage} in the header-name pipeline.
+     *
+     * @param headerNames blocked header names (null is treated as empty)
+     * @return This builder for method chaining
+     */
+    public SecurityConfigurationBuilder blockedHeaderNames(@Nullable Set<String> headerNames) {
+        this.blockedHeaderNames = headerNames == null ? Set.of() : Set.copyOf(headerNames);
+        return this;
+    }
+
+    /**
+     * Sets the case-insensitive allow-list of content types. An empty set (the default) means
+     * allow-all. Enforced by the content-type validator ({@code AllowBlockListStage}).
+     *
+     * @param contentTypes allowed content types (null is treated as empty)
+     * @return This builder for method chaining
+     */
+    public SecurityConfigurationBuilder allowedContentTypes(@Nullable Set<String> contentTypes) {
+        this.allowedContentTypes = contentTypes == null ? Set.of() : Set.copyOf(contentTypes);
+        return this;
+    }
+
+    /**
+     * Sets the case-insensitive block-list of content types (takes precedence over the allow-list).
+     * Enforced by the content-type validator ({@code AllowBlockListStage}).
+     *
+     * @param contentTypes blocked content types (null is treated as empty)
+     * @return This builder for method chaining
+     */
+    public SecurityConfigurationBuilder blockedContentTypes(@Nullable Set<String> contentTypes) {
+        this.blockedContentTypes = contentTypes == null ? Set.of() : Set.copyOf(contentTypes);
+        return this;
+    }
+
     /**
      * Builds the SecurityConfiguration with the current settings.
      *
@@ -450,7 +510,8 @@ public class SecurityConfigurationBuilder {
                 allowNullBytes, allowControlCharacters, allowExtendedAscii, normalizeUnicode,
                 caseSensitiveComparison, failOnSuspiciousPatterns,
                 requireSecureCookies, requireHttpOnlyCookies,
-                maxParameterCount, maxHeaderCount, maxCookieCount
+                maxParameterCount, maxHeaderCount, maxCookieCount,
+                allowedHeaderNames, blockedHeaderNames, allowedContentTypes, blockedContentTypes
         );
     }
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java
@@ -97,6 +97,10 @@ public class SecurityConfigurationBuilder {
     private boolean caseSensitiveComparison = false;
     private boolean failOnSuspiciousPatterns = false;
 
+    // Cookie Security defaults (opt-in; enforced by CookiePrefixValidationStage.validateCookie)
+    private boolean requireSecureCookies = false;
+    private boolean requireHttpOnlyCookies = false;
+
     /**
      * Package-private constructor for internal use.
      */
@@ -340,6 +344,37 @@ public class SecurityConfigurationBuilder {
         return this;
     }
 
+    // === Cookie Security Methods ===
+
+    /**
+     * Sets whether cookies must carry the {@code Secure} attribute.
+     *
+     * <p>Enforced by {@code CookiePrefixValidationStage.validateCookie(Cookie)}. Opt-in
+     * (default {@code false}); meaningful only for attribute-bearing (Set-Cookie) cookies,
+     * not for request {@code Cookie}-header {@code name=value} pairs.</p>
+     *
+     * @param require true to require the Secure attribute on validated cookies
+     * @return This builder for method chaining
+     */
+    public SecurityConfigurationBuilder requireSecureCookies(boolean require) {
+        this.requireSecureCookies = require;
+        return this;
+    }
+
+    /**
+     * Sets whether cookies must carry the {@code HttpOnly} attribute.
+     *
+     * <p>Enforced by {@code CookiePrefixValidationStage.validateCookie(Cookie)}. Opt-in
+     * (default {@code false}); meaningful only for attribute-bearing (Set-Cookie) cookies.</p>
+     *
+     * @param require true to require the HttpOnly attribute on validated cookies
+     * @return This builder for method chaining
+     */
+    public SecurityConfigurationBuilder requireHttpOnlyCookies(boolean require) {
+        this.requireHttpOnlyCookies = require;
+        return this;
+    }
+
     /**
      * Builds the SecurityConfiguration with the current settings.
      *
@@ -354,7 +389,8 @@ public class SecurityConfigurationBuilder {
                 maxCookieNameLength, maxCookieValueLength,
                 maxBodySize,
                 allowNullBytes, allowControlCharacters, allowExtendedAscii, normalizeUnicode,
-                caseSensitiveComparison, failOnSuspiciousPatterns
+                caseSensitiveComparison, failOnSuspiciousPatterns,
+                requireSecureCookies, requireHttpOnlyCookies
         );
     }
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java
@@ -101,6 +101,11 @@ public class SecurityConfigurationBuilder {
     private boolean requireSecureCookies = false;
     private boolean requireHttpOnlyCookies = false;
 
+    // Collection count defaults (enforced by RequestCollectionValidator)
+    private int maxParameterCount = SecurityDefaults.MAX_PARAMETER_COUNT_DEFAULT;
+    private int maxHeaderCount = SecurityDefaults.MAX_HEADER_COUNT_DEFAULT;
+    private int maxCookieCount = SecurityDefaults.MAX_COOKIE_COUNT_DEFAULT;
+
     /**
      * Package-private constructor for internal use.
      */
@@ -375,6 +380,60 @@ public class SecurityConfigurationBuilder {
         return this;
     }
 
+    // === Collection Count Methods ===
+
+    /**
+     * Sets the maximum number of request parameters.
+     *
+     * <p>Enforced by the collection-level {@code RequestCollectionValidator} (a single-value
+     * pipeline cannot count a collection). Defends against parameter-flood / hash-collision DoS.</p>
+     *
+     * @param maxCount Maximum parameter count (must be positive)
+     * @return This builder for method chaining
+     * @throws IllegalArgumentException if maxCount is not positive
+     */
+    public SecurityConfigurationBuilder maxParameterCount(int maxCount) {
+        if (maxCount <= 0) {
+            throw new IllegalArgumentException("maxParameterCount must be positive, got: " + maxCount);
+        }
+        this.maxParameterCount = maxCount;
+        return this;
+    }
+
+    /**
+     * Sets the maximum number of request headers.
+     *
+     * <p>Enforced by the collection-level {@code RequestCollectionValidator}.</p>
+     *
+     * @param maxCount Maximum header count (must be positive)
+     * @return This builder for method chaining
+     * @throws IllegalArgumentException if maxCount is not positive
+     */
+    public SecurityConfigurationBuilder maxHeaderCount(int maxCount) {
+        if (maxCount <= 0) {
+            throw new IllegalArgumentException("maxHeaderCount must be positive, got: " + maxCount);
+        }
+        this.maxHeaderCount = maxCount;
+        return this;
+    }
+
+    /**
+     * Sets the maximum number of request cookies.
+     *
+     * <p>Enforced by the collection-level {@code RequestCollectionValidator}.</p>
+     *
+     * @param maxCount Maximum cookie count (must be positive)
+     * @return This builder for method chaining
+     * @throws IllegalArgumentException if maxCount is not positive
+     */
+    public SecurityConfigurationBuilder maxCookieCount(int maxCount) {
+        if (maxCount <= 0) {
+            throw new IllegalArgumentException("maxCookieCount must be positive, got: " + maxCount);
+        }
+        this.maxCookieCount = maxCount;
+        return this;
+    }
+
     /**
      * Builds the SecurityConfiguration with the current settings.
      *
@@ -390,7 +449,8 @@ public class SecurityConfigurationBuilder {
                 maxBodySize,
                 allowNullBytes, allowControlCharacters, allowExtendedAscii, normalizeUnicode,
                 caseSensitiveComparison, failOnSuspiciousPatterns,
-                requireSecureCookies, requireHttpOnlyCookies
+                requireSecureCookies, requireHttpOnlyCookies,
+                maxParameterCount, maxHeaderCount, maxCookieCount
         );
     }
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java
@@ -283,9 +283,15 @@ public class SecurityConfigurationBuilder {
     }
 
     /**
-     * Sets whether Unicode normalization should be performed.
+     * Sets whether Unicode normalization is performed during decoding.
      *
-     * @param normalize true to normalize Unicode, false to leave as-is
+     * <p>When enabled, input is canonicalized and the canonical form is passed to downstream
+     * stages (normalize-and-continue). The stage rejects input only when a fold introduces a
+     * structurally significant separator (such as a fullwidth solidus folding to {@code /});
+     * benign compatibility folds of legitimate international text are preserved. When disabled,
+     * input is left as-is.</p>
+     *
+     * @param normalize true to canonicalize Unicode, false to leave as-is
      * @return This builder for method chaining
      */
     public SecurityConfigurationBuilder normalizeUnicode(boolean normalize) {

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java
@@ -321,7 +321,8 @@ public final class SecurityDefaults {
             MAX_COOKIE_NAME_LENGTH_STRICT, MAX_COOKIE_VALUE_LENGTH_STRICT,
             MAX_BODY_SIZE_STRICT,
             false, false, false, true, // no null bytes, no control chars, no extended ASCII, normalize Unicode
-            true, true); // case-sensitive comparison, fail on suspicious patterns
+            true, true, // case-sensitive comparison, fail on suspicious patterns
+            false, false); // requireSecureCookies, requireHttpOnlyCookies (opt-in)
 
     /**
      * Configuration preset for balanced security and usability.
@@ -347,5 +348,6 @@ public final class SecurityDefaults {
             MAX_COOKIE_NAME_LENGTH_LENIENT, MAX_COOKIE_VALUE_LENGTH_LENIENT,
             MAX_BODY_SIZE_LENIENT,
             false, true, true, false, // no null bytes (never allowed), control chars, extended ASCII, no normalization
-            false, false); // case-insensitive comparison, no suspicious-pattern failures
+            false, false, // case-insensitive comparison, no suspicious-pattern failures
+            false, false); // requireSecureCookies, requireHttpOnlyCookies (opt-in)
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java
@@ -323,7 +323,8 @@ public final class SecurityDefaults {
             false, false, false, true, // no null bytes, no control chars, no extended ASCII, normalize Unicode
             true, true, // case-sensitive comparison, fail on suspicious patterns
             false, false, // requireSecureCookies, requireHttpOnlyCookies (opt-in)
-            MAX_PARAMETER_COUNT_STRICT, MAX_HEADER_COUNT_STRICT, MAX_COOKIE_COUNT_STRICT);
+            MAX_PARAMETER_COUNT_STRICT, MAX_HEADER_COUNT_STRICT, MAX_COOKIE_COUNT_STRICT,
+            Set.of(), Set.of(), Set.of(), Set.of()); // allow/block lists (empty = allow-all, opt-in)
 
     /**
      * Configuration preset for balanced security and usability.
@@ -351,5 +352,6 @@ public final class SecurityDefaults {
             false, true, true, false, // no null bytes (never allowed), control chars, extended ASCII, no normalization
             false, false, // case-insensitive comparison, no suspicious-pattern failures
             false, false, // requireSecureCookies, requireHttpOnlyCookies (opt-in)
-            MAX_PARAMETER_COUNT_LENIENT, MAX_HEADER_COUNT_LENIENT, MAX_COOKIE_COUNT_LENIENT);
+            MAX_PARAMETER_COUNT_LENIENT, MAX_HEADER_COUNT_LENIENT, MAX_COOKIE_COUNT_LENIENT,
+            Set.of(), Set.of(), Set.of(), Set.of()); // allow/block lists (empty = allow-all, opt-in)
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java
@@ -42,12 +42,12 @@ import java.util.Set;
  *   <li><strong>Configuration Presets</strong> - Pre-built configurations for common scenarios</li>
  * </ul>
  *
- * <h3>Advisory Constants</h3>
- * <p>The count limits (parameter/header/cookie counts) and header/content-type
- * classification sets are <strong>reference values for application-layer enforcement</strong>.
- * The validation pipelines in this library operate on single values and therefore cannot
- * enforce request-level policies such as counts or header allow/block lists - enforce
- * those in your request-processing layer using these constants as recommended values.</p>
+ * <h3>Count and Classification Constants</h3>
+ * <p>The count limits (parameter/header/cookie counts) are the preset defaults enforced by
+ * {@code RequestCollectionValidator} (parameters 100, headers 50, cookies 20; strict 20/20/10,
+ * lenient 500/100/50). The header/content-type classification sets
+ * ({@code DANGEROUS_HEADER_NAMES}, {@code DANGEROUS_CONTENT_TYPES}, etc.) remain reference
+ * values you may feed into the configurable allow/block lists.</p>
  *
  * <h3>Usage Examples</h3>
  * <pre>
@@ -322,7 +322,8 @@ public final class SecurityDefaults {
             MAX_BODY_SIZE_STRICT,
             false, false, false, true, // no null bytes, no control chars, no extended ASCII, normalize Unicode
             true, true, // case-sensitive comparison, fail on suspicious patterns
-            false, false); // requireSecureCookies, requireHttpOnlyCookies (opt-in)
+            false, false, // requireSecureCookies, requireHttpOnlyCookies (opt-in)
+            MAX_PARAMETER_COUNT_STRICT, MAX_HEADER_COUNT_STRICT, MAX_COOKIE_COUNT_STRICT);
 
     /**
      * Configuration preset for balanced security and usability.
@@ -349,5 +350,6 @@ public final class SecurityDefaults {
             MAX_BODY_SIZE_LENIENT,
             false, true, true, false, // no null bytes (never allowed), control chars, extended ASCII, no normalization
             false, false, // case-insensitive comparison, no suspicious-pattern failures
-            false, false); // requireSecureCookies, requireHttpOnlyCookies (opt-in)
+            false, false, // requireSecureCookies, requireHttpOnlyCookies (opt-in)
+            MAX_PARAMETER_COUNT_LENIENT, MAX_HEADER_COUNT_LENIENT, MAX_COOKIE_COUNT_LENIENT);
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/security/core/UrlSecurityFailureType.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/core/UrlSecurityFailureType.java
@@ -85,6 +85,9 @@ public enum UrlSecurityFailureType {
     /** Excessive directory nesting depth detected */
     EXCESSIVE_NESTING("Excessive directory nesting"),
 
+    /** A collection (parameters, headers, cookies) exceeds its configured maximum count */
+    TOO_MANY_ELEMENTS("Too many elements in collection"),
+
     // === Pattern-Based Detection ===
 
     /** Suspicious patterns that match attack signatures */
@@ -197,7 +200,8 @@ public enum UrlSecurityFailureType {
     public boolean isSizeViolation() {
         return this == PATH_TOO_LONG ||
                 this == INPUT_TOO_LONG ||
-                this == EXCESSIVE_NESTING;
+                this == EXCESSIVE_NESTING ||
+                this == TOO_MANY_ELEMENTS;
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/ContentTypeValidationPipeline.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/ContentTypeValidationPipeline.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.security.pipeline;
+
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.core.HttpSecurityValidator;
+import de.cuioss.http.security.core.ValidationType;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.validation.AllowBlockListStage;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Validation pipeline for HTTP {@code Content-Type} values, enforcing the configured
+ * content-type allow/block lists.
+ *
+ * <p>A content type travels as a header value, so this pipeline reports {@link ValidationType#HEADER_VALUE}.
+ * It applies {@link AllowBlockListStage#forContentTypes(SecurityConfiguration)}: a value present in
+ * {@code blockedContentTypes} is rejected, and - if {@code allowedContentTypes} is non-empty - any
+ * value not in it is rejected (empty allow-list = allow-all). Security violations are recorded on the
+ * supplied {@link SecurityEventCounter}, consistent with the other pipelines.</p>
+ *
+ * @since 1.0
+ */
+@EqualsAndHashCode(callSuper = false, of = {})
+@ToString(callSuper = true)
+@Getter
+public final class ContentTypeValidationPipeline extends AbstractValidationPipeline {
+
+    private static final ValidationType VALIDATION_TYPE = ValidationType.HEADER_VALUE;
+
+    /**
+     * Creates a new content-type validation pipeline with the specified configuration.
+     *
+     * @param config The security configuration to use
+     * @param eventCounter The counter for tracking security events
+     * @throws NullPointerException if config or eventCounter is null
+     */
+    public ContentTypeValidationPipeline(SecurityConfiguration config,
+            SecurityEventCounter eventCounter) {
+        super(createStages(config), Objects.requireNonNull(eventCounter, "EventCounter must not be null"));
+    }
+
+    private static List<HttpSecurityValidator> createStages(SecurityConfiguration config) {
+        Objects.requireNonNull(config, "Config must not be null");
+        return List.of(AllowBlockListStage.forContentTypes(config));
+    }
+
+    @Override
+    public ValidationType getValidationType() {
+        return VALIDATION_TYPE;
+    }
+}

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java
@@ -19,6 +19,7 @@ import de.cuioss.http.security.config.SecurityConfiguration;
 import de.cuioss.http.security.core.HttpSecurityValidator;
 import de.cuioss.http.security.core.ValidationType;
 import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.validation.AllowBlockListStage;
 import de.cuioss.http.security.validation.CharacterValidationStage;
 import de.cuioss.http.security.validation.LengthValidationStage;
 import de.cuioss.http.security.validation.NormalizationStage;
@@ -27,6 +28,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -39,6 +41,8 @@ import java.util.Objects;
  *   <li><strong>Character Validation</strong> - Validates RFC 7230 header characters</li>
  *   <li><strong>Normalization</strong> - Header normalization and security checks</li>
  *   <li><strong>Pattern Matching</strong> - Detects injection attacks and suspicious patterns</li>
+ *   <li><strong>Allow/Block List</strong> - (header names only) enforces the configured
+ *       {@code allowedHeaderNames}/{@code blockedHeaderNames} lists</li>
  * </ol>
  *
  * <h3>Design Principles</h3>
@@ -113,12 +117,17 @@ public final class HTTPHeaderValidationPipeline extends AbstractValidationPipeli
 
         // Create validation stages in the correct order for HTTP headers
         // Note: Headers typically don't need URL decoding, so we skip DecodingStage
-        return List.of(
+        List<HttpSecurityValidator> stages = new ArrayList<>(List.of(
                 new LengthValidationStage(config, validationType),
                 new CharacterValidationStage(config, validationType),
                 new NormalizationStage(config, validationType),
                 new PatternMatchingStage(config, validationType)
-        );
+        ));
+        // Header-name allow/block list enforcement (empty lists => no-op, allow-all).
+        if (validationType == ValidationType.HEADER_NAME) {
+            stages.add(AllowBlockListStage.forHeaderNames(config));
+        }
+        return List.copyOf(stages);
     }
 
     @Override

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java
@@ -133,20 +133,20 @@ public final class PipelineFactory {
      *   <li>Injection attempts</li>
      * </ul>
      *
-     * <p><strong>Note:</strong> parameter names currently share the exact same
-     * validation as parameter values (they use {@link URLParameterValidationPipeline}).
-     * A dedicated, stricter name-only pipeline is not yet implemented; this method
-     * exists so callers can express intent and so stricter rules can be added later
-     * without changing call sites.</p>
+     * <p>Parameter names are validated with genuine name-only rules via a
+     * {@link URLParameterNameValidationPipeline} (typed {@link ValidationType#PARAMETER_NAME}),
+     * <strong>not</strong> the parameter-value pipeline. In particular, decoded CR/LF and
+     * decoded parameter delimiters ({@code = &amp; ; space}) are rejected for names, and the
+     * stricter {@code maxParameterNameLength} limit applies.</p>
      *
      * @param config The security configuration to use
      * @param eventCounter The event counter for tracking security violations
-     * @return A configured URL parameter validation pipeline (currently identical to the value pipeline)
+     * @return A configured URL parameter name validation pipeline
      * @throws NullPointerException if config or eventCounter is null
      */
     public static HttpSecurityValidator createParameterNamePipeline(
             SecurityConfiguration config, SecurityEventCounter eventCounter) {
-        return new URLParameterValidationPipeline(config, eventCounter);
+        return new URLParameterNameValidationPipeline(config, eventCounter);
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java
@@ -195,6 +195,24 @@ public final class PipelineFactory {
 
 
     /**
+     * Creates a content-type validation pipeline that enforces the configured content-type
+     * allow/block lists ({@code allowedContentTypes} / {@code blockedContentTypes}).
+     *
+     * <p>Content types are single values checkable against a set; this pipeline applies the
+     * block-list (precedence) then the allow-list (empty = allow-all). Because a content type
+     * travels as a header value, the pipeline reports {@link ValidationType#HEADER_VALUE}.</p>
+     *
+     * @param config The security configuration to use
+     * @param eventCounter The event counter for tracking security violations
+     * @return A configured content-type validation pipeline
+     * @throws NullPointerException if config or eventCounter is null
+     */
+    public static HttpSecurityValidator createContentTypePipeline(
+            SecurityConfiguration config, SecurityEventCounter eventCounter) {
+        return new ContentTypeValidationPipeline(config, eventCounter);
+    }
+
+    /**
      * Generic factory method that creates the appropriate validation pipeline
      * based on the specified validation type.
      *

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLParameterNameValidationPipeline.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLParameterNameValidationPipeline.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.security.pipeline;
+
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.core.HttpSecurityValidator;
+import de.cuioss.http.security.core.ValidationType;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.validation.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Sequential validation pipeline specifically for URL parameter <em>names</em> (query keys).
+ *
+ * <p>Unlike parameter <em>values</em>, parameter names are structural: they must not carry
+ * delimiters or line breaks. This pipeline is typed {@link ValidationType#PARAMETER_NAME}, so
+ * name-only rules apply - in particular {@code DecodingStage} forbids decoded CR/LF and other
+ * structural characters ({@code = &amp; ; space}) for names, closing the encoded-delimiter
+ * injection gap that routing names through the value pipeline left open.</p>
+ *
+ * <h3>Validation Sequence</h3>
+ * <ol>
+ *   <li><strong>Length Validation</strong> - Enforces the parameter <em>name</em> length limit</li>
+ *   <li><strong>Character Validation</strong> - Validates RFC 3986 query characters</li>
+ *   <li><strong>Decoding</strong> - URL decodes with security checks (name-strict CR/LF and
+ *       delimiter rejection on the decoded output)</li>
+ *   <li><strong>Normalization</strong> - Normalization and security checks</li>
+ *   <li><strong>Pattern Matching</strong> - Detects suspicious parameter names and injection attacks</li>
+ * </ol>
+ *
+ * @since 1.0
+ */
+@EqualsAndHashCode(callSuper = false, of = {})
+@ToString(callSuper = true)
+@Getter
+public final class URLParameterNameValidationPipeline extends AbstractValidationPipeline {
+
+    private static final ValidationType VALIDATION_TYPE = ValidationType.PARAMETER_NAME;
+
+    /**
+     * Creates a new URL parameter name validation pipeline with the specified configuration.
+     *
+     * @param config The security configuration to use
+     * @param eventCounter The counter for tracking security events
+     * @throws NullPointerException if config or eventCounter is null
+     */
+    public URLParameterNameValidationPipeline(SecurityConfiguration config,
+            SecurityEventCounter eventCounter) {
+        super(createStages(config), Objects.requireNonNull(eventCounter, "EventCounter must not be null"));
+    }
+
+    private static List<HttpSecurityValidator> createStages(SecurityConfiguration config) {
+        Objects.requireNonNull(config, "Config must not be null");
+        // Stages are typed PARAMETER_NAME so that name-only rules (stricter length limit,
+        // decoded delimiter/CR-LF rejection, suspicious-name detection) are actually applied.
+        return List.of(
+                new LengthValidationStage(config, ValidationType.PARAMETER_NAME),
+                new CharacterValidationStage(config, ValidationType.PARAMETER_NAME),
+                new DecodingStage(config, ValidationType.PARAMETER_NAME),
+                new NormalizationStage(config, ValidationType.PARAMETER_NAME),
+                new PatternMatchingStage(config, ValidationType.PARAMETER_NAME)
+        );
+    }
+
+    @Override
+    public ValidationType getValidationType() {
+        return VALIDATION_TYPE;
+    }
+}

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/AllowBlockListStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/AllowBlockListStage.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.security.validation;
+
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.core.HttpSecurityValidator;
+import de.cuioss.http.security.core.UrlSecurityFailureType;
+import de.cuioss.http.security.core.ValidationType;
+import de.cuioss.http.security.exceptions.UrlSecurityException;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.jspecify.annotations.Nullable;
+
+import java.util.*;
+
+/**
+ * Allow/block-list enforcement stage for single-value HTTP components (header names, content types).
+ *
+ * <p>A single header name or content-type value <em>is</em> checkable against a set - correcting
+ * PR #74's over-broad claim that allow/block lists "fundamentally can't be enforced by single-value
+ * validation pipelines". This stage restores that enforcement: it tests one value against the
+ * configured, <strong>case-insensitive</strong> allow and block lists (precomputed to lowercase at
+ * construction, mirroring the lookup sets #74 deleted).</p>
+ *
+ * <h3>Semantics</h3>
+ * <ul>
+ *   <li><strong>Block-list precedence</strong> - a value present in the block-list is rejected
+ *       regardless of the allow-list.</li>
+ *   <li><strong>Empty allow-list = allow-all</strong> - an empty allow-list imposes no restriction
+ *       (it does <em>not</em> deny-all); a non-empty allow-list rejects any value not in it.</li>
+ *   <li><strong>Case-insensitive</strong> - comparison is done on the lowercased value.</li>
+ * </ul>
+ *
+ * <p>Use {@link #forHeaderNames(SecurityConfiguration)} for the header-name lists (wired into the
+ * header-name pipeline) and {@link #forContentTypes(SecurityConfiguration)} for the content-type
+ * lists.</p>
+ *
+ * @since 1.0
+ */
+@EqualsAndHashCode
+@ToString
+public final class AllowBlockListStage implements HttpSecurityValidator {
+
+    private final Set<String> allowedLowercase;
+    private final Set<String> blockedLowercase;
+    private final ValidationType validationType;
+    private final boolean mediaTypeOnly;
+
+    /**
+     * Creates an allow/block-list stage that matches the whole value.
+     *
+     * @param allowed the allow-list (empty = allow-all); compared case-insensitively
+     * @param blocked the block-list (takes precedence); compared case-insensitively
+     * @param validationType the validation type used in emitted exceptions
+     * @throws NullPointerException if any argument is null
+     */
+    public AllowBlockListStage(Set<String> allowed, Set<String> blocked, ValidationType validationType) {
+        this(allowed, blocked, validationType, false);
+    }
+
+    /**
+     * Creates an allow/block-list stage.
+     *
+     * @param allowed the allow-list (empty = allow-all); compared case-insensitively
+     * @param blocked the block-list (takes precedence); compared case-insensitively
+     * @param validationType the validation type used in emitted exceptions
+     * @param mediaTypeOnly when {@code true}, only the media type of the value is matched: any
+     *        parameters (everything from the first {@code ;}) and surrounding whitespace are
+     *        stripped before comparison, so {@code application/json; charset=UTF-8} matches an
+     *        {@code application/json} list entry
+     * @throws NullPointerException if any argument is null
+     */
+    public AllowBlockListStage(Set<String> allowed, Set<String> blocked, ValidationType validationType,
+            boolean mediaTypeOnly) {
+        Objects.requireNonNull(allowed, "allowed must not be null");
+        Objects.requireNonNull(blocked, "blocked must not be null");
+        this.validationType = Objects.requireNonNull(validationType, "validationType must not be null");
+        this.mediaTypeOnly = mediaTypeOnly;
+        this.allowedLowercase = toLowercaseSet(allowed);
+        this.blockedLowercase = toLowercaseSet(blocked);
+    }
+
+    private static Set<String> toLowercaseSet(Set<String> source) {
+        Set<String> lower = HashSet.newHashSet(source.size());
+        for (String value : source) {
+            lower.add(value.toLowerCase(Locale.ROOT));
+        }
+        return Set.copyOf(lower);
+    }
+
+    /**
+     * Creates a stage enforcing the header-name allow/block lists from the configuration.
+     *
+     * @param config the security configuration
+     * @return a header-name allow/block-list stage
+     */
+    public static AllowBlockListStage forHeaderNames(SecurityConfiguration config) {
+        Objects.requireNonNull(config, "config must not be null");
+        return new AllowBlockListStage(config.allowedHeaderNames(), config.blockedHeaderNames(),
+                ValidationType.HEADER_NAME);
+    }
+
+    /**
+     * Creates a stage enforcing the content-type allow/block lists from the configuration.
+     *
+     * @param config the security configuration
+     * @return a content-type allow/block-list stage
+     */
+    public static AllowBlockListStage forContentTypes(SecurityConfiguration config) {
+        Objects.requireNonNull(config, "config must not be null");
+        // Content types travel as a header value; use HEADER_VALUE as the reported type.
+        // Match on media type only so parameters (e.g. "; charset=UTF-8") do not defeat the lists.
+        return new AllowBlockListStage(config.allowedContentTypes(), config.blockedContentTypes(),
+                ValidationType.HEADER_VALUE, true);
+    }
+
+    @Override
+    public Optional<String> validate(@Nullable String value) throws UrlSecurityException {
+        if (value == null) {
+            return Optional.empty();
+        }
+        if (value.isEmpty()) {
+            return Optional.of(value);
+        }
+
+        String lower = comparisonKey(value);
+
+        if (blockedLowercase.contains(lower)) {
+            throw UrlSecurityException.builder()
+                    .failureType(UrlSecurityFailureType.INVALID_INPUT)
+                    .validationType(validationType)
+                    .originalInput(value)
+                    .detail("Value '" + value + "' is block-listed")
+                    .build();
+        }
+
+        if (!allowedLowercase.isEmpty() && !allowedLowercase.contains(lower)) {
+            throw UrlSecurityException.builder()
+                    .failureType(UrlSecurityFailureType.INVALID_INPUT)
+                    .validationType(validationType)
+                    .originalInput(value)
+                    .detail("Value '" + value + "' is not in the allow-list")
+                    .build();
+        }
+
+        return Optional.of(value);
+    }
+
+    /**
+     * Computes the lowercase key used for allow/block-list membership. In {@code mediaTypeOnly}
+     * mode the media type is isolated by dropping any parameters (from the first {@code ;}) and
+     * trimming surrounding whitespace.
+     */
+    private String comparisonKey(String value) {
+        String candidate = value;
+        if (mediaTypeOnly) {
+            int semicolon = candidate.indexOf(';');
+            if (semicolon >= 0) {
+                candidate = candidate.substring(0, semicolon);
+            }
+            candidate = candidate.trim();
+        }
+        return candidate.toLowerCase(Locale.ROOT);
+    }
+}

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java
@@ -239,4 +239,36 @@ public final class CharacterValidationConstants {
             case COOKIE_NAME, COOKIE_VALUE -> RFC3986_UNRESERVED;
         };
     }
+
+    /**
+     * Determines whether a character is a Unicode combining mark.
+     *
+     * <p>Combining marks attach to and alter the rendering of an adjacent base character.
+     * When present in HTTP components they can visually spoof legitimate values and enable
+     * homograph attacks, so they are rejected across all components regardless of which
+     * Unicode block they inhabit.</p>
+     *
+     * <p>This membership test uses the character's general category rather than a fixed
+     * range, covering <em>all</em> combining blocks:</p>
+     * <ul>
+     *   <li>{@link Character#NON_SPACING_MARK} (Mn) - e.g. Combining Diacritical Marks
+     *       (U+0300-U+036F), Combining Cyrillic (U+0483-U+0489), Combining Half Marks
+     *       (U+FE20-U+FE2F)</li>
+     *   <li>{@link Character#COMBINING_SPACING_MARK} (Mc) - spacing combining marks used in
+     *       many Indic scripts</li>
+     *   <li>{@link Character#ENCLOSING_MARK} (Me) - enclosing marks such as U+20DD-U+20E0</li>
+     * </ul>
+     *
+     * <p>This replaces the previous hardcoded {@code U+0300-U+036F} range check, which covered
+     * only the "Combining Diacritical Marks" block and missed every other combining block.</p>
+     *
+     * @param codePoint the character (or code point) to classify
+     * @return {@code true} if the character is a combining mark
+     */
+    public static boolean isCombiningMark(int codePoint) {
+        int type = Character.getType(codePoint);
+        return type == Character.NON_SPACING_MARK
+                || type == Character.COMBINING_SPACING_MARK
+                || type == Character.ENCLOSING_MARK;
+    }
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java
@@ -18,13 +18,20 @@ package de.cuioss.http.security.validation;
 import de.cuioss.http.security.core.ValidationType;
 
 import java.util.BitSet;
+import java.util.function.IntPredicate;
 
 /**
  * RFC-compliant character set definitions for HTTP component validation.
  *
- * <p>This utility class provides pre-computed BitSet instances containing allowed characters
- * for different HTTP components according to RFC 3986 (URI) and RFC 7230 (HTTP) specifications.
- * All character sets provide O(1) character lookups.</p>
+ * <p>This utility class exposes the allowed-character sets for different HTTP components
+ * according to RFC 3986 (URI) and RFC 7230 (HTTP) specifications as immutable
+ * {@link IntPredicate} membership tests. The predicates are backed by pre-computed,
+ * <strong>private</strong> {@link BitSet} instances and provide O(1) character lookups.</p>
+ *
+ * <p><strong>Immutability:</strong> the backing {@code BitSet}s are private and never handed
+ * out, so the security character rules cannot be corrupted by any JVM code. Callers receive an
+ * {@link IntPredicate} membership test ({@code predicate.test(ch)}) with no mutation vector,
+ * replacing the previous mutable {@code public static final BitSet} fields.</p>
  *
  * <h3>Design Principles</h3>
  * <ul>
@@ -46,17 +53,17 @@ import java.util.BitSet;
  * <h3>Usage Examples</h3>
  * <pre>
  * // Get character set for URL path validation
- * BitSet pathChars = CharacterValidationConstants.getCharacterSet(ValidationType.URL_PATH);
+ * IntPredicate pathChars = CharacterValidationConstants.getCharacterSet(ValidationType.URL_PATH);
  *
  * // Check if character is allowed in URL paths
  * char ch = '/';
- * boolean isAllowed = pathChars.get(ch); // Returns true
+ * boolean isAllowed = pathChars.test(ch); // Returns true
  *
  * // Validate string characters
  * String input = "/api/users";
  * for (int i = 0; i &lt; input.length(); i++) {
  *     char c = input.charAt(i);
- *     if (!pathChars.get(c)) {
+ *     if (!pathChars.test(c)) {
  *         throw new IllegalArgumentException("Invalid character: " + c);
  *     }
  * }
@@ -95,32 +102,37 @@ public final class CharacterValidationConstants {
     /**
      * RFC 3986 unreserved characters: ALPHA / DIGIT / "-" / "." / "_" / "~".
      * <p>These are the basic safe characters allowed in URIs without percent-encoding.</p>
+     * <p>Immutable membership test; the backing {@link BitSet} is private and cannot be mutated.</p>
      */
-    public static final BitSet RFC3986_UNRESERVED;
+    public static final IntPredicate RFC3986_UNRESERVED;
 
     /**
      * RFC 3986 path characters including unreserved + path-specific characters.
      * <p>Includes all unreserved characters plus: / @ : ! $ &amp; ' ( ) * + , ; =</p>
+     * <p>Immutable membership test; the backing {@link BitSet} is private and cannot be mutated.</p>
      */
-    public static final BitSet RFC3986_PATH_CHARS;
+    public static final IntPredicate RFC3986_PATH_CHARS;
 
     /**
      * RFC 3986 query characters including unreserved + query-specific characters.
      * <p>Includes all unreserved characters plus: ? &amp; = ! $ ' ( ) * + , ;</p>
+     * <p>Immutable membership test; the backing {@link BitSet} is private and cannot be mutated.</p>
      */
-    public static final BitSet RFC3986_QUERY_CHARS;
+    public static final IntPredicate RFC3986_QUERY_CHARS;
 
     /**
      * RFC 7230 header field characters (visible ASCII minus delimiters).
      * <p>Includes space through tilde (32-126) plus tab character.</p>
+     * <p>Immutable membership test; the backing {@link BitSet} is private and cannot be mutated.</p>
      */
-    public static final BitSet RFC7230_HEADER_CHARS;
+    public static final IntPredicate RFC7230_HEADER_CHARS;
 
     /**
      * HTTP body content characters (permissive for JSON, XML, text, etc.).
      * <p>Includes printable ASCII (32-126), tab, LF, CR, and extended ASCII (128-255).</p>
+     * <p>Immutable membership test; the backing {@link BitSet} is private and cannot be mutated.</p>
      */
-    public static final BitSet HTTP_BODY_CHARS;
+    public static final IntPredicate HTTP_BODY_CHARS;
 
     static {
         // Initialize RFC3986_UNRESERVED
@@ -135,7 +147,8 @@ public final class CharacterValidationConstants {
         unreserved.set('.');
         unreserved.set('_');
         unreserved.set('~');
-        RFC3986_UNRESERVED = unreserved;
+        // Publish as an immutable membership test bound to the private BitSet.
+        RFC3986_UNRESERVED = unreserved::get;
 
         // Initialize RFC3986_PATH_CHARS
         BitSet pathChars = new BitSet(256);
@@ -145,7 +158,7 @@ public final class CharacterValidationConstants {
         pathChars.set(':');
         // sub-delims for path: "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
         "!$&'()*+,;=".chars().forEach(pathChars::set);
-        RFC3986_PATH_CHARS = pathChars;
+        RFC3986_PATH_CHARS = pathChars::get;
 
         // Initialize RFC3986_QUERY_CHARS
         BitSet queryChars = new BitSet(256);
@@ -155,7 +168,7 @@ public final class CharacterValidationConstants {
         queryChars.set('=');
         // sub-delims for query
         "!$'()*+,;".chars().forEach(queryChars::set);
-        RFC3986_QUERY_CHARS = queryChars;
+        RFC3986_QUERY_CHARS = queryChars::get;
 
         // Initialize RFC7230_HEADER_CHARS
         BitSet headerChars = new BitSet(256);
@@ -167,7 +180,7 @@ public final class CharacterValidationConstants {
         headerChars.set('\t'); // Tab is allowed in headers
         // Only exclude characters that could break HTTP: CR, LF, NULL
         // Note: Other dangerous chars are handled at application level
-        RFC7230_HEADER_CHARS = headerChars;
+        RFC7230_HEADER_CHARS = headerChars::get;
 
         // Initialize HTTP_BODY_CHARS (very permissive for body content)
         BitSet bodyChars = new BitSet(256);
@@ -185,18 +198,18 @@ public final class CharacterValidationConstants {
         }
         // Note: Null bytes and other control chars (1-31) are excluded by default
         // They can be allowed via configuration if needed
-        HTTP_BODY_CHARS = bodyChars;
+        HTTP_BODY_CHARS = bodyChars::get;
     }
 
     /**
      * Returns the appropriate character set for the specified validation type.
      *
      * <p>This method provides a centralized mapping from validation types to their
-     * corresponding RFC-compliant character sets. The returned BitSet is a defensive
-     * copy: {@link BitSet} is mutable, and handing out the shared constant would let
-     * any caller corrupt the allowed-character rules for every validator in the JVM.
-     * The copy is created once per call (validators call this at construction, not
-     * per validation), so the cost is negligible.</p>
+     * corresponding RFC-compliant character sets. The returned {@link IntPredicate} is the
+     * <strong>shared, immutable</strong> membership test: because the backing {@link BitSet}
+     * is private and never exposed, there is no mutation vector and no defensive copy is
+     * required (nor is one made). This is both safer and faster than the previous
+     * clone-per-call approach.</p>
      *
      * <h4>Validation Type Mappings:</h4>
      * <ul>
@@ -208,7 +221,7 @@ public final class CharacterValidationConstants {
      * </ul>
      *
      * @param type The validation type specifying which HTTP component is being validated
-     * @return The corresponding BitSet containing allowed characters for the validation type
+     * @return The shared immutable {@link IntPredicate} membership test for the validation type
      * @throws NullPointerException if {@code type} is null
      * @see ValidationType
      * @see #RFC3986_PATH_CHARS
@@ -217,14 +230,13 @@ public final class CharacterValidationConstants {
      * @see #HTTP_BODY_CHARS
      * @see #RFC3986_UNRESERVED
      */
-    public static BitSet getCharacterSet(ValidationType type) {
-        BitSet characterSet = switch (type) {
+    public static IntPredicate getCharacterSet(ValidationType type) {
+        return switch (type) {
             case URL_PATH -> RFC3986_PATH_CHARS;
             case PARAMETER_NAME, PARAMETER_VALUE -> RFC3986_QUERY_CHARS;
             case HEADER_NAME, HEADER_VALUE -> RFC7230_HEADER_CHARS;
             case BODY -> HTTP_BODY_CHARS;
             case COOKIE_NAME, COOKIE_VALUE -> RFC3986_UNRESERVED;
         };
-        return (BitSet) characterSet.clone();
     }
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
@@ -24,8 +24,8 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.jspecify.annotations.Nullable;
 
-import java.util.BitSet;
 import java.util.Optional;
+import java.util.function.IntPredicate;
 
 /**
  * Character validation stage that enforces RFC-compliant character sets for HTTP components.
@@ -116,7 +116,7 @@ import java.util.Optional;
 @ToString
 public final class CharacterValidationStage implements HttpSecurityValidator {
 
-    private final BitSet allowedChars;
+    private final IntPredicate allowedChars;
     private final ValidationType validationType;
     private final boolean allowPercentEncoding;
     private final boolean allowNullBytes;
@@ -128,7 +128,8 @@ public final class CharacterValidationStage implements HttpSecurityValidator {
         this.allowNullBytes = config.allowNullBytes();
         this.allowControlCharacters = config.allowControlCharacters();
         this.allowExtendedAscii = config.allowExtendedAscii();
-        // Defensive copy per stage - the shared constants cannot be corrupted through this instance
+        // Shared immutable membership test - the backing character set is private and
+        // cannot be corrupted, so no per-stage defensive copy is needed.
         this.allowedChars = CharacterValidationConstants.getCharacterSet(type);
 
         // Determine if percent encoding is allowed based on type
@@ -297,7 +298,7 @@ public final class CharacterValidationStage implements HttpSecurityValidator {
                 return false;
             }
             // Always allow common whitespace characters that are in the base character set
-            if (allowedChars.get(ch)) {
+            if (allowedChars.test(ch)) {
                 return true;
             }
             // Other control characters depend on configuration
@@ -306,7 +307,7 @@ public final class CharacterValidationStage implements HttpSecurityValidator {
 
         // Characters 32-127 (basic ASCII) - check against the base character set
         if (ch <= 127) {
-            return allowedChars.get(ch);
+            return allowedChars.test(ch);
         }
 
         // Extended ASCII characters (128-255)
@@ -320,7 +321,7 @@ public final class CharacterValidationStage implements HttpSecurityValidator {
             }
             // For other types (URL paths, parameters, header values, body),
             // allow extended ASCII based on configuration
-            return allowExtendedAscii || allowedChars.get(ch);
+            return allowExtendedAscii || allowedChars.test(ch);
         }
 
         // Unicode characters above 255:
@@ -351,7 +352,7 @@ public final class CharacterValidationStage implements HttpSecurityValidator {
                 return UrlSecurityFailureType.INVALID_CHARACTER;
             }
             // If it's in the base character set, it's just an invalid character for this context
-            if (allowedChars.get(ch)) {
+            if (allowedChars.test(ch)) {
                 return UrlSecurityFailureType.INVALID_CHARACTER;
             }
             return UrlSecurityFailureType.CONTROL_CHARACTERS;

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
@@ -327,8 +327,9 @@ public final class CharacterValidationStage implements HttpSecurityValidator {
         // Unicode characters above 255:
         // For URLs (paths/parameters): Always rejected per RFC 3986 (ASCII-only)
         // For headers/body: Allowed if allowExtendedAscii is true (which enables full Unicode support for these contexts)
-        // Always reject combining characters (U+0300-U+036F) as they can cause normalization issues
-        if (ch >= 0x0300 && ch <= 0x036F) {
+        // Always reject combining marks (any Unicode combining block) as they can cause
+        // normalization issues and enable homograph attacks.
+        if (CharacterValidationConstants.isCombiningMark(ch)) {
             return false;
         }
         // The allowExtendedAscii flag controls both extended ASCII and Unicode for applicable validation types

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.http.security.validation;
 
+import de.cuioss.http.security.config.SecurityConfiguration;
 import de.cuioss.http.security.core.HttpSecurityValidator;
 import de.cuioss.http.security.core.UrlSecurityFailureType;
 import de.cuioss.http.security.core.ValidationType;
@@ -22,6 +23,7 @@ import de.cuioss.http.security.data.Cookie;
 import de.cuioss.http.security.exceptions.UrlSecurityException;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -30,6 +32,12 @@ import java.util.Optional;
  * <p>This stage validates that cookies with security prefixes ({@code __Host-} and {@code __Secure-})
  * meet the requirements specified in RFC 6265bis. These prefixes provide additional security
  * guarantees to prevent subdomain attacks and ensure HTTPS-only transmission.</p>
+ *
+ * <p>In addition, {@link #validateCookie(Cookie)} enforces the opt-in configuration flags
+ * {@code requireSecureCookies} and {@code requireHttpOnlyCookies} (both default {@code false}):
+ * when enabled, every validated cookie must carry the {@code Secure} / {@code HttpOnly}
+ * attribute respectively. These are meaningful only for attribute-bearing (Set-Cookie) cookies,
+ * not request {@code Cookie}-header {@code name=value} pairs.</p>
  *
  * <p><strong>Standalone stage:</strong> unlike the URL/parameter/header stages, this stage is
  * <em>not</em> part of any pipeline built by {@code PipelineFactory} (which does not support
@@ -114,7 +122,26 @@ import java.util.Optional;
  * @see <a href="https://portswigger.net/research/cookie-chaos-how-to-bypass-host-and-secure-cookie-prefixes">Cookie Chaos Research</a>
  * @since 1.0
  */
-public record CookiePrefixValidationStage() implements HttpSecurityValidator {
+public record CookiePrefixValidationStage(SecurityConfiguration config) implements HttpSecurityValidator {
+
+    /**
+     * Canonical constructor.
+     *
+     * @param config the security configuration driving optional attribute requirements
+     *               ({@code requireSecureCookies} / {@code requireHttpOnlyCookies}); must not be null
+     */
+    public CookiePrefixValidationStage {
+        Objects.requireNonNull(config, "config must not be null");
+    }
+
+    /**
+     * Creates a stage using the default configuration, i.e. only RFC 6265bis prefix rules
+     * (the {@code requireSecureCookies}/{@code requireHttpOnlyCookies} attribute requirements
+     * default to off).
+     */
+    public CookiePrefixValidationStage() {
+        this(SecurityConfiguration.defaults());
+    }
 
     /** Prefix for host-locked cookies */
     private static final String HOST_PREFIX = "__Host-";
@@ -181,6 +208,26 @@ public record CookiePrefixValidationStage() implements HttpSecurityValidator {
 
         // Validate name format (no leading/trailing whitespace)
         validate(cookieName);
+
+        // Opt-in attribute requirements (default off). Meaningful for attribute-bearing
+        // Set-Cookie cookies; a request Cookie-header name=value pair carries no attributes
+        // and would always fail if these are enabled - enable them only for the Set-Cookie side.
+        if (config.requireSecureCookies() && !cookie.isSecure()) {
+            throw UrlSecurityException.builder()
+                    .failureType(UrlSecurityFailureType.COOKIE_PREFIX_VIOLATION)
+                    .validationType(ValidationType.COOKIE_NAME)
+                    .originalInput(cookieName)
+                    .detail("Cookie must have the Secure attribute (requireSecureCookies)")
+                    .build();
+        }
+        if (config.requireHttpOnlyCookies() && !cookie.isHttpOnly()) {
+            throw UrlSecurityException.builder()
+                    .failureType(UrlSecurityFailureType.COOKIE_PREFIX_VIOLATION)
+                    .validationType(ValidationType.COOKIE_NAME)
+                    .originalInput(cookieName)
+                    .detail("Cookie must have the HttpOnly attribute (requireHttpOnlyCookies)")
+                    .build();
+        }
 
         // Check for __Host- prefix requirements
         if (cookieName.startsWith(HOST_PREFIX)) {

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java
@@ -40,7 +40,8 @@ import java.util.regex.Pattern;
  *   <li><strong>Double Encoding Detection</strong> - Identifies %25XX patterns indicating double encoding</li>
  *   <li><strong>Overlong UTF-8 Detection</strong> - Blocks malformed UTF-8 encoding attacks</li>
  *   <li><strong>URL Decoding</strong> - Performs standard URL percent-decoding</li>
- *   <li><strong>Unicode Normalization</strong> - Optionally normalizes Unicode and detects changes</li>
+ *   <li><strong>Unicode Normalization</strong> - Optionally canonicalizes Unicode (normalize and
+ *       continue), rejecting only folds that introduce a structural separator</li>
  * </ol>
  *
  * <h3>Design Principles</h3>
@@ -56,7 +57,8 @@ import java.util.regex.Pattern;
  *   <li><strong>Double Encoding</strong> - Detects %25XX patterns that could bypass filters</li>
  *   <li><strong>Overlong UTF-8</strong> - Blocks malformed UTF-8 encoding attacks</li>
  *   <li><strong>Invalid Encoding</strong> - Catches malformed percent-encoded sequences</li>
- *   <li><strong>Unicode Normalization Attacks</strong> - Detects normalization changes that could alter meaning</li>
+ *   <li><strong>Unicode Normalization Attacks</strong> - Canonicalizes input and rejects folds that
+ *       introduce a structural separator (e.g. fullwidth solidus U+FF0F &rarr; {@code /})</li>
  * </ul>
  *
  * <h3>Usage Examples</h3>
@@ -138,16 +140,18 @@ ValidationType validationType) implements HttpSecurityValidator {
      *   <li>Double encoding detection - fails fast if %25XX patterns found</li>
      *   <li>UTF-8 overlong encoding detection - blocks malformed UTF-8 attack patterns</li>
      *   <li>URL decoding - converts percent-encoded sequences to characters</li>
-     *   <li>Unicode normalization - optionally normalizes and detects changes</li>
+     *   <li>Unicode normalization - optionally canonicalizes and continues with the canonical form,
+     *       rejecting only structural-separator folds</li>
      * </ol>
      *
      * @param value The input string to validate and decode
-     * @return The validated and decoded string wrapped in Optional, or Optional.empty() if input was null
+     * @return The validated and canonicalized string wrapped in Optional, or Optional.empty() if input was null
      * @throws UrlSecurityException if any security violations are detected:
      *                              <ul>
      *                                <li>DOUBLE_ENCODING - if double encoding patterns are found</li>
      *                                <li>INVALID_ENCODING - if URL decoding fails due to malformed input</li>
-     *                                <li>UNICODE_NORMALIZATION_CHANGED - if Unicode normalization changes the string</li>
+     *                                <li>UNICODE_NORMALIZATION_CHANGED - if normalization introduces a
+     *                                    structurally significant separator character</li>
      *                              </ul>
      */
     @Override
@@ -197,26 +201,87 @@ ValidationType validationType) implements HttpSecurityValidator {
         // again or encoding becomes a bypass for the character rules.
         validateDecodedCharacters(value, decoded);
 
-        // Step 3: Unicode normalization with change detection.
-        // NFKC (not NFC) is required to fold compatibility homoglyphs such as the
-        // fullwidth solidus U+FF0F to their canonical form: a change after folding
-        // indicates an input that would read differently after normalization.
+        // Step 3: Unicode normalization - canonicalize-then-validate (OWASP model).
+        // Normalize and CONTINUE with the canonical form downstream, rejecting only
+        // when the fold introduces a structurally significant character (a separator
+        // such as / \ . : ? # %) that was not present before -- i.e. the
+        // homoglyph-separator attack (fullwidth solidus U+FF0F -> '/'). Benign
+        // compatibility folds (fullwidth letters, ligatures, CJK compatibility
+        // ideographs) are preserved rather than rejected, so legitimate international
+        // content passes. Form is chosen by type: NFKC for URL paths (must fold
+        // compatibility homoglyphs of separators), NFC for parameter values (lossless,
+        // preserves legitimate international text).
         if (config.normalizeUnicode()) {
-            String normalized = Normalizer.normalize(decoded, Normalizer.Form.NFKC);
-            if (!decoded.equals(normalized)) {
-                // Normalization changed the string - potential attack
+            String normalized = Normalizer.normalize(decoded, normalizationForm());
+            if (introducesStructuralCharacter(decoded, normalized)) {
                 throw UrlSecurityException.builder()
                         .failureType(UrlSecurityFailureType.UNICODE_NORMALIZATION_CHANGED)
                         .validationType(validationType)
                         .originalInput(value)
                         .sanitizedInput(normalized)
-                        .detail("Unicode normalization changed string content")
+                        .detail("Unicode normalization introduced a structurally significant character")
                         .build();
             }
             decoded = normalized;
         }
 
         return Optional.of(decoded);
+    }
+
+    /**
+     * Structurally significant characters: separators whose introduction changes how a
+     * value parses (path/segment/scheme/query/fragment/encoding delimiters). The
+     * dot-dot traversal sequence is covered transitively by counting {@code '.'}.
+     */
+    private static final String STRUCTURAL_CHARS = "/\\.:?#%";
+
+    /**
+     * Selects the Unicode normalization form for this validation type.
+     *
+     * <p><strong>NFKC</strong> (compatibility) for {@code URL_PATH}: fullwidth /
+     * compatibility homoglyphs of path separators must fold to their canonical ASCII
+     * form so the structural-fold check below and downstream path parsing see them.
+     * <strong>NFC</strong> (canonical, lossless) for {@code PARAMETER_VALUE} and any
+     * other type: preserves legitimate international content. {@code BODY} is not routed
+     * through this stage today.</p>
+     *
+     * @return the normalization form to apply
+     */
+    private Normalizer.Form normalizationForm() {
+        return switch (validationType) {
+            case URL_PATH -> Normalizer.Form.NFKC;
+            default -> Normalizer.Form.NFC;
+        };
+    }
+
+    /**
+     * Determines whether normalization <em>introduced</em> a structurally significant
+     * character - i.e. added occurrences of a separator that were not present before the
+     * fold. Per-character counts are compared so a fold that adds a new separator is
+     * caught even when the same separator already appears in the input.
+     *
+     * @param before the decoded string prior to normalization
+     * @param after the normalized string
+     * @return {@code true} if any structural character occurs more often after folding
+     */
+    private static boolean introducesStructuralCharacter(String before, String after) {
+        for (int i = 0; i < STRUCTURAL_CHARS.length(); i++) {
+            char structural = STRUCTURAL_CHARS.charAt(i);
+            if (countOccurrences(after, structural) > countOccurrences(before, structural)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int countOccurrences(String value, char target) {
+        int count = 0;
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) == target) {
+                count++;
+            }
+        }
+        return count;
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java
@@ -295,11 +295,14 @@ ValidationType validationType) implements HttpSecurityValidator {
      *       mirroring the raw-character rule; decoded combining marks can visually alter adjacent
      *       characters and enable homograph attacks. Classified by Unicode general category
      *       ({@link CharacterValidationConstants#isCombiningMark(int)}), not a fixed range</li>
-     *   <li><strong>Decoded CR/LF</strong> - always rejected for header names/values and cookie
+     *   <li><strong>Decoded CR/LF</strong> - always rejected for header names/values, cookie
      *       names/values (they travel inside HTTP headers, so a decoded line break is a
-     *       response-splitting vector). For URL paths, rejected unless control characters are
-     *       explicitly allowed. Parameter values are exempt because encoded line breaks are
-     *       legitimate form data.</li>
+     *       response-splitting vector) and parameter <em>names</em> (structural). For URL paths,
+     *       rejected unless control characters are explicitly allowed. Parameter <em>values</em>
+     *       are exempt because encoded line breaks are legitimate form data.</li>
+     *   <li><strong>Decoded parameter-name delimiters</strong> ({@code = &amp; ; space}) - rejected
+     *       for parameter <em>names</em> only, since a decoded delimiter would split the name and
+     *       enable parameter injection</li>
      * </ul>
      *
      * @param originalInput The original (still encoded) input for error reporting
@@ -337,18 +340,40 @@ ValidationType validationType) implements HttpSecurityValidator {
                         .detail("Decoded line break at position " + i)
                         .build();
             }
+
+            // Parameter names are structural: a decoded delimiter (=, &, ;, space) would split
+            // the name and enable parameter-injection. These are legitimate inside a parameter
+            // VALUE (form data), so this rule is name-only.
+            if (validationType == ValidationType.PARAMETER_NAME && isParameterNameDelimiter(ch)) {
+                throw UrlSecurityException.builder()
+                        .failureType(UrlSecurityFailureType.INVALID_CHARACTER)
+                        .validationType(validationType)
+                        .originalInput(originalInput)
+                        .detail("Decoded parameter-name delimiter '" + ch + "' at position " + i)
+                        .build();
+            }
         }
     }
 
     /**
-     * A decoded CR/LF is forbidden for header/cookie contexts unconditionally (response
-     * splitting), and for URL paths unless control characters are explicitly allowed.
+     * Characters that delimit parameters in a query string and therefore must not appear
+     * inside a decoded parameter <em>name</em>.
+     */
+    private static boolean isParameterNameDelimiter(char ch) {
+        return ch == '&' || ch == '=' || ch == ';' || ch == ' ';
+    }
+
+    /**
+     * A decoded CR/LF is forbidden for header/cookie contexts and for parameter <em>names</em>
+     * unconditionally (response splitting / parameter injection), and for URL paths unless
+     * control characters are explicitly allowed. Parameter <em>values</em> and bodies may
+     * legitimately carry decoded line breaks (form data).
      */
     private boolean decodedLineBreakForbidden() {
         return switch (validationType) {
-            case HEADER_NAME, HEADER_VALUE, COOKIE_NAME, COOKIE_VALUE -> true;
+            case HEADER_NAME, HEADER_VALUE, COOKIE_NAME, COOKIE_VALUE, PARAMETER_NAME -> true;
             case URL_PATH -> !config.allowControlCharacters();
-            case PARAMETER_NAME, PARAMETER_VALUE, BODY -> false;
+            case PARAMETER_VALUE, BODY -> false;
         };
     }
 

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java
@@ -226,9 +226,10 @@ ValidationType validationType) implements HttpSecurityValidator {
      * <ul>
      *   <li><strong>Null bytes</strong> - rejected unless explicitly allowed (defense in depth;
      *       encoded {@code %00} is normally already rejected before decoding)</li>
-     *   <li><strong>Combining characters (U+0300-U+036F)</strong> - always rejected, mirroring
-     *       the raw-character rule; decoded combining marks can visually alter adjacent
-     *       characters and enable homograph attacks</li>
+     *   <li><strong>Combining marks (all Unicode combining blocks)</strong> - always rejected,
+     *       mirroring the raw-character rule; decoded combining marks can visually alter adjacent
+     *       characters and enable homograph attacks. Classified by Unicode general category
+     *       ({@link CharacterValidationConstants#isCombiningMark(int)}), not a fixed range</li>
      *   <li><strong>Decoded CR/LF</strong> - always rejected for header names/values and cookie
      *       names/values (they travel inside HTTP headers, so a decoded line break is a
      *       response-splitting vector). For URL paths, rejected unless control characters are
@@ -253,7 +254,7 @@ ValidationType validationType) implements HttpSecurityValidator {
                         .build();
             }
 
-            if (ch >= 0x0300 && ch <= 0x036F) {
+            if (CharacterValidationConstants.isCombiningMark(ch)) {
                 throw UrlSecurityException.builder()
                         .failureType(UrlSecurityFailureType.INVALID_CHARACTER)
                         .validationType(validationType)

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/RequestCollectionValidator.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/RequestCollectionValidator.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.security.validation;
+
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.core.UrlSecurityFailureType;
+import de.cuioss.http.security.core.ValidationType;
+import de.cuioss.http.security.exceptions.UrlSecurityException;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Request-level (collection) validator that enforces the maximum parameter, header, and cookie
+ * <em>counts</em> configured in {@link SecurityConfiguration}.
+ *
+ * <p>The single-value validation pipelines built by {@code PipelineFactory} operate on one value
+ * at a time and therefore cannot enforce a count over a whole collection - the missing API that
+ * PR #74 (correctly) identified when it removed the unenforced count knobs. This validator supplies
+ * that missing collection-level entry point: pass the parameter map, header map, or cookie
+ * collection and it rejects the request when a count exceeds its configured limit
+ * ({@code maxParameterCount} / {@code maxHeaderCount} / {@code maxCookieCount}).</p>
+ *
+ * <p>Count limits defend against resource-exhaustion and hash-collision denial-of-service attacks.
+ * Defaults come from {@link de.cuioss.http.security.config.SecurityDefaults} (parameters 100,
+ * headers 50, cookies 20; strict 20/20/10, lenient 500/100/50).</p>
+ *
+ * <h3>Usage Example</h3>
+ * <pre>
+ * SecurityConfiguration config = SecurityConfiguration.defaults();
+ * SecurityEventCounter counter = new SecurityEventCounter();
+ * RequestCollectionValidator validator = new RequestCollectionValidator(config, counter);
+ *
+ * validator.validateParameters(request.getParameterMap());
+ * validator.validateHeaders(request.getHeaderMap());
+ * validator.validateCookies(request.getCookies());
+ * </pre>
+ *
+ * <p>Violations throw {@link UrlSecurityException} with failure type
+ * {@link UrlSecurityFailureType#TOO_MANY_ELEMENTS} and record an event on the supplied
+ * {@link SecurityEventCounter}, consistent with the single-value pipelines.</p>
+ *
+ * @since 1.0
+ */
+public final class RequestCollectionValidator {
+
+    private final SecurityConfiguration config;
+    private final SecurityEventCounter eventCounter;
+
+    /**
+     * Creates a request-collection validator.
+     *
+     * @param config the security configuration providing the count limits
+     * @param eventCounter the counter for recording security violations
+     * @throws NullPointerException if either argument is null
+     */
+    public RequestCollectionValidator(SecurityConfiguration config, SecurityEventCounter eventCounter) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.eventCounter = Objects.requireNonNull(eventCounter, "eventCounter must not be null");
+    }
+
+    /**
+     * Validates the number of request parameters against {@code maxParameterCount}.
+     *
+     * @param parameters the parameter map (keys are parameter names)
+     * @throws NullPointerException if {@code parameters} is null
+     * @throws UrlSecurityException if the parameter count exceeds the configured maximum
+     */
+    public void validateParameters(Map<String, ?> parameters) {
+        Objects.requireNonNull(parameters, "parameters must not be null");
+        validateParameterCount(parameters.size());
+    }
+
+    /**
+     * Validates the number of request headers against {@code maxHeaderCount}.
+     *
+     * @param headers the header map (keys are header names)
+     * @throws NullPointerException if {@code headers} is null
+     * @throws UrlSecurityException if the header count exceeds the configured maximum
+     */
+    public void validateHeaders(Map<String, ?> headers) {
+        Objects.requireNonNull(headers, "headers must not be null");
+        validateHeaderCount(headers.size());
+    }
+
+    /**
+     * Validates the number of request cookies against {@code maxCookieCount}.
+     *
+     * @param cookies the cookie collection
+     * @throws NullPointerException if {@code cookies} is null
+     * @throws UrlSecurityException if the cookie count exceeds the configured maximum
+     */
+    public void validateCookies(Collection<?> cookies) {
+        Objects.requireNonNull(cookies, "cookies must not be null");
+        validateCookieCount(cookies.size());
+    }
+
+    /**
+     * Validates a parameter count against {@code maxParameterCount}.
+     *
+     * @param count the number of parameters (non-negative)
+     * @throws UrlSecurityException if the count exceeds the configured maximum
+     */
+    public void validateParameterCount(int count) {
+        enforce(count, config.maxParameterCount(), ValidationType.PARAMETER_NAME, "parameter");
+    }
+
+    /**
+     * Validates a header count against {@code maxHeaderCount}.
+     *
+     * @param count the number of headers (non-negative)
+     * @throws UrlSecurityException if the count exceeds the configured maximum
+     */
+    public void validateHeaderCount(int count) {
+        enforce(count, config.maxHeaderCount(), ValidationType.HEADER_NAME, "header");
+    }
+
+    /**
+     * Validates a cookie count against {@code maxCookieCount}.
+     *
+     * @param count the number of cookies (non-negative)
+     * @throws UrlSecurityException if the count exceeds the configured maximum
+     */
+    public void validateCookieCount(int count) {
+        enforce(count, config.maxCookieCount(), ValidationType.COOKIE_NAME, "cookie");
+    }
+
+    private void enforce(int actual, int max, ValidationType validationType, String kind) {
+        if (actual > max) {
+            eventCounter.increment(UrlSecurityFailureType.TOO_MANY_ELEMENTS);
+            throw UrlSecurityException.builder()
+                    .failureType(UrlSecurityFailureType.TOO_MANY_ELEMENTS)
+                    .validationType(validationType)
+                    .originalInput(actual + " " + kind + "s")
+                    .detail("Too many " + kind + "s: " + actual + " exceeds maximum of " + max)
+                    .build();
+        }
+    }
+}

--- a/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
@@ -170,7 +171,8 @@ class SecurityConfigurationTest {
                 pathLength, false, paramNameLength, paramValueLength,
                 headerNameLength, headerValueLength, cookieNameLength, cookieValueLength,
                 bodySize, false, false, true, false, false, false,
-                false, false, 100, 50, 20));
+                false, false, 100, 50, 20,
+                Set.of(), Set.of(), Set.of(), Set.of()));
     }
 
     @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
@@ -169,7 +169,8 @@ class SecurityConfigurationTest {
         assertThrows(IllegalArgumentException.class, () -> new SecurityConfiguration(
                 pathLength, false, paramNameLength, paramValueLength,
                 headerNameLength, headerValueLength, cookieNameLength, cookieValueLength,
-                bodySize, false, false, true, false, false, false));
+                bodySize, false, false, true, false, false, false,
+                false, false));
     }
 
     @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
@@ -170,7 +170,7 @@ class SecurityConfigurationTest {
                 pathLength, false, paramNameLength, paramValueLength,
                 headerNameLength, headerValueLength, cookieNameLength, cookieValueLength,
                 bodySize, false, false, true, false, false, false,
-                false, false));
+                false, false, 100, 50, 20));
     }
 
     @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java
@@ -61,11 +61,12 @@ class UrlSecurityFailureTypeTest {
     }
 
     @Test
-    void shouldHave24FailureTypes() {
+    void shouldHave25FailureTypes() {
         // Verify we have the expected number of failure types
         // Original 22 (after removing SQL, Command, XSS) + 2 cookie security types
+        // + TOO_MANY_ELEMENTS (F-12 collection count enforcement)
         UrlSecurityFailureType[] values = UrlSecurityFailureType.values();
-        assertEquals(24, values.length, "Should have 24 failure types (22 + cookie security)");
+        assertEquals(25, values.length, "Should have 25 failure types (22 + 2 cookie security + TOO_MANY_ELEMENTS)");
     }
 
     @ParameterizedTest

--- a/cui-http-core/src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java
@@ -15,12 +15,9 @@
  */
 package de.cuioss.http.security.core;
 
-import de.cuioss.test.generator.Generators;
-import de.cuioss.test.generator.TypedGenerator;
-import de.cuioss.test.generator.junit.EnableGeneratorController;
-import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -31,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Test for {@link UrlSecurityFailureType}
  */
-@EnableGeneratorController
 class UrlSecurityFailureTypeTest {
 
     @Test
@@ -70,25 +66,10 @@ class UrlSecurityFailureTypeTest {
     }
 
     @ParameterizedTest
-    @TypeGeneratorSource(value = UrlSecurityFailureTypeGenerator.class, count = 23)
+    @EnumSource(UrlSecurityFailureType.class)
     void shouldHaveNonNullDescriptions(UrlSecurityFailureType type) {
         assertNotNull(type.getDescription(), "Description should not be null for: " + type);
         assertFalse(type.getDescription().trim().isEmpty(), "Description should not be empty for: " + type);
-    }
-
-    static class UrlSecurityFailureTypeGenerator implements TypedGenerator<UrlSecurityFailureType> {
-        private final TypedGenerator<UrlSecurityFailureType> gen =
-                Generators.enumValues(UrlSecurityFailureType.class);
-
-        @Override
-        public UrlSecurityFailureType next() {
-            return gen.next();
-        }
-
-        @Override
-        public Class<UrlSecurityFailureType> getType() {
-            return UrlSecurityFailureType.class;
-        }
     }
 
     @Test
@@ -186,7 +167,7 @@ class UrlSecurityFailureTypeTest {
     }
 
     @ParameterizedTest
-    @TypeGeneratorSource(value = UrlSecurityFailureTypeGenerator.class, count = 25)
+    @EnumSource(UrlSecurityFailureType.class)
     void shouldHaveExactlyOneCategory(UrlSecurityFailureType type) {
         int categoryCount = 0;
 
@@ -206,7 +187,7 @@ class UrlSecurityFailureTypeTest {
     }
 
     @ParameterizedTest
-    @TypeGeneratorSource(value = UrlSecurityFailureTypeGenerator.class, count = 25)
+    @EnumSource(UrlSecurityFailureType.class)
     void shouldHaveDescriptiveNames(UrlSecurityFailureType type) {
         String name = type.name();
         assertTrue(name.matches("^[A-Z][A-Z0-9_]*[A-Z0-9]$"),
@@ -216,7 +197,7 @@ class UrlSecurityFailureTypeTest {
     }
 
     @ParameterizedTest
-    @TypeGeneratorSource(value = UrlSecurityFailureTypeGenerator.class, count = 21)
+    @EnumSource(UrlSecurityFailureType.class)
     void shouldSupportToString(UrlSecurityFailureType type) {
         String toString = type.toString();
         assertNotNull(toString);
@@ -225,7 +206,7 @@ class UrlSecurityFailureTypeTest {
     }
 
     @ParameterizedTest
-    @TypeGeneratorSource(value = UrlSecurityFailureTypeGenerator.class, count = 21)
+    @EnumSource(UrlSecurityFailureType.class)
     void shouldSupportValueOf(UrlSecurityFailureType type) {
         UrlSecurityFailureType parsed = UrlSecurityFailureType.valueOf(type.name());
         assertEquals(type, parsed);
@@ -242,7 +223,7 @@ class UrlSecurityFailureTypeTest {
     }
 
     @ParameterizedTest
-    @TypeGeneratorSource(value = UrlSecurityFailureTypeGenerator.class, count = 21)
+    @EnumSource(UrlSecurityFailureType.class)
     void shouldBeSerializable(UrlSecurityFailureType type) {
         // This would work in actual serialization
         assertNotNull(type.name());

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/EdgeCaseValidURLsDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/EdgeCaseValidURLsDatabase.java
@@ -166,6 +166,22 @@ public class EdgeCaseValidURLsDatabase implements LegitimatePatternDatabase {
             "Commas are valid for representing lists in path segments"
     );
 
+    // F-05 (normalize-and-continue): percent-encoded compatibility characters that fold to
+    // benign, non-separator ASCII under NFKC must be canonicalized and accepted, not rejected.
+    // These lock in the OWASP canonicalize-then-validate model so legitimate international /
+    // compatibility content is not a false positive. (%EF%BD%81 = U+FF41 fullwidth 'a', etc.)
+    public static final LegitimateTestCase NFKC_FULLWIDTH_LETTER_FOLD = new LegitimateTestCase(
+            "/search/%EF%BD%81%EF%BD%82%EF%BD%83",
+            "Percent-encoded fullwidth letters (abc) that NFKC-fold to ASCII letters",
+            "Benign compatibility folds introduce no separator and must be canonicalized, not rejected"
+    );
+
+    public static final LegitimateTestCase NFKC_ROMAN_NUMERAL_FOLD = new LegitimateTestCase(
+            "/chapter/%E2%85%A2",
+            "Percent-encoded Roman numeral three (U+2162) that NFKC-folds to 'III'",
+            "Compatibility folds to letters (no structural separator) are legitimate and accepted"
+    );
+
     private static final List<LegitimateTestCase> ALL_LEGITIMATE_TEST_CASES = List.of(
             SINGLE_CHAR_PATH,
             ROOT_ONLY,
@@ -186,7 +202,9 @@ public class EdgeCaseValidURLsDatabase implements LegitimatePatternDatabase {
             PERCENT_ENCODED_SLASH,
             SEMICOLON_PARAMS,
             COLON_IN_PATH,
-            COMMA_SEPARATED
+            COMMA_SEPARATED,
+            NFKC_FULLWIDTH_LETTER_FOLD,
+            NFKC_ROMAN_NUMERAL_FOLD
     );
 
     @Override

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeControlCharacterAttackGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeControlCharacterAttackGenerator.java
@@ -250,14 +250,21 @@ public class UnicodeControlCharacterAttackGenerator implements TypedGenerator<St
             char c = pattern.charAt(i);
             result.append(c);
 
-            switch (i % 4) {
+            // Combining marks are drawn from several Unicode combining blocks (not just the
+            // U+0300-U+036F "Combining Diacritical Marks" block) so that category-based
+            // combining-mark rejection is exercised across all combining categories.
+            switch (i % 8) {
                 case 0 -> result.append('\uFE00'); // Variation Selector-1
                 case 1 -> result.append('\uFE0F'); // Variation Selector-16
-                case 2 -> result.append('\u0300'); // Combining Grave Accent
-                case 3 -> result.append('\u036F'); // Combining Latin Small Letter X
+                case 2 -> result.append('\u0300'); // Combining Grave Accent (Mn, U+0300-U+036F)
+                case 3 -> result.append('\u036F'); // Combining Latin Small Letter X (Mn, U+0300-U+036F)
+                case 4 -> result.append('\u0483'); // Combining Cyrillic Titlo (Mn, outside base block)
+                case 5 -> result.append('\u20DD'); // Combining Enclosing Circle (Me)
+                case 6 -> result.append('\uFE24'); // Combining Macron Left Half (Mn, Combining Half Marks)
+                case 7 -> result.append('\u0903'); // Devanagari Sign Visarga (Mc, spacing combining mark)
                 default -> {
                     // Intentionally empty - all cases covered by modulo operation
-                } // All cases covered by modulo 4
+                } // All cases covered by modulo 8
             }
         }
         return result.toString();

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java
@@ -55,7 +55,8 @@ class HTTPHeaderValidationPipelineTest {
             HTTPHeaderValidationPipeline pipeline = new HTTPHeaderValidationPipeline(config, eventCounter, ValidationType.HEADER_NAME);
 
             assertEquals(ValidationType.HEADER_NAME, pipeline.getValidationType());
-            assertEquals(4, pipeline.getStages().size());
+            // 4 common stages + the header-name allow/block-list stage (F-08)
+            assertEquals(5, pipeline.getStages().size());
             assertSame(eventCounter, pipeline.getEventCounter());
         }
 

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/PipelineFactoryTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/PipelineFactoryTest.java
@@ -127,19 +127,41 @@ class PipelineFactoryTest {
 
         @Test
         void shouldCreateParameterNamePipeline() {
-            // Test that PARAMETER_NAME now creates a pipeline instead of throwing an exception
+            // F-07: PARAMETER_NAME now creates a genuine PARAMETER_NAME-typed pipeline
+            // (not the parameter-value pipeline).
             HttpSecurityValidator paramNameValidator = PipelineFactory.createPipeline(
                     ValidationType.PARAMETER_NAME, config, eventCounter);
-            assertNotNull(paramNameValidator);
+            assertInstanceOf(URLParameterNameValidationPipeline.class, paramNameValidator);
+            assertEquals(ValidationType.PARAMETER_NAME,
+                    ((URLParameterNameValidationPipeline) paramNameValidator).getValidationType());
 
             // Test factory method directly
             HttpSecurityValidator directValidator = PipelineFactory.createParameterNamePipeline(config, eventCounter);
-            assertNotNull(directValidator);
+            assertInstanceOf(URLParameterNameValidationPipeline.class, directValidator);
 
             // Verify it can validate a simple parameter name
             Optional<String> result = directValidator.validate("page");
             assertTrue(result.isPresent());
             assertEquals("page", result.get());
+        }
+
+        @Test
+        void shouldApplyNameOnlyRulesInParameterNamePipeline() {
+            // F-07: name-only rules are genuinely enforced - a decoded CR/LF and a decoded
+            // parameter delimiter must be rejected for names (they would be accepted in a value).
+            HttpSecurityValidator nameValidator = PipelineFactory.createParameterNamePipeline(config, eventCounter);
+            HttpSecurityValidator valueValidator = PipelineFactory.createUrlParameterPipeline(config, eventCounter);
+
+            // Decoded CR/LF (%0D%0A) - forbidden in a name, allowed in a value
+            assertThrows(UrlSecurityException.class, () -> nameValidator.validate("na%0D%0Ame"));
+            assertTrue(valueValidator.validate("va%0D%0Alue").isPresent());
+
+            // Decoded '=' delimiter (%3D) - forbidden in a name, allowed in a value
+            assertThrows(UrlSecurityException.class, () -> nameValidator.validate("na%3Dme"));
+            assertTrue(valueValidator.validate("va%3Dlue").isPresent());
+
+            // Decoded '&' delimiter (%26) - forbidden in a name
+            assertThrows(UrlSecurityException.class, () -> nameValidator.validate("na%26me"));
         }
 
         @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java
@@ -183,18 +183,21 @@ class URLParameterValidationPipelineTest {
         }
 
         /**
-         * Regression: a percent-encoded fullwidth solidus (%EF%BC%8F = U+FF0F) folds to
-         * '/' under NFKC. With normalization on by default, this homoglyph must be
-         * rejected rather than silently normalized into a path separator.
+         * F-05 re-partition: parameter values are canonicalized with the <em>lossless</em>
+         * NFC form (not NFKC), so a percent-encoded fullwidth solidus (%EF%BC%8F = U+FF0F)
+         * is preserved rather than folded into a path separator. This is deliberate:
+         * parameter values are not parsed as paths, and NFC preserves legitimate
+         * international content (the fullwidth-CJK-in-parameter false positive). Structural
+         * folding to a separator is enforced for {@code URL_PATH} (NFKC), not for parameters.
          */
         @Test
-        void shouldRejectEncodedFullwidthSolidusHomoglyph() {
-            assertTrue(config.normalizeUnicode(), "Default config must normalize (NFKC) for this guarantee");
+        void shouldPreserveEncodedFullwidthContentInParameters() {
+            assertTrue(config.normalizeUnicode(), "Default config normalizes (NFC) parameter values");
 
-            UrlSecurityException exception = assertThrows(UrlSecurityException.class, () ->
-                    pipeline.validate("path%EF%BC%8F%EF%BC%8Fadmin"));
-
-            assertEquals(UrlSecurityFailureType.UNICODE_NORMALIZATION_CHANGED, exception.getFailureType());
+            // The fullwidth solidus does not fold under NFC, so no structural separator is
+            // introduced and the value is accepted (normalize-and-continue).
+            Optional<String> result = pipeline.validate("path%EF%BC%8F%EF%BC%8Fadmin");
+            assertTrue(result.isPresent(), "Fullwidth content in a parameter value should be preserved, not rejected");
         }
     }
 

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java
@@ -172,10 +172,11 @@ class URLPathValidationPipelineTest {
             assertTrue(eventCounter.getTotalCount() > 0);
         }
 
-        @Test
-        void shouldPreserveStageExceptionAsCause() {
+        @ParameterizedTest
+        @TypeGeneratorSource(value = PathTraversalURLGenerator.class, count = 5)
+        void shouldPreserveStageExceptionAsCause(String attackPath) {
             UrlSecurityException exception = assertThrows(UrlSecurityException.class, () ->
-                    pipeline.validate("/api/../../../etc/passwd"));
+                    pipeline.validate(attackPath));
 
             assertInstanceOf(UrlSecurityException.class, exception.getCause(),
                     "Pipeline must preserve the originating stage exception as cause");

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/AllowBlockListStageTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/AllowBlockListStageTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.security.validation;
+
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.core.HttpSecurityValidator;
+import de.cuioss.http.security.core.UrlSecurityFailureType;
+import de.cuioss.http.security.core.ValidationType;
+import de.cuioss.http.security.exceptions.UrlSecurityException;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.pipeline.PipelineFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for header-name / content-type allow-block list enforcement (F-08).
+ */
+@DisplayName("AllowBlockListStage (F-08)")
+class AllowBlockListStageTest {
+
+    @Test
+    @DisplayName("Empty lists allow everything")
+    void shouldAllowAllWhenEmpty() {
+        var stage = new AllowBlockListStage(Set.of(), Set.of(), ValidationType.HEADER_NAME);
+        assertEquals(Optional.of("X-Anything"), stage.validate("X-Anything"));
+        assertEquals(Optional.empty(), stage.validate(null));
+        assertEquals(Optional.of(""), stage.validate(""));
+    }
+
+    @Test
+    @DisplayName("Block-list rejects case-insensitively")
+    void shouldRejectBlocked() {
+        var stage = new AllowBlockListStage(Set.of(), Set.of("X-Debug"), ValidationType.HEADER_NAME);
+        var exception = assertThrows(UrlSecurityException.class, () -> stage.validate("x-debug"));
+        assertEquals(UrlSecurityFailureType.INVALID_INPUT, exception.getFailureType());
+        assertTrue(exception.getDetail().orElse("").contains("block-listed"));
+        // A non-blocked value passes.
+        assertEquals(Optional.of("X-Allowed"), stage.validate("X-Allowed"));
+    }
+
+    @Test
+    @DisplayName("Non-empty allow-list rejects values not in it")
+    void shouldEnforceAllowList() {
+        var stage = new AllowBlockListStage(Set.of("Accept", "Content-Type"), Set.of(), ValidationType.HEADER_NAME);
+        assertEquals(Optional.of("accept"), stage.validate("accept")); // case-insensitive match
+        var exception = assertThrows(UrlSecurityException.class, () -> stage.validate("X-Custom"));
+        assertEquals(UrlSecurityFailureType.INVALID_INPUT, exception.getFailureType());
+        assertTrue(exception.getDetail().orElse("").contains("allow-list"));
+    }
+
+    @Test
+    @DisplayName("Block-list takes precedence over allow-list")
+    void shouldPreferBlockOverAllow() {
+        var stage = new AllowBlockListStage(Set.of("X-Debug"), Set.of("X-Debug"), ValidationType.HEADER_NAME);
+        assertThrows(UrlSecurityException.class, () -> stage.validate("X-Debug"));
+    }
+
+    @Test
+    @DisplayName("Header-name pipeline enforces the configured block-list")
+    void shouldEnforceInHeaderNamePipeline() {
+        SecurityConfiguration config = SecurityConfiguration.builder()
+                .blockedHeaderNames(Set.of("X-Debug"))
+                .build();
+        SecurityEventCounter counter = new SecurityEventCounter();
+        HttpSecurityValidator pipeline = PipelineFactory.createHeaderNamePipeline(config, counter);
+
+        assertThrows(UrlSecurityException.class, () -> pipeline.validate("X-Debug"));
+        assertTrue(counter.getCount(UrlSecurityFailureType.INVALID_INPUT) >= 1);
+        assertTrue(pipeline.validate("Accept").isPresent());
+    }
+
+    @Test
+    @DisplayName("Content-type pipeline enforces the configured allow-list")
+    void shouldEnforceInContentTypePipeline() {
+        SecurityConfiguration config = SecurityConfiguration.builder()
+                .allowedContentTypes(Set.of("application/json"))
+                .build();
+        SecurityEventCounter counter = new SecurityEventCounter();
+        HttpSecurityValidator pipeline = PipelineFactory.createContentTypePipeline(config, counter);
+
+        assertTrue(pipeline.validate("application/json").isPresent());
+        assertThrows(UrlSecurityException.class, () -> pipeline.validate("application/octet-stream"));
+    }
+
+    @Test
+    @DisplayName("Content-type matching ignores parameters (charset, boundary)")
+    void shouldMatchContentTypeMediaTypeIgnoringParameters() {
+        SecurityConfiguration config = SecurityConfiguration.builder()
+                .allowedContentTypes(Set.of("application/json"))
+                .blockedContentTypes(Set.of("application/octet-stream"))
+                .build();
+        SecurityEventCounter counter = new SecurityEventCounter();
+        HttpSecurityValidator pipeline = PipelineFactory.createContentTypePipeline(config, counter);
+
+        // Allowed media type with parameters must still pass (was a false positive before the fix).
+        assertTrue(pipeline.validate("application/json; charset=UTF-8").isPresent());
+        assertTrue(pipeline.validate("application/json;charset=utf-8").isPresent());
+        // Blocked media type with parameters must still be rejected.
+        assertThrows(UrlSecurityException.class,
+                () -> pipeline.validate("application/octet-stream; name=evil.bin"));
+    }
+
+    @Test
+    @DisplayName("Null arguments are rejected")
+    void shouldRejectNullArguments() {
+        assertThrows(NullPointerException.class,
+                () -> new AllowBlockListStage(null, Set.of(), ValidationType.HEADER_NAME));
+        assertThrows(NullPointerException.class,
+                () -> new AllowBlockListStage(Set.of(), null, ValidationType.HEADER_NAME));
+        assertThrows(NullPointerException.class,
+                () -> new AllowBlockListStage(Set.of(), Set.of(), null));
+    }
+}

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationConstantsTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationConstantsTest.java
@@ -18,7 +18,7 @@ package de.cuioss.http.security.validation;
 import de.cuioss.http.security.core.ValidationType;
 import org.junit.jupiter.api.Test;
 
-import java.util.BitSet;
+import java.util.function.IntPredicate;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -26,152 +26,144 @@ class CharacterValidationConstantsTest {
 
     @Test
     void shouldInitializeRFC3986UnreservedCharacters() {
-        BitSet unreserved = CharacterValidationConstants.RFC3986_UNRESERVED;
+        IntPredicate unreserved = CharacterValidationConstants.RFC3986_UNRESERVED;
 
         // Test ALPHA characters
         for (char c = 'A'; c <= 'Z'; c++) {
-            assertTrue(unreserved.get(c), "Uppercase letter " + c + " should be allowed");
+            assertTrue(unreserved.test(c), "Uppercase letter " + c + " should be allowed");
         }
         for (char c = 'a'; c <= 'z'; c++) {
-            assertTrue(unreserved.get(c), "Lowercase letter " + c + " should be allowed");
+            assertTrue(unreserved.test(c), "Lowercase letter " + c + " should be allowed");
         }
 
         // Test DIGIT characters
         for (char c = '0'; c <= '9'; c++) {
-            assertTrue(unreserved.get(c), "Digit " + c + " should be allowed");
+            assertTrue(unreserved.test(c), "Digit " + c + " should be allowed");
         }
 
         // Test specific unreserved characters
-        assertTrue(unreserved.get('-'));
-        assertTrue(unreserved.get('.'));
-        assertTrue(unreserved.get('_'));
-        assertTrue(unreserved.get('~'));
+        assertTrue(unreserved.test('-'));
+        assertTrue(unreserved.test('.'));
+        assertTrue(unreserved.test('_'));
+        assertTrue(unreserved.test('~'));
 
         // Test some characters that should NOT be allowed
-        assertFalse(unreserved.get(' '));
-        assertFalse(unreserved.get('/'));
-        assertFalse(unreserved.get('?'));
-        assertFalse(unreserved.get('#'));
+        assertFalse(unreserved.test(' '));
+        assertFalse(unreserved.test('/'));
+        assertFalse(unreserved.test('?'));
+        assertFalse(unreserved.test('#'));
     }
 
     @Test
+    @SuppressWarnings("java:S5961") // Exhaustive RFC 3986 path character-set membership check
     void shouldInitializeRFC3986PathCharacters() {
-        BitSet pathChars = CharacterValidationConstants.RFC3986_PATH_CHARS;
+        IntPredicate pathChars = CharacterValidationConstants.RFC3986_PATH_CHARS;
 
         // Should include all unreserved characters
-        assertTrue(pathChars.get('A'));
-        assertTrue(pathChars.get('0'));
-        assertTrue(pathChars.get('-'));
+        assertTrue(pathChars.test('A'));
+        assertTrue(pathChars.test('0'));
+        assertTrue(pathChars.test('-'));
 
         // Should include path-specific characters
-        assertTrue(pathChars.get('/'));
-        assertTrue(pathChars.get('@'));
-        assertTrue(pathChars.get(':'));
+        assertTrue(pathChars.test('/'));
+        assertTrue(pathChars.test('@'));
+        assertTrue(pathChars.test(':'));
 
         // Should include sub-delims for path
-        assertTrue(pathChars.get('!'));
-        assertTrue(pathChars.get('$'));
-        assertTrue(pathChars.get('&'));
-        assertTrue(pathChars.get('\''));
-        assertTrue(pathChars.get('('));
-        assertTrue(pathChars.get(')'));
-        assertTrue(pathChars.get('*'));
-        assertTrue(pathChars.get('+'));
-        assertTrue(pathChars.get(','));
-        assertTrue(pathChars.get(';'));
-        assertTrue(pathChars.get('='));
+        assertTrue(pathChars.test('!'));
+        assertTrue(pathChars.test('$'));
+        assertTrue(pathChars.test('&'));
+        assertTrue(pathChars.test('\''));
+        assertTrue(pathChars.test('('));
+        assertTrue(pathChars.test(')'));
+        assertTrue(pathChars.test('*'));
+        assertTrue(pathChars.test('+'));
+        assertTrue(pathChars.test(','));
+        assertTrue(pathChars.test(';'));
+        assertTrue(pathChars.test('='));
 
         // Should NOT include some characters
-        assertFalse(pathChars.get(' '));
-        assertFalse(pathChars.get('?'));
-        assertFalse(pathChars.get('#'));
+        assertFalse(pathChars.test(' '));
+        assertFalse(pathChars.test('?'));
+        assertFalse(pathChars.test('#'));
     }
 
     @Test
     void shouldInitializeRFC3986QueryCharacters() {
-        BitSet queryChars = CharacterValidationConstants.RFC3986_QUERY_CHARS;
+        IntPredicate queryChars = CharacterValidationConstants.RFC3986_QUERY_CHARS;
 
         // Should include all unreserved characters
-        assertTrue(queryChars.get('A'));
-        assertTrue(queryChars.get('0'));
-        assertTrue(queryChars.get('-'));
+        assertTrue(queryChars.test('A'));
+        assertTrue(queryChars.test('0'));
+        assertTrue(queryChars.test('-'));
 
         // Should include query-specific characters
-        assertTrue(queryChars.get('?'));
-        assertTrue(queryChars.get('&'));
-        assertTrue(queryChars.get('='));
+        assertTrue(queryChars.test('?'));
+        assertTrue(queryChars.test('&'));
+        assertTrue(queryChars.test('='));
 
         // Should include some sub-delims for query
-        assertTrue(queryChars.get('!'));
-        assertTrue(queryChars.get('$'));
-        assertTrue(queryChars.get('\''));
+        assertTrue(queryChars.test('!'));
+        assertTrue(queryChars.test('$'));
+        assertTrue(queryChars.test('\''));
 
         // Should NOT include some characters
-        assertFalse(queryChars.get(' '));
-        assertFalse(queryChars.get('#'));
+        assertFalse(queryChars.test(' '));
+        assertFalse(queryChars.test('#'));
     }
 
     @Test
+    @SuppressWarnings("java:S5961") // Exhaustive RFC 7230 header character-set membership check
     void shouldInitializeRFC7230HeaderCharacters() {
-        BitSet headerChars = CharacterValidationConstants.RFC7230_HEADER_CHARS;
+        IntPredicate headerChars = CharacterValidationConstants.RFC7230_HEADER_CHARS;
 
         // Should include most visible ASCII
-        assertTrue(headerChars.get('A'));
-        assertTrue(headerChars.get('0'));
-        assertTrue(headerChars.get('-'));
-        assertTrue(headerChars.get('_'));
-        assertTrue(headerChars.get('/'));
-        assertTrue(headerChars.get(':'));
-        assertTrue(headerChars.get('='));
+        assertTrue(headerChars.test('A'));
+        assertTrue(headerChars.test('0'));
+        assertTrue(headerChars.test('-'));
+        assertTrue(headerChars.test('_'));
+        assertTrue(headerChars.test('/'));
+        assertTrue(headerChars.test(':'));
+        assertTrue(headerChars.test('='));
 
         // Should include space and tab
-        assertTrue(headerChars.get(' '));
-        assertTrue(headerChars.get('\t'));
+        assertTrue(headerChars.test(' '));
+        assertTrue(headerChars.test('\t'));
 
         // Should exclude control characters
-        assertFalse(headerChars.get('\0'));
-        assertFalse(headerChars.get('\n'));
-        assertFalse(headerChars.get('\r'));
-        assertFalse(headerChars.get('\u0001'));
+        assertFalse(headerChars.test('\0'));
+        assertFalse(headerChars.test('\n'));
+        assertFalse(headerChars.test('\r'));
+        assertFalse(headerChars.test(1));
 
         // Should exclude characters outside printable range
-        assertFalse(headerChars.get((char) 127)); // DEL
-        assertFalse(headerChars.get((char) 31));  // Below space
+        assertFalse(headerChars.test(127)); // DEL
+        assertFalse(headerChars.test(31));  // Below space
     }
 
     @Test
     void shouldReturnCorrectCharacterSetForValidationType() {
-        assertEquals(CharacterValidationConstants.RFC3986_PATH_CHARS,
+        // The accessor now returns the shared immutable predicate instance (no defensive
+        // copy), so identity equality is both correct and the strongest available assertion.
+        assertSame(CharacterValidationConstants.RFC3986_PATH_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.URL_PATH));
 
-        assertEquals(CharacterValidationConstants.RFC3986_QUERY_CHARS,
+        assertSame(CharacterValidationConstants.RFC3986_QUERY_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.PARAMETER_NAME));
-        assertEquals(CharacterValidationConstants.RFC3986_QUERY_CHARS,
+        assertSame(CharacterValidationConstants.RFC3986_QUERY_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.PARAMETER_VALUE));
 
-        assertEquals(CharacterValidationConstants.RFC7230_HEADER_CHARS,
+        assertSame(CharacterValidationConstants.RFC7230_HEADER_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.HEADER_NAME));
-        assertEquals(CharacterValidationConstants.RFC7230_HEADER_CHARS,
+        assertSame(CharacterValidationConstants.RFC7230_HEADER_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.HEADER_VALUE));
 
-        assertEquals(CharacterValidationConstants.HTTP_BODY_CHARS,
+        assertSame(CharacterValidationConstants.HTTP_BODY_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.BODY));
-        assertEquals(CharacterValidationConstants.RFC3986_UNRESERVED,
+        assertSame(CharacterValidationConstants.RFC3986_UNRESERVED,
                 CharacterValidationConstants.getCharacterSet(ValidationType.COOKIE_NAME));
-        assertEquals(CharacterValidationConstants.RFC3986_UNRESERVED,
+        assertSame(CharacterValidationConstants.RFC3986_UNRESERVED,
                 CharacterValidationConstants.getCharacterSet(ValidationType.COOKIE_VALUE));
-    }
-
-    @Test
-    void shouldReturnDefensiveCopies() {
-        // Mutating a returned set must not corrupt the shared constants
-        var copy = CharacterValidationConstants.getCharacterSet(ValidationType.URL_PATH);
-        assertNotSame(CharacterValidationConstants.RFC3986_PATH_CHARS, copy);
-
-        copy.set('<');
-        assertFalse(CharacterValidationConstants.RFC3986_PATH_CHARS.get('<'),
-                "Shared constant must be unaffected by mutation of the returned copy");
-        assertFalse(CharacterValidationConstants.getCharacterSet(ValidationType.URL_PATH).get('<'));
     }
 
     @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.http.security.validation;
 
+import de.cuioss.http.security.config.SecurityConfiguration;
 import de.cuioss.http.security.core.UrlSecurityFailureType;
 import de.cuioss.http.security.data.Cookie;
 import de.cuioss.http.security.exceptions.UrlSecurityException;
@@ -305,6 +306,57 @@ class CookiePrefixValidationStageTest {
         void shouldTreatWrongPositionAsRegular(String name) {
             Cookie regular = new Cookie(name, "value", "");
             assertDoesNotThrow(() -> validator.validateCookie(regular));
+        }
+    }
+
+    @Nested
+    @DisplayName("Cookie attribute requirements (F-11)")
+    class AttributeRequirements {
+
+        @Test
+        @DisplayName("Default config does not require Secure or HttpOnly")
+        void shouldNotEnforceByDefault() {
+            // Default validator (no-arg) leaves both flags off - behavior unchanged.
+            Cookie plain = new Cookie("session", "abc123", "");
+            assertDoesNotThrow(() -> validator.validateCookie(plain));
+        }
+
+        @Test
+        @DisplayName("requireSecureCookies rejects a cookie without Secure")
+        void shouldRejectMissingSecureWhenRequired() {
+            var secureValidator = new CookiePrefixValidationStage(
+                    SecurityConfiguration.builder()
+                            .requireSecureCookies(true)
+                            .build());
+
+            Cookie missingSecure = new Cookie("session", "abc123", "HttpOnly");
+            var exception = assertThrows(UrlSecurityException.class,
+                    () -> secureValidator.validateCookie(missingSecure));
+            assertEquals(UrlSecurityFailureType.COOKIE_PREFIX_VIOLATION, exception.getFailureType());
+            assertTrue(exception.getDetail().orElse("").contains("Secure"));
+
+            // A cookie that carries Secure passes.
+            Cookie withSecure = new Cookie("session", "abc123", "Secure");
+            assertDoesNotThrow(() -> secureValidator.validateCookie(withSecure));
+        }
+
+        @Test
+        @DisplayName("requireHttpOnlyCookies rejects a cookie without HttpOnly")
+        void shouldRejectMissingHttpOnlyWhenRequired() {
+            var httpOnlyValidator = new CookiePrefixValidationStage(
+                    SecurityConfiguration.builder()
+                            .requireHttpOnlyCookies(true)
+                            .build());
+
+            Cookie missingHttpOnly = new Cookie("session", "abc123", "Secure");
+            var exception = assertThrows(UrlSecurityException.class,
+                    () -> httpOnlyValidator.validateCookie(missingHttpOnly));
+            assertEquals(UrlSecurityFailureType.COOKIE_PREFIX_VIOLATION, exception.getFailureType());
+            assertTrue(exception.getDetail().orElse("").contains("HttpOnly"));
+
+            // A cookie that carries HttpOnly passes.
+            Cookie withHttpOnly = new Cookie("session", "abc123", "HttpOnly");
+            assertDoesNotThrow(() -> httpOnlyValidator.validateCookie(withHttpOnly));
         }
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java
@@ -207,28 +207,51 @@ class DecodingStageTest {
     }
 
     @Test
-    @DisplayName("Should detect Unicode normalization changes")
-    void shouldDetectUnicodeNormalizationChanges() {
+    @DisplayName("Should reject folds that introduce a structural separator")
+    void shouldRejectStructuralNormalizationFold() {
         SecurityConfiguration unicodeConfig = SecurityConfiguration.builder()
                 .normalizeUnicode(true)
                 .build();
 
-        DecodingStage unicodeDecoder = new DecodingStage(unicodeConfig, ValidationType.HEADER_VALUE);
+        DecodingStage unicodeDecoder = new DecodingStage(unicodeConfig, ValidationType.URL_PATH);
 
-        // Fullwidth 'A' (U+FF21) is a compatibility character that NFKC folds to 'A'.
-        // NFKC (not NFC) is required to catch this; it is not a combining mark, so it
-        // reaches the normalization step rather than the post-decode character check.
-        String compatibility = "ＡBC"; // fullwidth A + BC
-        String folded = "ABC";
+        // Fullwidth solidus U+FF0F folds to '/' under NFKC - a homoglyph path separator.
+        // Introducing a structural separator that was not present before the fold is the
+        // attack the check targets, so it is rejected (normalize-and-continue rejects only
+        // structural folds, not benign compatibility folds).
+        String structural = "a\uFF0Fb"; // a + fullwidth solidus + b
+        String folded = "a/b";
 
         UrlSecurityException exception = assertThrows(UrlSecurityException.class,
-                () -> unicodeDecoder.validate(compatibility));
+                () -> unicodeDecoder.validate(structural));
 
         assertEquals(UrlSecurityFailureType.UNICODE_NORMALIZATION_CHANGED, exception.getFailureType());
-        assertEquals(compatibility, exception.getOriginalInput());
+        assertEquals(structural, exception.getOriginalInput());
         assertEquals(Optional.of(folded), exception.getSanitizedInput());
         assertTrue(exception.getDetail().isPresent());
-        assertTrue(exception.getDetail().get().contains("Unicode normalization changed"));
+        assertTrue(exception.getDetail().get().contains("structurally significant"));
+    }
+
+    @Test
+    @DisplayName("Should preserve benign compatibility folds (normalize-and-continue)")
+    void shouldPreserveBenignCompatibilityFold() {
+        SecurityConfiguration unicodeConfig = SecurityConfiguration.builder()
+                .normalizeUnicode(true)
+                .build();
+
+        // URL_PATH uses NFKC: a fullwidth letter folds to its ASCII form but introduces no
+        // separator, so it is canonicalized and passed downstream rather than rejected.
+        DecodingStage nfkcPathDecoder = new DecodingStage(unicodeConfig, ValidationType.URL_PATH);
+        Optional<String> pathResult = nfkcPathDecoder.validate("ＡBC"); // fullwidth A + BC
+        assertTrue(pathResult.isPresent());
+        assertEquals("ABC", pathResult.get(), "NFKC folds the fullwidth letter to ASCII and continues");
+
+        // PARAMETER_VALUE uses the lossless NFC form: legitimate international content is
+        // preserved unchanged (fullwidth letters do not fold under NFC).
+        DecodingStage paramDecoder = new DecodingStage(unicodeConfig, ValidationType.PARAMETER_VALUE);
+        Optional<String> paramResult = paramDecoder.validate("ＡBC");
+        assertTrue(paramResult.isPresent());
+        assertEquals("ＡBC", paramResult.get(), "NFC preserves fullwidth letters in parameter values");
     }
 
     @Test
@@ -241,7 +264,7 @@ class DecodingStageTest {
         DecodingStage noUnicodeDecoder = new DecodingStage(noUnicodeConfig, ValidationType.HEADER_VALUE);
 
         // With normalization disabled the compatibility character passes through unchanged
-        String compatibility = "ＡBC";
+        String compatibility = "ＡBC"; // fullwidth A + BC
         assertDoesNotThrow(() -> {
             Optional<String> result = noUnicodeDecoder.validate(compatibility);
             assertTrue(result.isPresent());

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/RequestCollectionValidatorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/RequestCollectionValidatorTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.security.validation;
+
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.config.SecurityDefaults;
+import de.cuioss.http.security.core.UrlSecurityFailureType;
+import de.cuioss.http.security.exceptions.UrlSecurityException;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the collection-level count validator (F-12).
+ */
+@DisplayName("RequestCollectionValidator (F-12)")
+class RequestCollectionValidatorTest {
+
+    private SecurityEventCounter eventCounter;
+    private RequestCollectionValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        eventCounter = new SecurityEventCounter();
+        validator = new RequestCollectionValidator(SecurityConfiguration.defaults(), eventCounter);
+    }
+
+    private static Map<String, String> mapOfSize(int size) {
+        return IntStream.range(0, size).boxed()
+                .collect(Collectors.toMap(i -> "k" + i, i -> "v" + i));
+    }
+
+    @Test
+    @DisplayName("Counts within the default limits pass")
+    void shouldAcceptWithinLimits() {
+        assertDoesNotThrow(() -> validator.validateParameters(mapOfSize(SecurityDefaults.MAX_PARAMETER_COUNT_DEFAULT)));
+        assertDoesNotThrow(() -> validator.validateHeaders(mapOfSize(SecurityDefaults.MAX_HEADER_COUNT_DEFAULT)));
+        assertDoesNotThrow(() -> validator.validateCookies(
+                IntStream.range(0, SecurityDefaults.MAX_COOKIE_COUNT_DEFAULT).boxed().toList()));
+        assertEquals(0, eventCounter.getTotalCount());
+    }
+
+    @Test
+    @DisplayName("Parameter count over the limit is rejected and recorded")
+    void shouldRejectTooManyParameters() {
+        Map<String, String> tooMany = mapOfSize(SecurityDefaults.MAX_PARAMETER_COUNT_DEFAULT + 1);
+        var exception = assertThrows(UrlSecurityException.class,
+                () -> validator.validateParameters(tooMany));
+        assertEquals(UrlSecurityFailureType.TOO_MANY_ELEMENTS, exception.getFailureType());
+        assertTrue(exception.getDetail().orElse("").contains("parameter"));
+        assertEquals(1, eventCounter.getCount(UrlSecurityFailureType.TOO_MANY_ELEMENTS));
+    }
+
+    @Test
+    @DisplayName("Header count over the limit is rejected")
+    void shouldRejectTooManyHeaders() {
+        var exception = assertThrows(UrlSecurityException.class,
+                () -> validator.validateHeaderCount(SecurityDefaults.MAX_HEADER_COUNT_DEFAULT + 1));
+        assertEquals(UrlSecurityFailureType.TOO_MANY_ELEMENTS, exception.getFailureType());
+    }
+
+    @Test
+    @DisplayName("Cookie count over the limit is rejected")
+    void shouldRejectTooManyCookies() {
+        List<Integer> tooMany = IntStream.range(0, SecurityDefaults.MAX_COOKIE_COUNT_DEFAULT + 1).boxed().toList();
+        var exception = assertThrows(UrlSecurityException.class,
+                () -> validator.validateCookies(tooMany));
+        assertEquals(UrlSecurityFailureType.TOO_MANY_ELEMENTS, exception.getFailureType());
+        assertTrue(exception.getDetail().orElse("").contains("cookie"));
+    }
+
+    @Test
+    @DisplayName("Strict preset enforces tighter counts than lenient")
+    void shouldHonorPresetLimits() {
+        RequestCollectionValidator strict =
+                new RequestCollectionValidator(SecurityConfiguration.strict(), eventCounter);
+        RequestCollectionValidator lenient =
+                new RequestCollectionValidator(SecurityConfiguration.lenient(), new SecurityEventCounter());
+
+        // Strict cookie limit is 10; lenient accepts 50.
+        assertThrows(UrlSecurityException.class,
+                () -> strict.validateCookieCount(SecurityDefaults.MAX_COOKIE_COUNT_STRICT + 1));
+        assertDoesNotThrow(() -> lenient.validateCookieCount(SecurityDefaults.MAX_COOKIE_COUNT_STRICT + 1));
+    }
+
+    @Test
+    @DisplayName("Custom builder count is honored")
+    void shouldHonorCustomLimit() {
+        RequestCollectionValidator custom = new RequestCollectionValidator(
+                SecurityConfiguration.builder().maxParameterCount(2).build(), eventCounter);
+        assertDoesNotThrow(() -> custom.validateParameterCount(2));
+        assertThrows(UrlSecurityException.class, () -> custom.validateParameterCount(3));
+    }
+
+    @Test
+    @DisplayName("Null arguments are rejected")
+    void shouldRejectNulls() {
+        SecurityConfiguration defaults = SecurityConfiguration.defaults();
+        assertThrows(NullPointerException.class,
+                () -> new RequestCollectionValidator(null, eventCounter));
+        assertThrows(NullPointerException.class,
+                () -> new RequestCollectionValidator(defaults, null));
+        assertThrows(NullPointerException.class, () -> validator.validateParameters(null));
+        assertThrows(NullPointerException.class, () -> validator.validateHeaders(null));
+        assertThrows(NullPointerException.class, () -> validator.validateCookies((List<?>) null));
+    }
+}

--- a/doc/http-security/configuration.adoc
+++ b/doc/http-security/configuration.adoc
@@ -1,0 +1,132 @@
+= HTTP Security Configuration Reference
+:toc: macro
+:toclevels: 3
+
+This document is the central reference for every *enforced* setting in
+`de.cuioss.http.security.config.SecurityConfiguration`. For each knob it lists the default
+value across the three presets and the stage / validator that enforces it.
+
+Every setting listed here is enforced. Single-value settings are consumed by the validation
+stages inside the pipelines built by `PipelineFactory`; request-level settings that need
+collection or attribute context are enforced by dedicated validators
+(`RequestCollectionValidator`, `CookiePrefixValidationStage`).
+
+toc::[]
+
+== Presets
+
+Three presets are provided as the single source of truth
+(`de.cuioss.http.security.config.SecurityDefaults`):
+
+* `SecurityConfiguration.defaults()` — balanced (identical to `builder().build()`)
+* `SecurityConfiguration.strict()` — security over compatibility
+* `SecurityConfiguration.lenient()` — maximum compatibility (trusted environments only)
+
+Build a custom configuration with `SecurityConfiguration.builder()`.
+
+== Length limits
+
+Enforced by `LengthValidationStage` (runs first in every pipeline to prevent DoS).
+
+[cols="3,1,1,1", options="header"]
+|===
+| Setting | default | strict | lenient
+| `maxPathLength`          | 4096 | 1024 | 8192
+| `maxParameterNameLength` | 128  | 64   | 256
+| `maxParameterValueLength`| 2048 | 1024 | 8192
+| `maxHeaderNameLength`    | 128  | 64   | 256
+| `maxHeaderValueLength`   | 2048 | 1024 | 8192
+| `maxCookieNameLength`    | 128  | 64   | 256
+| `maxCookieValueLength`   | 2048 | 1024 | 8192
+| `maxBodySize` (bytes)    | 5 MB | 1 MB | 10 MB
+|===
+
+== Encoding and character policy
+
+[cols="3,1,1,1,3", options="header"]
+|===
+| Setting | default | strict | lenient | Enforced by
+| `allowDoubleEncoding`     | false | false | true  | `DecodingStage`
+| `allowNullBytes`          | false | false | false | `CharacterValidationStage`, `DecodingStage`
+| `allowControlCharacters`  | false | false | true  | `CharacterValidationStage`
+| `allowExtendedAscii`      | true  | false | true  | `CharacterValidationStage`
+| `normalizeUnicode`        | true  | true  | false | `DecodingStage`
+|===
+
+`normalizeUnicode` follows the OWASP _canonicalize-then-validate_ model: input is normalized and
+the canonical form flows to downstream stages (normalize-and-continue). It is rejected only when a
+fold introduces a structurally significant separator (`/ \ . : ? # %`) — e.g. a fullwidth solidus
+`U+FF0F` folding to `/`. Benign compatibility folds of legitimate international text are preserved.
+Paths use NFKC; parameter values use the lossless NFC form. NFKC is not confusable/homograph
+defense (that is a UTS #39 capability).
+
+== Pattern matching policy
+
+Enforced by `PatternMatchingStage`.
+
+[cols="3,1,1,1", options="header"]
+|===
+| Setting | default | strict | lenient
+| `caseSensitiveComparison`  | false | true  | false
+| `failOnSuspiciousPatterns` | false | true  | false
+|===
+
+== Collection count limits
+
+Request-level limits enforced by `RequestCollectionValidator` (a single-value pipeline cannot
+count a collection). Defend against resource-exhaustion / hash-collision DoS.
+
+[cols="3,1,1,1", options="header"]
+|===
+| Setting | default | strict | lenient
+| `maxParameterCount` | 100 | 20 | 500
+| `maxHeaderCount`    | 50  | 20 | 100
+| `maxCookieCount`    | 20  | 10 | 50
+|===
+
+[source,java]
+----
+RequestCollectionValidator validator = new RequestCollectionValidator(config, counter);
+validator.validateParameters(request.getParameterMap());
+validator.validateHeaders(request.getHeaderMap());
+validator.validateCookies(request.getCookies());
+----
+
+== Cookie attribute requirements
+
+Opt-in (default `false`) requirements enforced by `CookiePrefixValidationStage.validateCookie(Cookie)`.
+Meaningful only for attribute-bearing (Set-Cookie) cookies, not request `Cookie`-header
+`name=value` pairs.
+
+[cols="3,1,1,1", options="header"]
+|===
+| Setting | default | strict | lenient
+| `requireSecureCookies`   | false | false | false
+| `requireHttpOnlyCookies` | false | false | false
+|===
+
+== Header-name and content-type allow/block lists
+
+Case-insensitive allow/block lists (default empty). Block-list takes precedence; an empty
+allow-list means allow-all. Enforced by `AllowBlockListStage`.
+
+[cols="3,1,3", options="header"]
+|===
+| Setting | default (all presets) | Enforced by
+| `allowedHeaderNames`   | empty (allow-all) | header-name pipeline (`HTTPHeaderValidationPipeline`, `HEADER_NAME`)
+| `blockedHeaderNames`   | empty (block-none)| header-name pipeline (`HTTPHeaderValidationPipeline`, `HEADER_NAME`)
+| `allowedContentTypes`  | empty (allow-all) | `ContentTypeValidationPipeline` / `PipelineFactory.createContentTypePipeline`
+| `blockedContentTypes`  | empty (block-none)| `ContentTypeValidationPipeline` / `PipelineFactory.createContentTypePipeline`
+|===
+
+[source,java]
+----
+SecurityConfiguration config = SecurityConfiguration.builder()
+    .blockedHeaderNames(Set.of("X-Debug", "X-Test"))
+    .allowedContentTypes(Set.of("application/json"))
+    .build();
+----
+
+The classification constants in `SecurityDefaults` (`DANGEROUS_HEADER_NAMES`,
+`DANGEROUS_CONTENT_TYPES`, `SAFE_CONTENT_TYPES`, …) are reference values you may feed into these
+lists.

--- a/doc/http-security/specification/specification.adoc
+++ b/doc/http-security/specification/specification.adoc
@@ -155,7 +155,7 @@ The following classes implement the validation stages:
 
 [#_encodingvalidationstage]
 [#_decodingstage]
-* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage] - URL decoding with security checks
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage] - URL decoding with security checks and Unicode canonicalization (OWASP canonicalize-then-validate: normalize-and-continue, rejecting only folds that introduce a structural separator; NFKC for paths, NFC for parameter values). Legitimate international text passes; NFKC is not confusable/homograph defense.
 
 [#_normalizationstage]
 * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage] - Path normalization per RFC 3986

--- a/doc/security-readme.adoc
+++ b/doc/security-readme.adoc
@@ -72,6 +72,9 @@ See `de.cuioss.http.security.pipeline.URLParameterValidationPipeline`.
 * Cookie count: 20
 * Body size: 5MB
 
+See the link:http-security/configuration.adoc[Configuration Reference] for every enforced setting,
+its default across the strict/default/lenient presets, and the stage that enforces it.
+
 == Usage Example
 
 [source,java]

--- a/doc/security-readme.adoc
+++ b/doc/security-readme.adoc
@@ -47,9 +47,18 @@ See `de.cuioss.http.security.pipeline.URLParameterValidationPipeline`.
 
 == Validation Stages
 
-* `DecodingStage` - URL percent-decoding and UTF-8 overlong encoding detection
-* `NormalizationStage` - Unicode normalization for consistent character representation
-* `CharacterValidationStage` - Invalid and dangerous character detection
+* `DecodingStage` - URL percent-decoding, UTF-8 overlong encoding detection, and Unicode
+  canonicalization. Unicode normalization follows the OWASP _canonicalize-then-validate_ model:
+  input is normalized and the canonical form flows to downstream stages (normalize-and-continue),
+  and it is rejected **only** when a fold introduces a structurally significant separator
+  (`/ \ . : ? # %`) — e.g. a fullwidth solidus `U+FF0F` folding to `/`. Benign compatibility
+  folds of legitimate international text (CJK / Cyrillic / Arabic, fullwidth letters, ligatures)
+  are preserved, not rejected. URL paths use NFKC; parameter values use the lossless NFC form.
+  Note: NFKC is not a confusable/homograph defense — true confusable detection is a UTS&nbsp;#39
+  capability and out of scope here.
+* `NormalizationStage` - Path normalization (RFC&nbsp;3986 dot-segment resolution), not Unicode
+* `CharacterValidationStage` - Invalid and dangerous character detection, including rejection of
+  Unicode combining marks (classified by general category, all combining blocks)
 * `LengthValidationStage` - Length limit enforcement to prevent buffer overflow attacks
 * `PatternMatchingStage` - Attack pattern detection using configured security rules
 


### PR DESCRIPTION
Post-merge review remediation (ledger F-04–F-18, security-validation & config group). Each finding is a separate commit referencing its ID.

## Findings

- **F-14** refactor: character sets immutable via `IntPredicate` (private `BitSet`s; accessor returns shared predicate, no per-stage clone). Closes the mutable `public static final BitSet` integrity bypass.
- **F-06** fix: reject **all** Unicode combining marks by general category (`NON_SPACING_MARK`/`COMBINING_SPACING_MARK`/`ENCLOSING_MARK`) instead of the hardcoded U+0300–U+036F block. Generator extended for adversarial coverage.
- **F-05** fix: Unicode normalization is now **canonicalize-then-validate** (OWASP) — normalize-and-continue, rejecting only folds that introduce a structural separator (`/ \ . : ? # %`). NFKC for paths, lossless **NFC** for parameter values (fixes the fullwidth-CJK-in-parameter false positive). Docs + generator/DB re-partition; legitimate-input net added.
- **F-07** feat: genuine `PARAMETER_NAME` validation — new `URLParameterNameValidationPipeline`; `DecodingStage` forbids decoded CR/LF and delimiters (`= & ; space`) for names.
- **F-11** feat: re-add + enforce `requireSecureCookies`/`requireHttpOnlyCookies` (opt-in, default false) in `CookiePrefixValidationStage.validateCookie`.
- **F-12** feat: re-add + enforce `maxParameterCount`/`maxHeaderCount`/`maxCookieCount` via new collection-level `RequestCollectionValidator`; new `TOO_MANY_ELEMENTS` failure type (size category).
- **F-08** feat: re-add + enforce header-name/content-type allow/block lists via new `AllowBlockListStage` (header-name pipeline + new `ContentTypeValidationPipeline`).
- **F-13** docs: central `doc/http-security/configuration.adoc` — every enforced knob, preset defaults, enforcing stage.
- **F-04** test: drive `shouldPreserveStageExceptionAsCause` from `PathTraversalURLGenerator`.
- **F-18** test: exhaustive `@EnumSource` for the finite-enum invariants (was random sampling).

## Verification

`./mvnw -Ppre-commit clean verify` — BUILD SUCCESS (5302 core tests, 0 failures).

Working notes for the review ledger are not part of this PR.