### PR TITLE
chore(release): prepare release 2.0.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,8 +2,8 @@ name: cui-http
 description: CUI HTTP client utilities
 
 release:
-  current-version: 1.4.1
-  next-version: 1.5-SNAPSHOT
+  current-version: 2.0.0
+  next-version: 2.1-SNAPSHOT
   create-github-release: true
 
 maven-build:


### PR DESCRIPTION
Bump `current-version` to `2.0.0`, `next-version` to `2.1-SNAPSHOT`.

This is a **major** release (from 1.4.1), requested explicitly. Merging this PR triggers the automated Release workflow on `.github/project.yml` changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s release version settings to the latest major release and the next snapshot version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->