### PR TITLE
fix(client): handler & result remediation (F-01/02/03/09/10/19/20)

### DIFF
--- a/cui-http-core/pom.xml
+++ b/cui-http-core/pom.xml
@@ -43,6 +43,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <!-- Controls certificate SAN for the TLS hostname-verification regression test (F-19).
+                 Version aligned with the transitive okhttp brought in by cui-test-mockwebserver-junit5. -->
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp-tls</artifactId>
+            <version>5.4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>de.cuioss.test</groupId>
             <artifactId>cui-test-value-objects</artifactId>
             <scope>test</scope>

--- a/cui-http-core/src/main/java/de/cuioss/http/client/HttpLogMessages.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/HttpLogMessages.java
@@ -92,6 +92,16 @@ public final class HttpLogMessages {
                 .identifier(114)
                 .template("Network error during %s request: %s")
                 .build();
+
+        /**
+         * Logged when a cleartext HTTP handler is built under the {@code allowInsecureHttp} opt-in.
+         * Used in: HttpHandler.HttpHandlerBuilder.build (http scheme with allowInsecureHttp=true)
+         */
+        public static final LogRecord INSECURE_HTTP_CONNECTION = LogRecordModel.builder()
+                .prefix(PREFIX)
+                .identifier(115)
+                .template("Using cleartext HTTP for %s (allowInsecureHttp=true); data is transmitted unencrypted")
+                .build();
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
@@ -27,7 +27,6 @@ import de.cuioss.http.client.result.HttpResult;
 import de.cuioss.tools.logging.CuiLogger;
 import org.jspecify.annotations.Nullable;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -433,7 +432,7 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
                     HttpResult.failure(
                             "Failed to build HTTP request: " + e.getMessage(),
                             e,
-                            HttpErrorCategory.CONFIGURATION_ERROR
+                            HttpErrorCategory.fromException(e)
                     )
             );
         }
@@ -535,7 +534,7 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
                     HttpResult.failure(
                             "Failed to build HTTP request: " + e.getMessage(),
                             e,
-                            HttpErrorCategory.CONFIGURATION_ERROR
+                            HttpErrorCategory.fromException(e)
                     )
             );
         }
