### PR TITLE
fix(test): resolve actionable CodeQL code-scanning findings

### DIFF
--- a/cui-http-core/src/test/java/de/cuioss/http/client/result/HttpResultTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/result/HttpResultTest.java
@@ -367,8 +367,8 @@ class HttpResultTest {
             HttpResult<String> result = HttpResult.failure(errorMsg, null, HttpErrorCategory.CLIENT_ERROR);
 
             String matched = switch (result) {
-                case HttpResult.Success<String>(var c, var e, var s) ->
-                    "Success: " + c;
+                case HttpResult.Success<String> success ->
+                    "Success: " + success.content();
                 case HttpResult.Failure<String> f ->
                     "Failure: " + f.errorMessage();
             };

--- a/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java
@@ -29,9 +29,6 @@ class SecurityDefaultsTest {
         assertEquals(1024, SecurityDefaults.MAX_PATH_LENGTH_STRICT);
         assertEquals(4096, SecurityDefaults.MAX_PATH_LENGTH_DEFAULT);
         assertEquals(8192, SecurityDefaults.MAX_PATH_LENGTH_LENIENT);
-
-        assertTrue(SecurityDefaults.MAX_PATH_LENGTH_STRICT < SecurityDefaults.MAX_PATH_LENGTH_DEFAULT);
-        assertTrue(SecurityDefaults.MAX_PATH_LENGTH_DEFAULT < SecurityDefaults.MAX_PATH_LENGTH_LENIENT);
     }
 
     @Test
@@ -39,9 +36,6 @@ class SecurityDefaultsTest {
         assertEquals(20, SecurityDefaults.MAX_PARAMETER_COUNT_STRICT);
         assertEquals(100, SecurityDefaults.MAX_PARAMETER_COUNT_DEFAULT);
         assertEquals(500, SecurityDefaults.MAX_PARAMETER_COUNT_LENIENT);
-
-        assertTrue(SecurityDefaults.MAX_PARAMETER_COUNT_STRICT < SecurityDefaults.MAX_PARAMETER_COUNT_DEFAULT);
-        assertTrue(SecurityDefaults.MAX_PARAMETER_COUNT_DEFAULT < SecurityDefaults.MAX_PARAMETER_COUNT_LENIENT);
     }
 
     @Test
@@ -90,9 +84,6 @@ class SecurityDefaultsTest {
         assertEquals(SecurityDefaults.MAX_BODY_SIZE_STRICT, 1024 * 1024);
         assertEquals(SecurityDefaults.MAX_BODY_SIZE_DEFAULT, 5 * 1024 * 1024);
         assertEquals(SecurityDefaults.MAX_BODY_SIZE_LENIENT, 10 * 1024 * 1024);
-
-        assertTrue(SecurityDefaults.MAX_BODY_SIZE_STRICT < SecurityDefaults.MAX_BODY_SIZE_DEFAULT);
-        assertTrue(SecurityDefaults.MAX_BODY_SIZE_DEFAULT < SecurityDefaults.MAX_BODY_SIZE_LENIENT);
     }
 
     @Test
@@ -310,17 +301,5 @@ class SecurityDefaultsTest {
         assertTrue(SecurityDefaults.PROBLEMATIC_CONTROL_CHARS.size() > 10);
         assertTrue(SecurityDefaults.INJECTION_CHARACTERS.size() > 5);
         // XSS patterns removed - application layer responsibility
-    }
-
-    @Test
-    void shouldHaveLogicalProgression() {
-        assertTrue(SecurityDefaults.MAX_PATH_LENGTH_STRICT < SecurityDefaults.MAX_PATH_LENGTH_DEFAULT);
-        assertTrue(SecurityDefaults.MAX_PATH_LENGTH_DEFAULT < SecurityDefaults.MAX_PATH_LENGTH_LENIENT);
-
-        assertTrue(SecurityDefaults.MAX_BODY_SIZE_STRICT < SecurityDefaults.MAX_BODY_SIZE_DEFAULT);
-        assertTrue(SecurityDefaults.MAX_BODY_SIZE_DEFAULT < SecurityDefaults.MAX_BODY_SIZE_LENIENT);
-
-        assertTrue(SecurityDefaults.MAX_PARAMETER_COUNT_STRICT < SecurityDefaults.MAX_PARAMETER_COUNT_DEFAULT);
-        assertTrue(SecurityDefaults.MAX_PARAMETER_COUNT_DEFAULT < SecurityDefaults.MAX_PARAMETER_COUNT_LENIENT);
     }
 }


### PR DESCRIPTION
## Summary

Analyzed the open CodeQL code-scanning alerts and fixed the ones that are genuine, actionable code issues. Structural (repo-policy) alerts and false positives are left as-is and documented below.

## Fixed

| Rule | Location | Fix |
|---|---|---|
| `java/local-variable-is-never-read` | `HttpResultTest` | The `Success` record deconstruction bound `etag`/`httpStatus` pattern variables that were never read. Replaced with a type pattern reading only `content()`. |
| `java/constant-comparison` ("Test is always true") | `SecurityDefaultsTest` | Removed redundant always-true ordering assertions between compile-time constants (exact values are already asserted via `assertEquals`), and the wholly-redundant `shouldHaveLogicalProgression` test. |

## Deliberately not changed

- **`java/unknown-javadoc-parameter`** (`HttpResult`, `UrlSecurityException`): Lombok `@Builder` false positive — the `@param` tags correctly document the record components; CodeQL attributes them to the generated builder methods. Recommend dismissing as false-positive.
- **`java/uncaught-number-format-exception`** (`HttpResultTest`): test literals (`"42"`, `"789"`) always parse; adding handling would obscure the `map()` semantics under test.
- **`java/class-name-matches-super-class`** (`AttackDatabase`, `LegitimatePatternDatabase`): the nested `ArgumentsProvider` name is intentional public test-API design (`Database.ArgumentsProvider.class`).
- **OpenSSF Scorecard alerts** (branch protection, code review, SAST, fuzzing, security policy, CII badge): repo-policy, not code.

## Verification

- `./mvnw -Ppre-commit clean verify -pl cui-http-core` — BUILD SUCCESS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage to use a simpler success-case check while keeping the same expected result.
  * Removed several strict ordering assertions for security-related limits, while retaining the remaining constant and pattern validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->