@@ -564,13 +563,11 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
         return httpClient.sendAsync(request, responseConverter.getBodyHandler())
                 .thenApply(response -> handleHttpResponse(response, method, cachedEntry, cacheKey))
                 .exceptionally(throwable -> {
-                    // Classify exceptions
-                    HttpErrorCategory category;
-                    if (throwable instanceof IOException) {
-                        category = HttpErrorCategory.NETWORK_ERROR;
+                    // Classify via the single source of truth in client.result
+                    HttpErrorCategory category = HttpErrorCategory.fromException(throwable);
+                    if (category == HttpErrorCategory.NETWORK_ERROR) {
                         LOGGER.warn(WARN.NETWORK_ERROR_DURING_REQUEST, method.methodName(), throwable.getMessage());
                     } else {
-                        category = HttpErrorCategory.CONFIGURATION_ERROR;
                         LOGGER.error(ERROR.CONFIGURATION_ERROR_DURING_REQUEST, method.methodName(), throwable.getMessage());
                     }
 

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
@@ -442,10 +442,11 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
     /**
      * Applies converter-derived {@code Accept} and {@code Content-Type} headers.
      *
-     * <p>{@code Accept} is always set from the response converter's content type;
-     * {@code Content-Type} is set only when a request body is present. Both are applied
-     * with {@code setHeader} first so a caller-provided header of the same name in
-     * {@code callerHeaders} (added afterwards) overrides the default.</p>
+     * <p>Each default is applied <strong>only when the caller has not already supplied that
+     * header</strong> (checked case-insensitively against {@code callerHeaders}), so a
+     * caller-provided value always wins. {@code Accept} is defaulted from the response
+     * converter's content type; {@code Content-Type} is defaulted only when a request body is
+     * present.</p>
      *
      * @param requestBuilder the request builder to configure
      * @param callerHeaders caller-supplied headers (used to detect explicit overrides)

--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java
@@ -82,8 +82,22 @@ import java.util.regex.Pattern;
  *   <li>URI must be valid and convertible to URL (validated at build time)</li>
  *   <li>SSL context created automatically for HTTPS if not provided</li>
  *   <li>Default timeout: 10 seconds for both connection and read</li>
- *   <li>URLs without scheme prefix default to HTTPS</li>
+ *   <li>Schemeless string URLs default to HTTPS</li>
  * </ul>
+ *
+ * <h3>Scheme policy (fail-secure)</h3>
+ * <p>HTTPS is required by default. {@link HttpHandlerBuilder#build()} rejects an {@code http://}
+ * URI with {@link IllegalArgumentException} unless {@link HttpHandlerBuilder#allowInsecureHttp(boolean)}
+ * is set (default {@code false}); when permitted, a cleartext handler is built and a WARN is logged.
+ * Any scheme other than {@code http}/{@code https} is always rejected. This applies uniformly to
+ * {@code uri(URI)}, {@code url(URL)}, and string inputs.</p>
+ *
+ * <h3>TLS floor</h3>
+ * <p>For HTTPS, the configured minimum TLS version is pinned on the wire via
+ * {@link SSLParameters#setProtocols}. A minimum of TLS&nbsp;1.2 and the generic {@code "TLS"}
+ * context both enforce {@code [TLSv1.2, TLSv1.3]} (deliberate); a 1.3 minimum enforces
+ * {@code [TLSv1.3]}. A caller cannot express "TLS&nbsp;1.3-only" via the generic {@code "TLS"}
+ * string. See {@link SecureSSLContextProvider}.</p>
  *
  * @since 1.0
  * @see HttpClient
@@ -122,6 +136,18 @@ public final class HttpHandler {
     private final int connectionTimeoutSeconds;
     @Getter
     private final int readTimeoutSeconds;
+    /**
+     * Whether this handler was built with the cleartext-HTTP opt-in
+     * ({@link HttpHandlerBuilder#allowInsecureHttp(boolean)}). A build-time scheme policy retained
+     * so {@link #asBuilder()} preserves the opt-in; it does not affect the wire behavior of an
+     * already-built handler, so it is excluded from {@code equals}/{@code toString}.
+     *
+     * @return {@code true} if cleartext HTTP was explicitly permitted for this handler
+     */
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    @Getter
+    private final boolean allowInsecureHttp;
     private final HttpClient httpClient;
 
     // Constructor for HTTP URIs (no SSL context needed)
@@ -133,6 +159,8 @@ public final class HttpHandler {
         this.secureSSLContextProvider = new SecureSSLContextProvider();
         this.connectionTimeoutSeconds = connectionTimeoutSeconds;
         this.readTimeoutSeconds = readTimeoutSeconds;
+        // Reached only via the opt-in, so this handler was explicitly permitted to use cleartext.
+        this.allowInsecureHttp = true;
 
         // Create the HttpClient for HTTP
         this.httpClient = HttpClient.newBuilder()
@@ -142,13 +170,14 @@ public final class HttpHandler {
 
     // Constructor for HTTPS URIs (SSL context required)
     private HttpHandler(URI uri, URL url, SSLContext sslContext, SecureSSLContextProvider secureSSLContextProvider,
-            int connectionTimeoutSeconds, int readTimeoutSeconds) {
+            int connectionTimeoutSeconds, int readTimeoutSeconds, boolean allowInsecureHttp) {
         this.uri = uri;
         this.url = url;
         this.sslContext = sslContext;
         this.secureSSLContextProvider = secureSSLContextProvider;
         this.connectionTimeoutSeconds = connectionTimeoutSeconds;
         this.readTimeoutSeconds = readTimeoutSeconds;
+        this.allowInsecureHttp = allowInsecureHttp;
 
         // JDK 11+ HttpClient enables hostname verification by default.
         // Pin the enabled TLS protocols so the configured minimum version is a hard
@@ -192,7 +221,8 @@ public final class HttpHandler {
                 .connectionTimeoutSeconds(connectionTimeoutSeconds)
                 .readTimeoutSeconds(readTimeoutSeconds)
                 .sslContext(sslContext)
-                .tlsVersions(secureSSLContextProvider);
+                .tlsVersions(secureSSLContextProvider)
+                .allowInsecureHttp(allowInsecureHttp);
     }
 
     /**
@@ -266,6 +296,7 @@ public final class HttpHandler {
         private @Nullable SecureSSLContextProvider secureSSLContextProvider;
         private @Nullable Integer connectionTimeoutSeconds;
         private @Nullable Integer readTimeoutSeconds;
+        private boolean allowInsecureHttp = false;
 
         /**
          * Sets the URI as a string.
@@ -391,6 +422,23 @@ public final class HttpHandler {
         }
 
         /**
+         * Permits building a handler for a plaintext {@code http://} URI.
+         * <p>
+         * HTTPS is required by default (fail-secure): {@link #build()} rejects an {@code http://}
+         * URI unless this flag is set. When enabled, a cleartext handler is built and a WARN is
+         * logged recording the unencrypted connection. Schemes other than {@code http}/{@code https}
+         * are always rejected. Default: {@code false}.
+         * </p>
+         *
+         * @param allowInsecureHttp {@code true} to permit cleartext HTTP.
+         * @return This builder instance.
+         */
+        public HttpHandlerBuilder allowInsecureHttp(boolean allowInsecureHttp) {
+            this.allowInsecureHttp = allowInsecureHttp;
+            return this;
+        }
+
+        /**
          * Builds a new {@link HttpHandler} instance with the configured parameters.
          *
          * @return A new {@link HttpHandler} instance.
@@ -425,18 +473,28 @@ public final class HttpHandler {
                 throw new IllegalStateException("Failed to convert URI to URL: " + uri, e);
             }
 
-            // Use appropriate constructor based on scheme
-            if ("https".equalsIgnoreCase(uri.getScheme())) {
+            // Fail-secure scheme policy: HTTPS is required; http is opt-in; anything else is rejected.
+            String scheme = uri.getScheme();
+            if ("https".equalsIgnoreCase(scheme)) {
                 // For HTTPS, create or validate SSL context and pin the enabled protocols
                 SecureSSLContextProvider actualSecureSSLContextProvider = secureSSLContextProvider != null ?
                         secureSSLContextProvider : new SecureSSLContextProvider();
                 SSLContext secureContext = actualSecureSSLContextProvider.getOrCreateSecureSSLContext(sslContext);
                 return new HttpHandler(uri, verifiedUrl, secureContext, actualSecureSSLContextProvider,
-                        actualConnectionTimeoutSeconds, actualReadTimeoutSeconds);
-            } else {
+                        actualConnectionTimeoutSeconds, actualReadTimeoutSeconds, allowInsecureHttp);
+            }
+            if ("http".equalsIgnoreCase(scheme)) {
+                if (!allowInsecureHttp) {
+                    throw new IllegalArgumentException("Refusing to build a plaintext HTTP handler for " + uri
+                            + "; HTTPS is required. Call allowInsecureHttp(true) to permit cleartext HTTP, "
+                            + "or use an https:// URI.");
+                }
+                LOGGER.warn(HttpLogMessages.WARN.INSECURE_HTTP_CONNECTION, uri);
                 // For HTTP, no SSL context needed
                 return new HttpHandler(uri, verifiedUrl, actualConnectionTimeoutSeconds, actualReadTimeoutSeconds);
             }
+            throw new IllegalArgumentException("Unsupported URI scheme '" + scheme + "' for " + uri
+                    + "; only http and https are supported.");
         }
 
         /**

--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/SecureSSLContextProvider.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/SecureSSLContextProvider.java
@@ -157,6 +157,12 @@ public record SecureSSLContextProvider(String minimumTlsVersion) {
      *   <li>Minimum {@link #TLS_V1_3} → {@code [TLSv1.3]}</li>
      *   <li>Minimum {@link #TLS_V1_2} or generic {@link #TLS} → {@code [TLSv1.2, TLSv1.3]}</li>
      * </ul>
+     * <p>
+     * The generic {@link #TLS} value deliberately enforces the same {@code [TLSv1.2, TLSv1.3]}
+     * floor as an explicit 1.2 minimum - this is a security improvement over JVM-default
+     * negotiation (which could include older enabled protocols). A consequence is that a caller
+     * <strong>cannot</strong> express a "TLS&nbsp;1.3-only" policy via the generic {@code "TLS"}
+     * string; select {@link #TLS_V1_3} explicitly for that.
      *
      * @return the ordered array of enabled protocol versions (never empty)
      */

--- a/cui-http-core/src/main/java/de/cuioss/http/client/result/HttpErrorCategory.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/result/HttpErrorCategory.java
@@ -15,6 +15,10 @@
  */
 package de.cuioss.http.client.result;
 
+import java.io.IOException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
 /**
  * Error categories for HTTP operations, used to classify failures for retry decisions.
  * Each category indicates whether the error is transient (retryable) or permanent.
@@ -81,6 +85,35 @@ public enum HttpErrorCategory {
      */
     public boolean isRetryable() {
         return this == NETWORK_ERROR || this == SERVER_ERROR;
+    }
+
+    /**
+     * Classifies a {@link Throwable} raised while executing or building an HTTP request into an
+     * error category. An {@link IOException} (connection/read timeout, DNS or connection failure)
+     * maps to the retryable {@link #NETWORK_ERROR}; any other throwable (e.g.
+     * {@link IllegalArgumentException} / {@link IllegalStateException} from request building, or a
+     * misconfiguration) maps to the non-retryable {@link #CONFIGURATION_ERROR}.
+     *
+     * <p>Asynchronous pipelines ({@link java.util.concurrent.CompletableFuture}) deliver failures
+     * wrapped in {@link CompletionException} / {@link ExecutionException}. Such wrappers are
+     * unwrapped to their cause before classification, so an {@code IOException} surfaced through a
+     * {@code CompletableFuture.exceptionally(...)} callback is still correctly classified as a
+     * retryable network error.</p>
+     *
+     * <p>This is the single source of truth for exception classification. It deliberately uses a
+     * JDK-only import so the {@code client.result} package does not depend on
+     * {@code client.handler}, preserving the {@code handler &rarr; result} layering.</p>
+     *
+     * @param throwable the failure to classify
+     * @return the corresponding error category
+     */
+    public static HttpErrorCategory fromException(Throwable throwable) {
+        Throwable unwrapped = throwable;
+        while ((unwrapped instanceof CompletionException || unwrapped instanceof ExecutionException)
+                && unwrapped.getCause() != null && unwrapped.getCause() != unwrapped) {
+            unwrapped = unwrapped.getCause();
+        }
+        return unwrapped instanceof IOException ? NETWORK_ERROR : CONFIGURATION_ERROR;
     }
 
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
@@ -85,7 +85,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         assertTrue(result1.isSuccess(), "First request should succeed");
         assertEquals("{\"id\":1,\"name\":\"test\"}", result1.getContent().orElse(null));
         assertEquals("\"etag-123\"", result1.getETag().orElse(null));
-        assertEquals(200, result1.getHttpStatus().orElse(-1));
+        assertEquals(Optional.of(200), result1.getHttpStatus());
 
         // Configure dispatcher to return 304 for second request
         dispatcher.with304();
@@ -95,7 +95,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         assertTrue(result2.isSuccess(), "Second request should succeed with cached content");
         assertEquals("{\"id\":1,\"name\":\"test\"}", result2.getContent().orElse(null), "Should return cached content");
         assertEquals("\"etag-123\"", result2.getETag().orElse(null), "Should preserve cached ETag");
-        assertEquals(304, result2.getHttpStatus().orElse(-1), "Status code should be 304");
+        assertEquals(Optional.of(304), result2.getHttpStatus(), "Status code should be 304");
 
         // Verify If-None-Match header was sent on second request
         assertTrue(dispatcher.getLastIfNoneMatch().isPresent(), "If-None-Match header should be sent");
@@ -189,7 +189,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         assertTrue(result.isSuccess(), "DELETE should succeed");
         // 204 response has empty body, but StringResponseConverter converts empty string to empty Optional
         // Content may be present (empty string) or absent depending on converter implementation
-        assertEquals(204, result.getHttpStatus().orElse(-1));
+        assertEquals(Optional.of(204), result.getHttpStatus());
     }
 
     /**
@@ -210,7 +210,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         HttpResult<Void> result = adapter.deleteBlocking();
 
         assertTrue(result.isSuccess(), "204 with Void converter must be success, not INVALID_CONTENT failure");
-        assertEquals(204, result.getHttpStatus().orElse(-1));
+        assertEquals(Optional.of(204), result.getHttpStatus());
         assertTrue(result.getContent().isEmpty(), "Void result carries no content");
         assertTrue(result.getErrorCategory().isEmpty(), "Success must not carry an error category");
     }
@@ -232,7 +232,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         HttpResult<Void> result = adapter.headBlocking();
 
         assertTrue(result.isSuccess(), "200 with Void converter must be success");
-        assertEquals(200, result.getHttpStatus().orElse(-1));
+        assertEquals(Optional.of(200), result.getHttpStatus());
         assertEquals("\"etag-head\"", result.getETag().orElse(null), "ETag should be exposed");
     }
 
@@ -254,7 +254,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         HttpResult<Void> result = adapter.getBlocking();
 
         assertTrue(result.isSuccess(), "200 with Void converter must be success");
-        assertEquals(200, result.getHttpStatus().orElse(-1));
+        assertEquals(Optional.of(200), result.getHttpStatus());
 
         // Second GET must not send If-None-Match (nothing was cached)
         HttpResult<Void> result2 = adapter.getBlocking();
@@ -336,7 +336,7 @@ class ETagAwareHttpAdapterIntegrationTest {
 
         assertFalse(result.isSuccess(), "Server error should result in failure");
         assertEquals(HttpErrorCategory.SERVER_ERROR, result.getErrorCategory().orElse(null));
-        assertEquals(503, result.getHttpStatus().orElse(-1));
+        assertEquals(Optional.of(503), result.getHttpStatus());
         assertTrue(result.isRetryable(), "Server errors should be retryable");
     }
 
@@ -361,7 +361,7 @@ class ETagAwareHttpAdapterIntegrationTest {
 
         assertFalse(result.isSuccess(), "Client error should result in failure");
         assertEquals(HttpErrorCategory.CLIENT_ERROR, result.getErrorCategory().orElse(null));
-        assertEquals(404, result.getHttpStatus().orElse(-1));
+        assertEquals(Optional.of(404), result.getHttpStatus());
         assertFalse(result.isRetryable(), "Client errors should not be retryable");
     }
 

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
@@ -73,7 +73,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         dispatcher.withSuccessAndETag("{\"id\":1,\"name\":\"test\"}", "\"etag-123\"");
 
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<String> adapter = ETagAwareHttpAdapter.<String>builder()
                 .httpHandler(handler)
@@ -112,7 +112,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         dispatcher.withSuccessAndETag("{\"id\":2,\"name\":\"created\"}", "\"etag-456\"");
 
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<String> adapter = ETagAwareHttpAdapter.<String>builder()
                 .httpHandler(handler)
@@ -150,7 +150,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         dispatcher.withSuccessAndETag("{\"id\":1,\"name\":\"updated\"}", "\"etag-updated\"");
 
         String serverUrl = uriBuilder.addPathSegments("api", "data", "1").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<String> adapter = ETagAwareHttpAdapter.<String>builder()
                 .httpHandler(handler)
@@ -177,7 +177,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         dispatcher.withNoContent();
 
         String serverUrl = uriBuilder.addPathSegments("api", "data", "1").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<String> adapter = ETagAwareHttpAdapter.<String>builder()
                 .httpHandler(handler)
@@ -203,7 +203,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         dispatcher.withNoContent();
 
         String serverUrl = uriBuilder.addPathSegments("api", "data", "1").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<Void> adapter = ETagAwareHttpAdapter.statusCodeOnly(handler);
 
@@ -225,7 +225,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         dispatcher.withSuccessAndETag("", "\"etag-head\"");
 
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<Void> adapter = ETagAwareHttpAdapter.statusCodeOnly(handler);
 
@@ -247,7 +247,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         dispatcher.withSuccessAndETag("ignored-body", "\"etag-get\"");
 
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<Void> adapter = ETagAwareHttpAdapter.statusCodeOnly(handler);
 
@@ -273,7 +273,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         dispatcher.withSuccessAndETag("{}", "\"e\"");
 
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<String> adapter = ETagAwareHttpAdapter.<String>builder()
                 .httpHandler(handler)
@@ -297,7 +297,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         dispatcher.withSuccessAndETag("{}", "\"e\"");
 
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<String> adapter = ETagAwareHttpAdapter.<String>builder()
                 .httpHandler(handler)
@@ -325,7 +325,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         dispatcher.withServerError();
 
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<String> adapter = ETagAwareHttpAdapter.<String>builder()
                 .httpHandler(handler)
@@ -350,7 +350,7 @@ class ETagAwareHttpAdapterIntegrationTest {
         dispatcher.withClientError();
 
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<String> adapter = ETagAwareHttpAdapter.<String>builder()
                 .httpHandler(handler)
@@ -375,7 +375,7 @@ class ETagAwareHttpAdapterIntegrationTest {
     void connectionRefusedShouldReturnFailure() {
         // Use an unreachable URL to simulate connection failure
         String unreachableUrl = "http://localhost:1/unreachable";
-        HttpHandler handler = HttpHandler.builder().url(unreachableUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(unreachableUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<String> adapter = ETagAwareHttpAdapter.<String>builder()
                 .httpHandler(handler)

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ResilientHttpAdapterIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ResilientHttpAdapterIntegrationTest.java
@@ -173,7 +173,7 @@ class ResilientHttpAdapterIntegrationTest {
         assertTrue(result2.isSuccess(), "304 response should be success (from cache)");
         assertEquals("{\"data\":\"cached\"}", result2.getContent().orElse(null), "Should return cached content");
         assertEquals("\"etag-composed\"", result2.getETag().orElse(null));
-        assertEquals(304, result2.getHttpStatus().orElse(-1));
+        assertEquals(Optional.of(304), result2.getHttpStatus());
 
         // 304 is a success, not retried
         assertTrue(result2.isSuccess(), "304 should not trigger retry");
@@ -210,7 +210,7 @@ class ResilientHttpAdapterIntegrationTest {
         HttpResult<String> result2 = resilientAdapter.getBlocking();
 
         assertTrue(result2.isSuccess(), "304 should be treated as success");
-        assertEquals(304, result2.getHttpStatus().orElse(-1));
+        assertEquals(Optional.of(304), result2.getHttpStatus());
         assertEquals("{\"data\":\"original\"}", result2.getContent().orElse(null), "Should return cached content");
         assertEquals(1, dispatcher.getCallCounter(), "304 should not trigger retry (only 1 call)");
     }

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ResilientHttpAdapterIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ResilientHttpAdapterIntegrationTest.java
@@ -71,7 +71,7 @@ class ResilientHttpAdapterIntegrationTest {
         dispatcher.withSuccessThenError("{\"status\":\"ok\"}", "\"etag-retry\"");
 
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<String> baseAdapter = ETagAwareHttpAdapter.<String>builder()
                 .httpHandler(handler)
@@ -116,7 +116,7 @@ class ResilientHttpAdapterIntegrationTest {
         dispatcher.withClientError();
 
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<String> baseAdapter = ETagAwareHttpAdapter.<String>builder()
                 .httpHandler(handler)
@@ -148,7 +148,7 @@ class ResilientHttpAdapterIntegrationTest {
         dispatcher.withSuccessAndETag("{\"data\":\"cached\"}", "\"etag-composed\"");
 
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         // Stack: ResilientHttpAdapter -> ETagAwareHttpAdapter
         HttpAdapter<String> etagAdapter = ETagAwareHttpAdapter.<String>builder()
@@ -190,7 +190,7 @@ class ResilientHttpAdapterIntegrationTest {
         dispatcher.withSuccessAndETag("{\"data\":\"original\"}", "\"etag-304\"");
 
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<String> etagAdapter = ETagAwareHttpAdapter.<String>builder()
                 .httpHandler(handler)
@@ -225,7 +225,7 @@ class ResilientHttpAdapterIntegrationTest {
         dispatcher.withServerError();
 
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<String> baseAdapter = ETagAwareHttpAdapter.<String>builder()
                 .httpHandler(handler)
@@ -254,7 +254,7 @@ class ResilientHttpAdapterIntegrationTest {
         dispatcher.withServerErrorThenSuccess("{\"created\":true}", null);
 
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
-        HttpHandler handler = HttpHandler.builder().url(serverUrl).build();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
 
         HttpAdapter<String> baseAdapter = ETagAwareHttpAdapter.<String>builder()
                 .httpHandler(handler)

--- a/cui-http-core/src/test/java/de/cuioss/http/client/converter/HttpResponseConverterTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/converter/HttpResponseConverterTest.java
@@ -107,7 +107,9 @@ class HttpResponseConverterTest {
 
     @Test
     void emptyContentIsValidDefaultsToFalse() {
-        var converter = new TestStringConverter();
+        // Assert the interface default through a production converter that does not override it,
+        // so the test proves the real shipping contract rather than a synthetic double.
+        var converter = StringContentConverter.identity();
 
         assertFalse(converter.emptyContentIsValid(),
                 "Content-producing converters must treat empty conversion results as failures");

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerHostnameVerificationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerHostnameVerificationTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.client.handler;
+
+import okhttp3.tls.HandshakeCertificates;
+import okhttp3.tls.HeldCertificate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLServerSocket;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression test guarding TLS hostname verification for {@link HttpHandler} (F-19).
+ *
+ * <p>PR #76 manipulates {@link javax.net.ssl.SSLParameters} - the object that, if mishandled,
+ * would disable hostname verification. Verification currently stays on only because
+ * {@code java.net.http.HttpClient} forces {@code "HTTPS"} endpoint identification internally, but
+ * no test guarded it. These tests connect over real TLS to an in-JVM server and assert that a
+ * certificate whose SAN does <em>not</em> match the connected host is rejected, while an otherwise
+ * identical matching certificate is accepted - so a future {@code SSLParameters} refactor cannot
+ * silently disable hostname verification.</p>
+ */
+@DisplayName("HttpHandler TLS hostname verification (F-19)")
+class HttpHandlerHostnameVerificationTest {
+
+    /**
+     * A matching-hostname certificate ({@code SAN=localhost}) is accepted: the handshake succeeds
+     * and the request returns SUCCESS. This confirms the trust chain and server are sound, isolating
+     * the SAN as the only variable in the negative test below.
+     */
+    @Test
+    @DisplayName("Matching-SAN certificate is accepted")
+    void shouldAcceptMatchingHostname() throws Exception {
+        HeldCertificate cert = new HeldCertificate.Builder()
+                .commonName("localhost")
+                .addSubjectAlternativeName("localhost")
+                .build();
+        try (OneShotTlsServer server = OneShotTlsServer.start(cert)) {
+            HttpHandler handler = HttpHandler.builder()
+                    .uri("https://localhost:" + server.port())
+                    .sslContext(clientTrusting(cert))
+                    .connectionTimeoutSeconds(5)
+                    .readTimeoutSeconds(5)
+                    .build();
+
+            assertEquals(HttpStatusFamily.SUCCESS, handler.pingGet(),
+                    "A certificate whose SAN matches the connected host must be accepted");
+        }
+    }
+
+    /**
+     * A mismatched-hostname certificate ({@code SAN=wrong.host.invalid}) is rejected: the handshake
+     * fails, so the ping does not reach a 200 and returns UNKNOWN. A client with hostname
+     * verification disabled would instead complete the handshake and observe SUCCESS.
+     */
+    @Test
+    @DisplayName("Mismatched-SAN certificate is rejected")
+    void shouldRejectWrongHostname() throws Exception {
+        HeldCertificate cert = new HeldCertificate.Builder()
+                .commonName("wrong.host.invalid")
+                .addSubjectAlternativeName("wrong.host.invalid")
+                .build();
+        try (OneShotTlsServer server = OneShotTlsServer.start(cert)) {
+            HttpHandler handler = HttpHandler.builder()
+                    .uri("https://localhost:" + server.port())
+                    .sslContext(clientTrusting(cert))
+                    .connectionTimeoutSeconds(5)
+                    .readTimeoutSeconds(5)
+                    .build();
+
+            assertEquals(HttpStatusFamily.UNKNOWN, handler.pingGet(),
+                    "A certificate whose SAN does not match the connected host must be rejected "
+                            + "(hostname verification active)");
+        }
+    }
+
+    /**
+     * Builds a client {@link SSLContext} that trusts exactly the given certificate, so that any
+     * handshake failure is attributable to hostname verification rather than trust.
+     */
+    private static SSLContext clientTrusting(HeldCertificate cert) {
+        return new HandshakeCertificates.Builder()
+                .addTrustedCertificate(cert.certificate())
+                .build()
+                .sslContext();
+    }
+
+    /**
+     * A minimal single-connection TLS server that presents the supplied certificate and answers the
+     * first request with an empty {@code 200 OK}. Runs its accept loop on a background thread.
+     */
+    private static final class OneShotTlsServer implements AutoCloseable {
+
+        private final SSLServerSocket serverSocket;
+        private final ExecutorService executor;
+
+        private OneShotTlsServer(SSLServerSocket serverSocket, ExecutorService executor) {
+            this.serverSocket = serverSocket;
+            this.executor = executor;
+        }
+
+        static OneShotTlsServer start(HeldCertificate cert) throws IOException {
+            SSLContext serverContext = new HandshakeCertificates.Builder()
+                    .heldCertificate(cert)
+                    .build()
+                    .sslContext();
+            SSLServerSocket socket = (SSLServerSocket) serverContext.getServerSocketFactory()
+                    .createServerSocket(0);
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            OneShotTlsServer server = new OneShotTlsServer(socket, executor);
+            executor.submit(server::serveOnce);
+            return server;
+        }
+
+        private void serveOnce() {
+            try (Socket client = serverSocket.accept();
+                 InputStream in = client.getInputStream();
+                 OutputStream out = client.getOutputStream()) {
+                // Drain the request line/headers (best effort) so the client can finish sending.
+                byte[] buffer = new byte[1024];
+                if (in.read(buffer) > 0) {
+                    // ignore contents; we only need the request to arrive
+                }
+                out.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                        .getBytes(StandardCharsets.US_ASCII));
+                out.flush();
+            } catch (IOException e) {
+                // Expected when the handshake is rejected by the client (hostname mismatch).
+            }
+        }
+
+        int port() {
+            return serverSocket.getLocalPort();
+        }
+
+        @Override
+        public void close() throws IOException {
+            executor.shutdownNow();
+            serverSocket.close();
+        }
+    }
+}

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerIntegrationTest.java
@@ -58,6 +58,7 @@ class HttpHandlerIntegrationTest {
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
         HttpHandler handler = HttpHandler.builder()
                 .url(serverUrl)
+                .allowInsecureHttp(true)
                 .build();
 
         HttpStatusFamily status = handler.pingHead();
@@ -74,6 +75,7 @@ class HttpHandlerIntegrationTest {
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
         HttpHandler handler = HttpHandler.builder()
                 .url(serverUrl)
+                .allowInsecureHttp(true)
                 .build();
 
         HttpStatusFamily status = handler.pingGet();
@@ -90,6 +92,7 @@ class HttpHandlerIntegrationTest {
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
         HttpHandler handler = HttpHandler.builder()
                 .url(serverUrl)
+                .allowInsecureHttp(true)
                 .build();
 
         HttpStatusFamily status = handler.pingHead();
@@ -106,6 +109,7 @@ class HttpHandlerIntegrationTest {
         String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
         HttpHandler handler = HttpHandler.builder()
                 .url(serverUrl)
+                .allowInsecureHttp(true)
                 .build();
 
         HttpStatusFamily status = handler.pingGet();

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerTest.java
@@ -292,6 +292,7 @@ class HttpHandlerTest {
         void shouldNotCreateSslContextForHttpUrls() {
             HttpHandler handler = HttpHandler.builder()
                     .url("http://example.com")
+                    .allowInsecureHttp(true) // fail-secure: http requires explicit opt-in (F-20)
                     .build();
 
             assertNotNull(handler);
@@ -545,6 +546,69 @@ class HttpHandlerTest {
             var exception = assertThrows(IllegalArgumentException.class, builder::build);
             assertEquals("URI must not be null or empty.", exception.getMessage(),
                     "Should throw IllegalArgumentException for missing URL");
+        }
+    }
+
+    @Nested
+    @DisplayName("Scheme policy (F-20)")
+    class SchemePolicy {
+
+        @Test
+        @DisplayName("http is rejected by default (fail-secure)")
+        void shouldRejectHttpByDefault() {
+            var builder = HttpHandler.builder().uri("http://example.com");
+            var exception = assertThrows(IllegalArgumentException.class, builder::build);
+            assertTrue(exception.getMessage().contains("HTTPS is required"),
+                    "Plaintext HTTP must be rejected without opt-in");
+        }
+
+        @Test
+        @DisplayName("http is permitted with allowInsecureHttp and logs a WARN")
+        void shouldAllowHttpWithOptIn() {
+            HttpHandler handler = HttpHandler.builder()
+                    .uri("http://example.com")
+                    .allowInsecureHttp(true)
+                    .build();
+
+            assertNotNull(handler);
+            assertNull(handler.getSslContext(), "HTTP handler must not create an SSL context");
+            assertTrue(handler.isAllowInsecureHttp());
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "allowInsecureHttp=true");
+        }
+
+        @Test
+        @DisplayName("https is unchanged (allowed, TLS)")
+        void shouldAllowHttps() {
+            HttpHandler handler = HttpHandler.builder()
+                    .uri("https://example.com")
+                    .build();
+
+            assertNotNull(handler.getSslContext(), "HTTPS handler must have an SSL context");
+        }
+
+        @Test
+        @DisplayName("non-http(s) schemes are always rejected")
+        void shouldRejectOtherSchemes() {
+            for (String badUri : new String[]{"ftp://example.com/file", "file:///etc/passwd"}) {
+                var builder = HttpHandler.builder().uri(badUri).allowInsecureHttp(true);
+                var exception = assertThrows(IllegalArgumentException.class, builder::build,
+                        "Scheme must be rejected: " + badUri);
+                assertTrue(exception.getMessage().contains("Unsupported URI scheme"),
+                        "Message should identify the unsupported scheme for: " + badUri);
+            }
+        }
+
+        @Test
+        @DisplayName("asBuilder preserves allowInsecureHttp")
+        void asBuilderShouldPreserveAllowInsecureHttp() {
+            HttpHandler handler = HttpHandler.builder()
+                    .uri("http://example.com")
+                    .allowInsecureHttp(true)
+                    .build();
+
+            // Rebuild an HTTP handler from the clone - would be rejected if the flag were lost.
+            HttpHandler cloned = handler.asBuilder().uri("http://other.example.com").build();
+            assertTrue(cloned.isAllowInsecureHttp(), "asBuilder() must carry the allowInsecureHttp flag");
         }
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/client/result/HttpErrorCategoryTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/result/HttpErrorCategoryTest.java
@@ -17,8 +17,12 @@ package de.cuioss.http.client.result;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.Arrays;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -87,5 +91,42 @@ class HttpErrorCategoryTest {
                 .collect(Collectors.toSet());
         assertEquals(Set.of(HttpErrorCategory.CLIENT_ERROR, HttpErrorCategory.INVALID_CONTENT, HttpErrorCategory.CONFIGURATION_ERROR), nonRetryable,
                 "CLIENT_ERROR, INVALID_CONTENT, and CONFIGURATION_ERROR should be non-retryable.");
+    }
+
+    @Test
+    void fromExceptionShouldMapIOExceptionToNetworkError() {
+        assertEquals(HttpErrorCategory.NETWORK_ERROR,
+                HttpErrorCategory.fromException(new IOException("timeout")));
+        assertEquals(HttpErrorCategory.NETWORK_ERROR,
+                HttpErrorCategory.fromException(new SocketTimeoutException()),
+                "IOException subclasses are network errors too");
+    }
+
+    @Test
+    void fromExceptionShouldUnwrapAsyncWrappersAroundIOException() {
+        // CompletableFuture pipelines deliver failures wrapped in CompletionException/ExecutionException.
+        assertEquals(HttpErrorCategory.NETWORK_ERROR,
+                HttpErrorCategory.fromException(new CompletionException(new IOException("connect failed"))),
+                "CompletionException-wrapped IOException must be a retryable network error");
+        assertEquals(HttpErrorCategory.NETWORK_ERROR,
+                HttpErrorCategory.fromException(new ExecutionException(new SocketTimeoutException())),
+                "ExecutionException-wrapped IOException must be a retryable network error");
+        // Nested wrappers are unwrapped too.
+        assertEquals(HttpErrorCategory.NETWORK_ERROR,
+                HttpErrorCategory.fromException(
+                        new CompletionException(new ExecutionException(new IOException("read timeout")))));
+        // A wrapper around a non-IOException stays a configuration error.
+        assertEquals(HttpErrorCategory.CONFIGURATION_ERROR,
+                HttpErrorCategory.fromException(new CompletionException(new IllegalStateException("bad state"))));
+    }
+
+    @Test
+    void fromExceptionShouldMapOtherThrowablesToConfigurationError() {
+        assertEquals(HttpErrorCategory.CONFIGURATION_ERROR,
+                HttpErrorCategory.fromException(new IllegalArgumentException("bad request")));
+        assertEquals(HttpErrorCategory.CONFIGURATION_ERROR,
+                HttpErrorCategory.fromException(new IllegalStateException("bad state")));
+        assertEquals(HttpErrorCategory.CONFIGURATION_ERROR,
+                HttpErrorCategory.fromException(new RuntimeException("other")));
     }
 }

--- a/doc/LogMessages.adoc
+++ b/doc/LogMessages.adoc
@@ -60,6 +60,11 @@ LogMessages Classes:
 |Handler
 |Network error during %s request: %s
 |Logged when a network error occurs during an HTTP request. Parameters: HTTP method, error message.
+
+|HTTP-115
+|Handler
+|Using cleartext HTTP for %s (allowInsecureHttp=true); data is transmitted unencrypted
+|Logged when a cleartext HTTP handler is built under the allowInsecureHttp opt-in. Parameters: URI.
 |===
 
 == ERROR Level (200-299)

--- a/doc/client-handlers-readme.adoc
+++ b/doc/client-handlers-readme.adoc
@@ -34,6 +34,25 @@ Builder-based HTTP client wrapper with automatic SSL context creation for HTTPS.
 * Configurable connection and read timeouts (default: 10 seconds)
 * Thread-safe after construction
 
+*Scheme policy (fail-secure):* HTTPS is required by default. `build()` rejects an `http://`
+URI with `IllegalArgumentException` unless `allowInsecureHttp(true)` is set (default `false`);
+when permitted, a cleartext handler is built and a WARN (`HTTP-115`) is logged. Any scheme
+other than `http`/`https` is always rejected. Schemeless string URLs default to `https`. This
+applies uniformly to `uri(URI)`, `url(URL)`, and string inputs.
+
+[source,java]
+----
+// Rejected: plaintext HTTP requires an explicit opt-in
+HttpHandler.builder().uri("http://api.example.com").build(); // throws IllegalArgumentException
+
+// Permitted (logs a WARN), e.g. for a trusted plaintext test endpoint
+HttpHandler.builder().uri("http://localhost:8080").allowInsecureHttp(true).build();
+----
+
+*TLS floor:* for HTTPS the configured minimum TLS version is pinned on the wire. A TLS 1.2
+minimum and the generic `TLS` context both enforce `[TLSv1.2, TLSv1.3]` (deliberate); a caller
+cannot express "TLS 1.3-only" via the generic `TLS` string.
+
 ==== xref:../cui-http-core/src/main/java/de/cuioss/http/client/adapter/package-info.java[HTTP Adapters (New Architecture)]
 
 Async-first HTTP client adapters with composable retry and caching.

--- a/doc/security-readme.adoc
+++ b/doc/security-readme.adoc
@@ -100,6 +100,20 @@ String validated = validator.validate(userInput)
 ----
 
 
+== TLS Floor
+
+For HTTPS connections, `SecureSSLContextProvider` pins the enabled protocols on the wire (via
+`SSLParameters.setProtocols`) so the configured minimum TLS version is a hard floor, not merely
+the context's default protocol object:
+
+* Minimum `TLSv1.3` enforces `[TLSv1.3]`.
+* Minimum `TLSv1.2` *and* the generic `TLS` value both enforce `[TLSv1.2, TLSv1.3]` — this is
+  deliberate and a security improvement over JVM-default negotiation.
+
+A consequence is that a caller cannot express a "TLS 1.3-only" policy through the generic `TLS`
+string; select `TLSv1.3` explicitly for that. This is a behavior change from the earlier
+JVM-default negotiation (release note).
+
 == Pipeline Selection Rules
 
 See xref:http-security/specification/pipeline-architecture-standards.adoc[Pipeline Architecture Standards] for detailed selection criteria.


### PR DESCRIPTION
Post-merge review remediation (ledger, client-handler group). Each finding is a separate commit referencing its ID.

## Findings

- **F-20** feat: HTTPS **fail-secure by default**. New builder flag `allowInsecureHttp(boolean)` (default `false`); `build()` rejects `http://` unless opted in (then plaintext + WARN `HTTP-115`), rejects any non-`http(s)` scheme, keeps schemeless-string→`https`; `asBuilder()` carries the flag. Uniform across `uri(URI)`/`url(URL)`/string. Breaking (1.5-SNAPSHOT); test code opted in.
- **F-19** test: deterministic TLS **hostname-verification** regression test — in-JVM one-shot TLS server with matching vs mismatched-SAN cert (via okhttp-tls); matching accepted, mismatched rejected.
- **F-10** docs: correct `applyContentTypeHeaders` Javadoc (default applied only when caller header absent).
- **F-01** refactor: consolidate exception→category mapping into `HttpErrorCategory.fromException(Throwable)` (JDK-only import, preserves `handler→result` layering); 3 call sites routed through it.
- **F-02** test: whole-Optional assertions for HTTP status (10 sites) instead of the `orElse(-1)` sentinel.
- **F-03** test: assert `emptyContentIsValid` default via production `StringContentConverter.identity()`.
- **F-09** docs: document the deliberate TLS 1.2 floor for the generic `TLS` value (SecureSSLContextProvider Javadoc + security-readme); cannot express "1.3-only" via generic string.

## Verification

`./mvnw -Ppre-commit clean verify` — BUILD SUCCESS (5283 core tests, 0 failures).

Working notes for the review ledger are not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in for plaintext `http://` connections. `https` is enforced by default; `http://` is rejected unless explicitly enabled, with a WARN when enabled.
  * Improved error classification by deriving categories from exceptions (including async wrapper unwrapping).

* **Bug Fixes**
  * Refined request-building/execution failure handling and alignment of related status assertions.

* **Documentation**
  * Documented the HTTP/HTTPS scheme policy, new WARN `HTTP-115`, and TLS “TLS floor” behavior.

* **Tests**
  * Added/expanded TLS hostname verification and scheme-policy regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->