### PR TITLE
feat: reusable proxy/forwarded-header resolution with built-in sanitization (#88)

### DIFF
--- a/cui-http-benchmarking/src/main/java/de/cuioss/http/forwarded/benchmark/ForwardedBenchmarkState.java
+++ b/cui-http-benchmarking/src/main/java/de/cuioss/http/forwarded/benchmark/ForwardedBenchmarkState.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded.benchmark;
+
+import de.cuioss.http.forwarded.ForwardedHeaderResolver;
+import de.cuioss.http.forwarded.ForwardedResolverConfig;
+import de.cuioss.http.forwarded.ResolvedForwarding;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+/**
+ * Shared JMH state for the forwarded-header resolver benchmarks. Builds the resolver once per trial
+ * and cycles through representative header sets for each invocation.
+ */
+@State(Scope.Thread)
+public class ForwardedBenchmarkState {
+
+    /** Resolver honoring all fields, with a trusted-proxy range for client-IP resolution. */
+    public ForwardedHeaderResolver resolver;
+
+    /** A representative pre-resolved result, used to benchmark serialization. */
+    public ResolvedForwarding resolved;
+
+    // Clean, realistic X-Forwarded-* header sets.
+    private static final List<Map<String, String>> CLEAN_XFORWARDED = List.of(
+            Map.of("X-Forwarded-Proto", "https", "X-Forwarded-Host", "app.example.com:8443",
+                    "X-Forwarded-Prefix", "/ui", "X-Forwarded-For", "203.0.113.7, 10.0.0.5"),
+            Map.of("X-Forwarded-Proto", "https", "X-Forwarded-Host", "api.example.com",
+                    "X-Forwarded-Port", "443", "X-Forwarded-For", "198.51.100.23, 10.1.2.3"),
+            Map.of("X-Forwarded-Proto", "http", "X-Forwarded-Host", "gateway.internal:8080",
+                    "X-Forwarded-Prefix", "/service/v1", "X-Forwarded-For", "192.0.2.44, 10.9.9.9"));
+
+    // RFC 7239 Forwarded header sets (exercise the quoted-string parser).
+    private static final List<Map<String, String>> FORWARDED_RFC = List.of(
+            Map.of("Forwarded", "for=203.0.113.7;host=app.example.com;proto=https, for=\"10.0.0.5\""),
+            Map.of("Forwarded", "proto=https;host=\"api.example.com:443\";for=\"[2001:db8::1]\", for=10.1.2.3"),
+            Map.of("Forwarded", "for=192.0.2.44;proto=http;host=gateway.internal:8080, for=10.9.9.9"));
+
+    // Injection / attack header sets (expected to be sanitized away).
+    private static final List<Map<String, String>> ATTACK_XFORWARDED = List.of(
+            Map.of("X-Forwarded-Host", "evil.com\r\nInjected: 1", "X-Forwarded-Prefix", "//attacker.com"),
+            Map.of("X-Forwarded-Prefix", "/app\\..\\..", "X-Forwarded-For", "not-an-ip, 10.0.0.5"),
+            Map.of("X-Forwarded-Proto", "javascript:alert(1)", "X-Forwarded-Host", "evil.com/../../etc"));
+
+    private final AtomicInteger cleanIndex = new AtomicInteger(0);
+    private final AtomicInteger forwardedIndex = new AtomicInteger(0);
+    private final AtomicInteger attackIndex = new AtomicInteger(0);
+
+    @Setup(Level.Trial)
+    public void setup() {
+        ForwardedResolverConfig config = ForwardedResolverConfig.builder()
+                .trustAll(true)
+                .trustedProxies(Set.of("10.0.0.0/8"))
+                .build();
+        resolver = new ForwardedHeaderResolver(config, new SecurityEventCounter());
+        resolved = new ResolvedForwarding(Optional.of("https"), Optional.of("app.example.com"),
+                OptionalInt.of(8443), "/ui", Optional.of("203.0.113.7"));
+    }
+
+    /** @return the next clean {@code X-Forwarded-*} header accessor, cycling. */
+    public Function<String, String> nextCleanXForwarded() {
+        return CLEAN_XFORWARDED.get(cleanIndex.getAndIncrement() % CLEAN_XFORWARDED.size())::get;
+    }
+
+    /** @return the next RFC 7239 {@code Forwarded} header accessor, cycling. */
+    public Function<String, String> nextForwarded() {
+        return FORWARDED_RFC.get(forwardedIndex.getAndIncrement() % FORWARDED_RFC.size())::get;
+    }
+
+    /** @return the next injection header accessor, cycling. */
+    public Function<String, String> nextAttack() {
+        return ATTACK_XFORWARDED.get(attackIndex.getAndIncrement() % ATTACK_XFORWARDED.size())::get;
+    }
+}

--- a/cui-http-benchmarking/src/main/java/de/cuioss/http/forwarded/benchmark/ForwardedResolverBenchmark.java
+++ b/cui-http-benchmarking/src/main/java/de/cuioss/http/forwarded/benchmark/ForwardedResolverBenchmark.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded.benchmark;
+
+import de.cuioss.http.forwarded.ResolvedForwarding;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Throughput benchmarks for {@link de.cuioss.http.forwarded.ForwardedHeaderResolver}.
+ * Measures resolution and serialization operations per second across clean, RFC 7239, and
+ * injection input patterns.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class ForwardedResolverBenchmark {
+
+    /** Primary throughput metric: full resolution of a clean proxied header set. */
+    @Benchmark
+    public ResolvedForwarding resolveCleanThroughput(ForwardedBenchmarkState state) {
+        return state.resolver.resolve(state.nextCleanXForwarded());
+    }
+
+    /** Resolution throughput exercising the RFC 7239 {@code Forwarded} parse path. */
+    @Benchmark
+    public ResolvedForwarding resolveForwardedThroughput(ForwardedBenchmarkState state) {
+        return state.resolver.resolve(state.nextForwarded());
+    }
+
+    /** Resolution throughput on injection inputs (values are sanitized away). */
+    @Benchmark
+    public ResolvedForwarding resolveAttackThroughput(ForwardedBenchmarkState state) {
+        return state.resolver.resolve(state.nextAttack());
+    }
+
+    /** Serialization throughput to the {@code X-Forwarded-*} header family. */
+    @Benchmark
+    public Map<String, String> serializeXForwardedThroughput(ForwardedBenchmarkState state) {
+        return state.resolved.toXForwardedHeaders();
+    }
+
+    /** Serialization throughput to a single RFC 7239 {@code Forwarded} value. */
+    @Benchmark
+    public Optional<String> serializeForwardedThroughput(ForwardedBenchmarkState state) {
+        return state.resolved.toForwardedHeader();
+    }
+}

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/CidrRange.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/CidrRange.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import java.net.InetAddress;
+
+/**
+ * An immutable IPv4 or IPv6 CIDR range (or single host when no prefix is given), used to define
+ * trusted-proxy hops for {@code X-Forwarded-For} client-IP resolution.
+ *
+ * <p>Matching is purely numeric — literals are parsed without DNS resolution — so an untrusted
+ * hostname can never be interpreted as a trusted address.</p>
+ */
+final class CidrRange {
+
+    private final byte[] network;
+    private final int prefixBits;
+
+    private CidrRange(byte[] network, int prefixBits) {
+        this.network = network;
+        this.prefixBits = prefixBits;
+    }
+
+    /**
+     * Parses a CIDR spec such as {@code 10.0.0.0/8}, {@code 2001:db8::/32}, or a bare literal
+     * {@code 192.168.1.1} (treated as a single host).
+     *
+     * @param spec the CIDR or IP literal
+     * @return the parsed range
+     * @throws IllegalArgumentException if the spec is not a valid IP literal / CIDR
+     */
+    static CidrRange parse(String spec) {
+        String trimmed = spec.strip();
+        int slash = trimmed.indexOf('/');
+        String ipPart = slash < 0 ? trimmed : trimmed.substring(0, slash);
+        InetAddress parsed = IpAddresses.parse(ipPart);
+        if (parsed == null) {
+            throw new IllegalArgumentException("Not an IP literal in trusted proxy: " + spec);
+        }
+        byte[] address = parsed.getAddress();
+        int maxBits = address.length * 8;
+
+        int prefix = maxBits;
+        if (slash >= 0) {
+            String prefixPart = trimmed.substring(slash + 1);
+            try {
+                prefix = Integer.parseInt(prefixPart);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid CIDR prefix in trusted proxy: " + spec, e);
+            }
+            if (prefix < 0 || prefix > maxBits) {
+                throw new IllegalArgumentException(
+                        "CIDR prefix out of range [0.." + maxBits + "] in trusted proxy: " + spec);
+            }
+        }
+        maskInPlace(address, prefix);
+        return new CidrRange(address, prefix);
+    }
+
+    /**
+     * @return {@code true} when {@code candidate} falls within this range (same address family
+     *         and matching network prefix)
+     */
+    boolean contains(InetAddress candidate) {
+        byte[] other = candidate.getAddress();
+        if (other.length != network.length) {
+            return false;
+        }
+        int fullBytes = prefixBits / 8;
+        for (int i = 0; i < fullBytes; i++) {
+            if (network[i] != other[i]) {
+                return false;
+            }
+        }
+        int remainingBits = prefixBits % 8;
+        if (remainingBits > 0) {
+            int mask = 0xFF << (8 - remainingBits) & 0xFF;
+            return (network[fullBytes] & mask) == (other[fullBytes] & mask);
+        }
+        return true;
+    }
+
+    private static void maskInPlace(byte[] address, int prefixBits) {
+        for (int i = 0; i < address.length; i++) {
+            int bitStart = i * 8;
+            if (bitStart >= prefixBits) {
+                address[i] = 0;
+            } else if (bitStart + 8 > prefixBits) {
+                int keep = prefixBits - bitStart;
+                int mask = 0xFF << (8 - keep) & 0xFF;
+                address[i] = (byte) (address[i] & mask);
+            }
+        }
+    }
+}

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ContextPaths.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ContextPaths.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Pure (non-logging) normalization and injection guards for reverse-proxy context-path prefixes.
+ *
+ * <p>Lifted from the {@code ProxyContextPathResolver} prior art. The rules: exactly one leading
+ * slash, no trailing slash, and an empty string when the value is absent, blank, carries control
+ * characters (CR/LF or other), is protocol-relative ({@code //host}), or contains a backslash
+ * (which some browsers normalize to {@code /}). Callers that need to log a rejection reason use
+ * {@link #containsControlCharacter(String)} / {@link #isProtocolRelativeOrBackslash(String)}.</p>
+ */
+final class ContextPaths {
+
+    private ContextPaths() {
+    }
+
+    /**
+     * Normalizes a raw prefix to exactly one leading slash and no trailing slash, or returns the
+     * empty string when the value is absent or rejected by the injection guard.
+     *
+     * @param raw the raw header value (may be {@code null})
+     * @return the normalized prefix, or an empty string
+     */
+    static String normalize(@Nullable String raw) {
+        if (raw == null) {
+            return "";
+        }
+        String trimmed = raw.strip();
+        if (trimmed.isEmpty() || containsControlCharacter(trimmed) || isProtocolRelativeOrBackslash(trimmed)) {
+            return "";
+        }
+        String withLeadingSlash = trimmed.startsWith("/") ? trimmed : "/" + trimmed;
+        String withoutTrailingSlash = stripTrailingSlashes(withLeadingSlash);
+        // A value of only slashes (e.g. "/") collapses to empty.
+        return "/".equals(withoutTrailingSlash) ? "" : withoutTrailingSlash;
+    }
+
+    static boolean containsControlCharacter(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (Character.isISOControl(value.charAt(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Rejects protocol-relative values ({@code //host}) and any backslash. Otherwise a value such
+     * as {@code //attacker.com} would compose into {@code //attacker.com/...} in the browser — a
+     * protocol-relative URL that exfiltrates the request to an attacker-controlled host.
+     */
+    static boolean isProtocolRelativeOrBackslash(String trimmed) {
+        return trimmed.startsWith("//") || trimmed.indexOf('\\') >= 0;
+    }
+
+    private static String stripTrailingSlashes(String value) {
+        int end = value.length();
+        while (end > 1 && value.charAt(end - 1) == '/') {
+            end--;
+        }
+        return value.substring(0, end);
+    }
+}

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderNames.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderNames.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+/**
+ * Canonical forwarded/proxy header names, shared between the resolver (parsing) and
+ * {@link ResolvedForwarding} (serialization) so the two sides never drift.
+ */
+final class ForwardedHeaderNames {
+
+    // de-facto X-Forwarded-* family
+    static final String X_FORWARDED_PROTO = "X-Forwarded-Proto";
+    static final String X_FORWARDED_HOST = "X-Forwarded-Host";
+    static final String X_FORWARDED_PORT = "X-Forwarded-Port";
+    static final String X_FORWARDED_PREFIX = "X-Forwarded-Prefix";
+    static final String X_FORWARDED_FOR = "X-Forwarded-For";
+
+    // Apache NiFi-proprietary family
+    static final String X_PROXY_SCHEME = "X-ProxyScheme";
+    static final String X_PROXY_HOST = "X-ProxyHost";
+    static final String X_PROXY_PORT = "X-ProxyPort";
+    static final String X_PROXY_CONTEXT_PATH = "X-ProxyContextPath";
+
+    // RFC 7239
+    static final String FORWARDED = "Forwarded";
+
+    private ForwardedHeaderNames() {
+    }
+}

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import de.cuioss.http.security.core.HttpSecurityValidator;
+import de.cuioss.http.security.exceptions.UrlSecurityException;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.pipeline.PipelineFactory;
+import de.cuioss.tools.logging.CuiLogger;
+import org.jspecify.annotations.Nullable;
+
+import java.net.InetAddress;
+import java.util.*;
+import java.util.function.Function;
+
+import static de.cuioss.http.forwarded.ForwardedHeaderNames.*;
+
+/**
+ * Resolves the reverse-proxy / forwarded-header family into a single sanitized
+ * {@link ResolvedForwarding}.
+ *
+ * <p>For each field the resolver: (1) selects the raw value by header precedence, (2) sanitizes it
+ * through the existing {@link de.cuioss.http.security} header-value pipeline (rejecting CR/LF, NUL,
+ * control characters, over-length, and suspicious patterns), (3) applies field-specific
+ * normalization and injection guards, and (4) honors it only when the configured trust model
+ * permits. Values that fail sanitization or are not trusted are dropped (and logged) rather than
+ * honored — {@code resolve} never throws.</p>
+ *
+ * <h3>Precedence</h3>
+ * <ul>
+ *   <li>scheme: {@code X-Forwarded-Proto} → {@code X-ProxyScheme} → RFC 7239 {@code proto}</li>
+ *   <li>host: {@code X-Forwarded-Host} → {@code X-ProxyHost} → RFC 7239 {@code host}</li>
+ *   <li>port: {@code X-Forwarded-Port} → {@code X-ProxyPort} → host {@code :port} fallback</li>
+ *   <li>context-path: {@code X-ProxyContextPath} → {@code X-Forwarded-Prefix}
+ *       ({@code Forwarded} has no prefix directive)</li>
+ *   <li>client-IP: {@code X-Forwarded-For} chain → RFC 7239 {@code for} chain</li>
+ * </ul>
+ *
+ * <h3>Usage Example</h3>
+ * <pre>{@code
+ * ForwardedResolverConfig config = ForwardedResolverConfig.builder()
+ *     .trustAll(true)
+ *     .trustedProxies(Set.of("10.0.0.0/8"))
+ *     .build();
+ * ForwardedHeaderResolver resolver =
+ *     new ForwardedHeaderResolver(config, new SecurityEventCounter());
+ *
+ * ResolvedForwarding forwarding = resolver.resolve(request::getHeader);
+ * }</pre>
+ *
+ * <p>Instances are immutable and thread-safe (the underlying pipeline and event counter are
+ * thread-safe).</p>
+ *
+ * @since 1.0
+ */
+public final class ForwardedHeaderResolver {
+
+    private static final CuiLogger LOGGER = new CuiLogger(ForwardedHeaderResolver.class);
+    private static final int MAX_PORT = 65535;
+
+    private final ForwardedResolverConfig config;
+    private final HttpSecurityValidator headerValueValidator;
+
+    /**
+     * Creates a resolver.
+     *
+     * @param config the trust-model and precedence configuration
+     * @param counter the security event counter used by the sanitization pipeline
+     * @throws NullPointerException if {@code config} or {@code counter} is {@code null}
+     */
+    public ForwardedHeaderResolver(ForwardedResolverConfig config, SecurityEventCounter counter) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        Objects.requireNonNull(counter, "counter must not be null");
+        this.headerValueValidator = PipelineFactory.createHeaderValuePipeline(config.securityConfig(), counter);
+    }
+
+    /**
+     * Resolves the forwarded-header family from the supplied header accessor.
+     *
+     * @param headerLookup maps a header name to its value (or {@code null} when absent); typically
+     *                     {@code request::getHeader}
+     * @return the sanitized, honored result (never {@code null}; {@link ResolvedForwarding#empty()}
+     *         when nothing is present or honored)
+     * @throws NullPointerException if {@code headerLookup} is {@code null}
+     */
+    public ResolvedForwarding resolve(Function<String, String> headerLookup) {
+        Objects.requireNonNull(headerLookup, "headerLookup must not be null");
+        RfcForwardedParser.Parsed forwarded = parseForwarded(headerLookup);
+
+        Optional<String> scheme = resolveScheme(headerLookup, forwarded);
+        HostPort hostPort = resolveHost(headerLookup, forwarded);
+        OptionalInt port = resolvePort(headerLookup, hostPort.port());
+        String contextPath = resolveContextPath(headerLookup);
+        Optional<String> clientIp = resolveClientIp(headerLookup, forwarded);
+
+        return new ResolvedForwarding(scheme, hostPort.host(), port, contextPath, clientIp);
+    }
+
+    // --- scheme ------------------------------------------------------------------------------
+
+    private Optional<String> resolveScheme(Function<String, String> lookup, RfcForwardedParser.Parsed forwarded) {
+        String raw = firstPresent(lookup, X_FORWARDED_PROTO, X_PROXY_SCHEME);
+        if (raw == null) {
+            raw = forwarded.proto().orElse(null);
+        }
+        if (raw == null || !config.trustAll()) {
+            return Optional.empty();
+        }
+        return sanitize(X_FORWARDED_PROTO, raw)
+                .map(ForwardedHeaderResolver::firstToken)
+                .map(value -> value.toLowerCase(Locale.ROOT))
+                .filter(value -> "http".equals(value) || "https".equals(value));
+    }
+
+    // --- host --------------------------------------------------------------------------------
+
+    private HostPort resolveHost(Function<String, String> lookup, RfcForwardedParser.Parsed forwarded) {
+        String raw = firstPresent(lookup, X_FORWARDED_HOST, X_PROXY_HOST);
+        if (raw == null) {
+            raw = forwarded.host().orElse(null);
+        }
+        if (raw == null || !config.trustAll()) {
+            return HostPort.EMPTY;
+        }
+        Optional<String> sanitized = sanitize(X_FORWARDED_HOST, raw).map(ForwardedHeaderResolver::firstToken);
+        if (sanitized.isEmpty()) {
+            return HostPort.EMPTY;
+        }
+        return parseHostPort(sanitized.get());
+    }
+
+    /**
+     * Splits a {@code host[:port]} token (bracketed IPv6 aware) and validates the host contains no
+     * path/backslash/whitespace. Returns {@link HostPort#EMPTY} for a malformed host.
+     */
+    private static HostPort parseHostPort(String value) {
+        String host;
+        OptionalInt port = OptionalInt.empty();
+        if (value.startsWith("[")) {
+            int close = value.indexOf(']');
+            if (close < 0) {
+                return HostPort.EMPTY;
+            }
+            host = value.substring(0, close + 1);
+            String rest = value.substring(close + 1);
+            if (rest.startsWith(":")) {
+                port = parsePort(rest.substring(1));
+            }
+        } else if (value.indexOf(':') == value.lastIndexOf(':') && value.indexOf(':') >= 0) {
+            host = value.substring(0, value.indexOf(':'));
+            port = parsePort(value.substring(value.indexOf(':') + 1));
+        } else {
+            host = value;
+        }
+        if (host.isEmpty() || containsHostSeparator(host)) {
+            return HostPort.EMPTY;
+        }
+        return new HostPort(Optional.of(host), port);
+    }
+
+    private static boolean containsHostSeparator(String host) {
+        for (int i = 0; i < host.length(); i++) {
+            char c = host.charAt(i);
+            if (c == '/' || c == '\\' || Character.isWhitespace(c)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // --- port --------------------------------------------------------------------------------
+
+    private OptionalInt resolvePort(Function<String, String> lookup, OptionalInt hostPortFallback) {
+        String raw = firstPresent(lookup, X_FORWARDED_PORT, X_PROXY_PORT);
+        if (raw == null) {
+            return hostPortFallback;
+        }
+        if (!config.trustAll()) {
+            return OptionalInt.empty();
+        }
+        return sanitize(X_FORWARDED_PORT, raw)
+                .map(ForwardedHeaderResolver::firstToken)
+                .map(ForwardedHeaderResolver::parsePort)
+                .orElse(OptionalInt.empty());
+    }
+
+    private static OptionalInt parsePort(String value) {
+        try {
+            int port = Integer.parseInt(value.strip());
+            return port >= 1 && port <= MAX_PORT ? OptionalInt.of(port) : OptionalInt.empty();
+        } catch (NumberFormatException e) {
+            return OptionalInt.empty();
+        }
+    }
+
+    // --- context path ------------------------------------------------------------------------
+
+    private String resolveContextPath(Function<String, String> lookup) {
+        String raw = firstPresent(lookup, X_PROXY_CONTEXT_PATH, X_FORWARDED_PREFIX);
+        if (raw == null) {
+            if (isPresent(lookup.apply(FORWARDED))) {
+                LOGGER.debug("Forwarded header present but carries no context-path directive");
+            }
+            return "";
+        }
+        // Apply the injection guards to the RAW value first: the header-value pipeline collapses a
+        // protocol-relative "//host" prefix to "/host", masking the attack, so the guard must run
+        // before sanitization can rewrite it.
+        String trimmed = raw.strip();
+        if (ContextPaths.containsControlCharacter(trimmed)) {
+            LOGGER.warn(ForwardedLogMessages.WARN.CONTEXT_PATH_CONTROL_CHARACTERS_REJECTED, sanitizeForLog(trimmed));
+            return "";
+        }
+        if (ContextPaths.isProtocolRelativeOrBackslash(trimmed)) {
+            LOGGER.warn(ForwardedLogMessages.WARN.CONTEXT_PATH_PROTOCOL_RELATIVE_REJECTED, sanitizeForLog(trimmed));
+            return "";
+        }
+        Optional<String> sanitized = sanitize(X_FORWARDED_PREFIX, raw);
+        if (sanitized.isEmpty()) {
+            return "";
+        }
+        String normalized = ContextPaths.normalize(sanitized.get());
+        if (normalized.isEmpty()) {
+            return "";
+        }
+        if (config.trustAll() || config.allowedContextPaths().contains(normalized)) {
+            return normalized;
+        }
+        LOGGER.debug("Ignoring context path %s: not trusted and not in the allowlist", normalized);
+        return "";
+    }
+
+    // --- client IP ---------------------------------------------------------------------------
+
+    private Optional<String> resolveClientIp(Function<String, String> lookup, RfcForwardedParser.Parsed forwarded) {
+        // Secure-by-default: without trusted proxies the immediate peer cannot be trusted, so the
+        // forwarded chain (including the nearest hop) is not honored at all.
+        if (config.trustedProxies().isEmpty()) {
+            return Optional.empty();
+        }
+        List<String> chain;
+        String xff = lookup.apply(X_FORWARDED_FOR);
+        if (isPresent(xff)) {
+            Optional<String> sanitized = sanitize(X_FORWARDED_FOR, xff);
+            if (sanitized.isEmpty()) {
+                return Optional.empty();
+            }
+            chain = List.of(sanitized.get().split(","));
+        } else if (!forwarded.forValues().isEmpty()) {
+            chain = forwarded.forValues();
+        } else {
+            return Optional.empty();
+        }
+        return walkChain(chain);
+    }
+
+    /**
+     * Walks the forwarded chain right-to-left, skipping trusted-proxy hops; the first untrusted,
+     * well-formed address is the client. Any unparseable hop encountered aborts resolution
+     * (secure default: an unverifiable chain yields no client IP).
+     */
+    private Optional<String> walkChain(List<String> chain) {
+        for (int i = chain.size() - 1; i >= 0; i--) {
+            String entry = chain.get(i).strip();
+            if (entry.isEmpty()) {
+                continue;
+            }
+            InetAddress address = IpAddresses.parseChainEntry(entry);
+            if (address == null) {
+                LOGGER.warn(ForwardedLogMessages.WARN.CLIENT_IP_ENTRY_UNPARSEABLE, sanitizeForLog(entry));
+                return Optional.empty();
+            }
+            if (!config.isTrustedProxy(address)) {
+                return Optional.of(IpAddresses.canonical(address));
+            }
+        }
+        return Optional.empty();
+    }
+
+    // --- shared helpers ----------------------------------------------------------------------
+
+    private RfcForwardedParser.Parsed parseForwarded(Function<String, String> lookup) {
+        String raw = lookup.apply(FORWARDED);
+        if (!isPresent(raw)) {
+            return new RfcForwardedParser.Parsed(Optional.empty(), Optional.empty(), List.of());
+        }
+        // Sanitize the Forwarded header value before parsing its directives.
+        return sanitize(FORWARDED, raw)
+                .map(RfcForwardedParser::parse)
+                .orElseGet(() -> new RfcForwardedParser.Parsed(Optional.empty(), Optional.empty(), List.of()));
+    }
+
+    /**
+     * Runs a raw header value through the security header-value pipeline. Returns the sanitized
+     * value, or empty when the value is absent/blank or fails sanitization (logged).
+     */
+    private Optional<String> sanitize(String headerName, @Nullable String raw) {
+        if (!isPresent(raw)) {
+            return Optional.empty();
+        }
+        try {
+            return headerValueValidator.validate(raw);
+        } catch (UrlSecurityException e) {
+            LOGGER.warn(ForwardedLogMessages.WARN.FORWARDED_VALUE_SANITIZATION_REJECTED,
+                    headerName, sanitizeForLog(raw));
+            return Optional.empty();
+        }
+    }
+
+    private static @Nullable String firstPresent(Function<String, String> lookup, String... headerNames) {
+        for (String name : headerNames) {
+            String value = lookup.apply(name);
+            if (isPresent(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isPresent(@Nullable String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private static String firstToken(String value) {
+        int comma = value.indexOf(',');
+        return (comma < 0 ? value : value.substring(0, comma)).strip();
+    }
+
+    /**
+     * Strips control characters and truncates before interpolating an untrusted value into a log
+     * message, so a malicious header cannot forge or inject log lines.
+     */
+    private static String sanitizeForLog(String value) {
+        StringBuilder builder = new StringBuilder(Math.min(value.length(), 200));
+        for (int i = 0; i < value.length() && i < 200; i++) {
+            char c = value.charAt(i);
+            builder.append(Character.isISOControl(c) ? '?' : c);
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Host token plus an optional port extracted from a {@code host:port} value.
+     */
+    private record HostPort(Optional<String> host, OptionalInt port) {
+        private static final HostPort EMPTY = new HostPort(Optional.empty(), OptionalInt.empty());
+    }
+}

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -66,6 +66,9 @@ import static de.cuioss.http.forwarded.ForwardedHeaderNames.*;
  *
  * @since 1.0
  */
+// S4276: Function<String,String> is the intentional transport-agnostic header-accessor abstraction
+// (e.g. request::getHeader) per issue #88 — not a UnaryOperator (which implies operating on a value).
+@SuppressWarnings("java:S4276")
 public final class ForwardedHeaderResolver {
 
     private static final CuiLogger LOGGER = new CuiLogger(ForwardedHeaderResolver.class);

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedLogMessages.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedLogMessages.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import de.cuioss.tools.logging.LogRecord;
+import de.cuioss.tools.logging.LogRecordModel;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Log messages for the {@code de.cuioss.http.forwarded} package.
+ * All messages follow the format: HTTP-[identifier]: [message].
+ *
+ * <p>Identifier range 120-129 is reserved for this package (WARN), distinct from the
+ * {@code de.cuioss.http.client} ranges in {@code HttpLogMessages}.</p>
+ *
+ * @since 1.0
+ */
+@UtilityClass
+public final class ForwardedLogMessages {
+
+    private static final String PREFIX = "HTTP";
+
+    /**
+     * Warning-level messages for rejected or malformed forwarded-header values.
+     */
+    @UtilityClass
+    public static final class WARN {
+
+        public static final LogRecord CONTEXT_PATH_CONTROL_CHARACTERS_REJECTED = LogRecordModel.builder()
+                .prefix(PREFIX)
+                .identifier(120)
+                .template("Rejecting proxy context path with control characters: %s")
+                .build();
+
+        public static final LogRecord CONTEXT_PATH_PROTOCOL_RELATIVE_REJECTED = LogRecordModel.builder()
+                .prefix(PREFIX)
+                .identifier(121)
+                .template("Rejecting proxy context path to prevent protocol-relative URL injection: %s")
+                .build();
+
+        public static final LogRecord FORWARDED_VALUE_SANITIZATION_REJECTED = LogRecordModel.builder()
+                .prefix(PREFIX)
+                .identifier(122)
+                .template("Rejecting forwarded header %s: value failed security sanitization: %s")
+                .build();
+
+        public static final LogRecord CLIENT_IP_ENTRY_UNPARSEABLE = LogRecordModel.builder()
+                .prefix(PREFIX)
+                .identifier(123)
+                .template("Ignoring client IP: forwarded chain carries an unparseable entry: %s")
+                .build();
+    }
+}

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedResolverConfig.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedResolverConfig.java
@@ -74,18 +74,19 @@ public final class ForwardedResolverConfig {
     }
 
     /**
-     * @return the normalized context paths honored even when {@link #trustAll()} is {@code false}
-     *         (unmodifiable)
+     * @return the normalized context paths honored even when {@link #trustAll()} is {@code false},
+     *         as an order-preserving unmodifiable copy
      */
     public Set<String> allowedContextPaths() {
-        return allowedContextPaths;
+        return Collections.unmodifiableSet(new LinkedHashSet<>(allowedContextPaths));
     }
 
     /**
-     * @return the raw trusted-proxy CIDR / IP specs, in configuration order (unmodifiable)
+     * @return the raw trusted-proxy CIDR / IP specs, in configuration order, as an order-preserving
+     *         unmodifiable copy
      */
     public Set<String> trustedProxies() {
-        return trustedProxies;
+        return Collections.unmodifiableSet(new LinkedHashSet<>(trustedProxies));
     }
 
     /**
@@ -175,12 +176,10 @@ public final class ForwardedResolverConfig {
          *                            entry is normalized (leading slash added, trailing slash
          *                            stripped) and empties are dropped
          * @return this builder
-         * @throws IllegalArgumentException if {@code allowedContextPaths} is {@code null}
+         * @throws NullPointerException if {@code allowedContextPaths} is {@code null}
          */
         public Builder allowedContextPaths(Set<String> allowedContextPaths) {
-            if (allowedContextPaths == null) {
-                throw new IllegalArgumentException("allowedContextPaths must not be null");
-            }
+            Objects.requireNonNull(allowedContextPaths, "allowedContextPaths must not be null");
             Set<String> normalized = new LinkedHashSet<>();
             for (String entry : allowedContextPaths) {
                 String value = ContextPaths.normalize(entry);
@@ -196,17 +195,15 @@ public final class ForwardedResolverConfig {
          * @param trustedProxies CIDR ranges / IP literals defining trusted proxy hops for
          *                       client-IP resolution
          * @return this builder
-         * @throws IllegalArgumentException if {@code trustedProxies} is {@code null} or any entry
-         *                                  is not a valid IP literal / CIDR
+         * @throws NullPointerException if {@code trustedProxies} is {@code null}
+         * @throws IllegalArgumentException if any entry is not a valid IP literal / CIDR
          */
         public Builder trustedProxies(Set<String> trustedProxies) {
-            if (trustedProxies == null) {
-                throw new IllegalArgumentException("trustedProxies must not be null");
-            }
+            Objects.requireNonNull(trustedProxies, "trustedProxies must not be null");
             Set<String> raw = new LinkedHashSet<>();
             List<CidrRange> ranges = new ArrayList<>();
             for (String entry : trustedProxies) {
-                if (entry == null || entry.isBlank()) {
+                if (entry.isBlank()) {
                     continue;
                 }
                 ranges.add(CidrRange.parse(entry));
@@ -220,13 +217,10 @@ public final class ForwardedResolverConfig {
         /**
          * @param securityConfig the security configuration for the sanitization pipeline
          * @return this builder
-         * @throws IllegalArgumentException if {@code securityConfig} is {@code null}
+         * @throws NullPointerException if {@code securityConfig} is {@code null}
          */
         public Builder securityConfig(SecurityConfiguration securityConfig) {
-            if (securityConfig == null) {
-                throw new IllegalArgumentException("securityConfig must not be null");
-            }
-            this.securityConfig = securityConfig;
+            this.securityConfig = Objects.requireNonNull(securityConfig, "securityConfig must not be null");
             return this;
         }
 

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedResolverConfig.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedResolverConfig.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import de.cuioss.http.security.config.SecurityConfiguration;
+
+import java.net.InetAddress;
+import java.util.*;
+
+/**
+ * Immutable trust-model configuration for {@link ForwardedHeaderResolver}.
+ *
+ * <p>The resolver is <strong>secure-by-default</strong>: with the defaults (no allowlist, no
+ * trusted proxies, {@code trustAll=false}), client-supplied forwarded values are ignored. To
+ * honor forwarded values a deployment must opt in explicitly:</p>
+ * <ul>
+ *   <li>{@code trustAll} — honor the sanitized scheme / host / port and any sanitized
+ *       context-path. Use only when the application sits fully behind a trusted proxy.</li>
+ *   <li>{@code allowedContextPaths} — honor these specific normalized context paths even when
+ *       {@code trustAll} is {@code false} (mirrors NiFi's {@code nifi.web.proxy.context.path}).</li>
+ *   <li>{@code trustedProxies} — CIDR ranges / IP literals defining trusted proxy hops; required
+ *       for {@code X-Forwarded-For} client-IP resolution. An empty set honors no client IP.</li>
+ * </ul>
+ *
+ * <h3>Usage Example</h3>
+ * <pre>{@code
+ * ForwardedResolverConfig config = ForwardedResolverConfig.builder()
+ *     .trustAll(true)
+ *     .trustedProxies(Set.of("10.0.0.0/8", "2001:db8::/32"))
+ *     .build();
+ *
+ * // Secure default — honors nothing:
+ * ForwardedResolverConfig locked = ForwardedResolverConfig.secureDefault();
+ * }</pre>
+ *
+ * <p>This class is immutable and thread-safe.</p>
+ *
+ * @since 1.0
+ */
+public final class ForwardedResolverConfig {
+
+    private final boolean trustAll;
+    private final Set<String> allowedContextPaths;
+    private final Set<String> trustedProxies;
+    private final List<CidrRange> trustedProxyRanges;
+    private final SecurityConfiguration securityConfig;
+
+    private ForwardedResolverConfig(Builder builder) {
+        this.trustAll = builder.trustAll;
+        this.allowedContextPaths = Collections.unmodifiableSet(new LinkedHashSet<>(builder.allowedContextPaths));
+        this.trustedProxies = Collections.unmodifiableSet(new LinkedHashSet<>(builder.trustedProxies));
+        this.trustedProxyRanges = List.copyOf(builder.trustedProxyRanges);
+        this.securityConfig = builder.securityConfig;
+    }
+
+    /**
+     * @return whether sanitized scheme / host / port and any sanitized context-path are honored
+     */
+    public boolean trustAll() {
+        return trustAll;
+    }
+
+    /**
+     * @return the normalized context paths honored even when {@link #trustAll()} is {@code false}
+     *         (unmodifiable)
+     */
+    public Set<String> allowedContextPaths() {
+        return allowedContextPaths;
+    }
+
+    /**
+     * @return the raw trusted-proxy CIDR / IP specs, in configuration order (unmodifiable)
+     */
+    public Set<String> trustedProxies() {
+        return trustedProxies;
+    }
+
+    /**
+     * @return the security configuration driving the header-value sanitization pipeline
+     */
+    public SecurityConfiguration securityConfig() {
+        return securityConfig;
+    }
+
+    /**
+     * @param address the candidate address (an {@code X-Forwarded-For} hop)
+     * @return {@code true} when {@code address} falls within any configured trusted-proxy range
+     */
+    boolean isTrustedProxy(InetAddress address) {
+        for (CidrRange range : trustedProxyRanges) {
+            if (range.contains(address)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return the secure-by-default configuration: honors nothing, uses
+     *         {@link SecurityConfiguration#defaults()}
+     */
+    public static ForwardedResolverConfig secureDefault() {
+        return builder().build();
+    }
+
+    /**
+     * @return a new builder initialized with secure defaults
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Parses a comma-separated allowlist of proxy context paths into a normalized,
+     * deterministically-ordered, unmodifiable set (blank / slash-only / injection-rejected
+     * entries dropped). Mirrors the prior-art {@code ProxyContextPathResolver.parseAllowlist}.
+     *
+     * @param commaSeparated the raw comma-separated allowlist (may be {@code null})
+     * @return an unmodifiable set of normalized context paths in input order
+     */
+    public static Set<String> parseAllowlist(String commaSeparated) {
+        Set<String> allowed = new LinkedHashSet<>();
+        if (commaSeparated == null || commaSeparated.isBlank()) {
+            return Collections.unmodifiableSet(allowed);
+        }
+        for (String entry : commaSeparated.split(",")) {
+            String normalized = ContextPaths.normalize(entry);
+            if (!normalized.isEmpty()) {
+                allowed.add(normalized);
+            }
+        }
+        return Collections.unmodifiableSet(allowed);
+    }
+
+    /**
+     * Builder for {@link ForwardedResolverConfig}. All setters are validated for immediate
+     * feedback; {@code trustedProxies} entries are parsed as IP literals / CIDR ranges and reject
+     * malformed specs with {@link IllegalArgumentException}.
+     */
+    public static final class Builder {
+
+        private boolean trustAll;
+        private Set<String> allowedContextPaths = Set.of();
+        private Set<String> trustedProxies = Set.of();
+        private List<CidrRange> trustedProxyRanges = List.of();
+        private SecurityConfiguration securityConfig = SecurityConfiguration.defaults();
+
+        private Builder() {
+        }
+
+        /**
+         * @param trustAll honor sanitized scheme / host / port and any sanitized context-path
+         * @return this builder
+         */
+        public Builder trustAll(boolean trustAll) {
+            this.trustAll = trustAll;
+            return this;
+        }
+
+        /**
+         * @param allowedContextPaths context paths to honor even when {@code trustAll=false}; each
+         *                            entry is normalized (leading slash added, trailing slash
+         *                            stripped) and empties are dropped
+         * @return this builder
+         * @throws IllegalArgumentException if {@code allowedContextPaths} is {@code null}
+         */
+        public Builder allowedContextPaths(Set<String> allowedContextPaths) {
+            if (allowedContextPaths == null) {
+                throw new IllegalArgumentException("allowedContextPaths must not be null");
+            }
+            Set<String> normalized = new LinkedHashSet<>();
+            for (String entry : allowedContextPaths) {
+                String value = ContextPaths.normalize(entry);
+                if (!value.isEmpty()) {
+                    normalized.add(value);
+                }
+            }
+            this.allowedContextPaths = normalized;
+            return this;
+        }
+
+        /**
+         * @param trustedProxies CIDR ranges / IP literals defining trusted proxy hops for
+         *                       client-IP resolution
+         * @return this builder
+         * @throws IllegalArgumentException if {@code trustedProxies} is {@code null} or any entry
+         *                                  is not a valid IP literal / CIDR
+         */
+        public Builder trustedProxies(Set<String> trustedProxies) {
+            if (trustedProxies == null) {
+                throw new IllegalArgumentException("trustedProxies must not be null");
+            }
+            Set<String> raw = new LinkedHashSet<>();
+            List<CidrRange> ranges = new ArrayList<>();
+            for (String entry : trustedProxies) {
+                if (entry == null || entry.isBlank()) {
+                    continue;
+                }
+                ranges.add(CidrRange.parse(entry));
+                raw.add(entry.strip());
+            }
+            this.trustedProxies = raw;
+            this.trustedProxyRanges = ranges;
+            return this;
+        }
+
+        /**
+         * @param securityConfig the security configuration for the sanitization pipeline
+         * @return this builder
+         * @throws IllegalArgumentException if {@code securityConfig} is {@code null}
+         */
+        public Builder securityConfig(SecurityConfiguration securityConfig) {
+            if (securityConfig == null) {
+                throw new IllegalArgumentException("securityConfig must not be null");
+            }
+            this.securityConfig = securityConfig;
+            return this;
+        }
+
+        /**
+         * @return a new immutable {@link ForwardedResolverConfig}
+         */
+        public ForwardedResolverConfig build() {
+            return new ForwardedResolverConfig(this);
+        }
+    }
+}

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/IpAddresses.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/IpAddresses.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import org.jspecify.annotations.Nullable;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.regex.Pattern;
+
+/**
+ * Numeric IP-literal parsing helpers. All parsing is literal-only (never DNS-resolving), so an
+ * untrusted hostname can never be interpreted as an address.
+ */
+final class IpAddresses {
+
+    private static final Pattern IPV4_LITERAL = Pattern.compile("\\d{1,3}(\\.\\d{1,3}){3}");
+    private static final Pattern IPV6_LITERAL = Pattern.compile("[0-9A-Fa-f:.]+");
+
+    private IpAddresses() {
+    }
+
+    /**
+     * Parses an IPv4 or IPv6 literal without any DNS lookup.
+     *
+     * @param literal the candidate literal (already trimmed)
+     * @return the parsed address, or {@code null} when {@code literal} is not a valid IP literal
+     */
+    static @Nullable InetAddress parse(String literal) {
+        boolean looksV4 = IPV4_LITERAL.matcher(literal).matches();
+        boolean looksV6 = literal.indexOf(':') >= 0 && IPV6_LITERAL.matcher(literal).matches();
+        if (!looksV4 && !looksV6) {
+            return null;
+        }
+        try {
+            // Guarded to a numeric literal above, so getByName performs no DNS lookup.
+            return InetAddress.getByName(literal);
+        } catch (UnknownHostException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Extracts the bare IP literal from a forwarded-chain entry, stripping an optional port and
+     * unwrapping bracketed IPv6.
+     *
+     * <p>Handles {@code 192.0.2.7}, {@code 192.0.2.7:443}, {@code [2001:db8::1]},
+     * {@code [2001:db8::1]:443}, and bare {@code 2001:db8::1}. RFC 7239 {@code unknown} and
+     * obfuscated ({@code _hidden}) node identifiers yield {@code null}.</p>
+     *
+     * @param entry a single forwarded-chain entry (already trimmed, unquoted)
+     * @return the parsed address, or {@code null} when the entry is not a usable IP literal
+     */
+    static @Nullable InetAddress parseChainEntry(String entry) {
+        String token = entry.strip();
+        if (token.isEmpty() || "unknown".equalsIgnoreCase(token) || token.charAt(0) == '_') {
+            return null;
+        }
+        String ipPart;
+        if (token.charAt(0) == '[') {
+            int close = token.indexOf(']');
+            if (close < 0) {
+                return null;
+            }
+            ipPart = token.substring(1, close);
+        } else if (token.indexOf(':') == token.lastIndexOf(':') && token.indexOf(':') >= 0) {
+            // exactly one colon -> IPv4:port
+            ipPart = token.substring(0, token.indexOf(':'));
+        } else {
+            // no colon (IPv4) or multiple colons (bare IPv6)
+            ipPart = token;
+        }
+        return parse(ipPart);
+    }
+
+    /**
+     * @return the canonical textual form of {@code address} ({@link InetAddress#getHostAddress()})
+     */
+    static String canonical(InetAddress address) {
+        return address.getHostAddress();
+    }
+}

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ResolvedForwarding.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ResolvedForwarding.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+/**
+ * Immutable, sanitized result of resolving the reverse-proxy / forwarded-header family.
+ *
+ * <p>Each field is already normalized and injection-guarded by
+ * {@link ForwardedHeaderResolver}, and only carries a value when the configured trust model
+ * honored it. Absent or un-honored fields resolve to {@link Optional#empty()} (or an empty
+ * {@code contextPath}).</p>
+ *
+ * <h3>Serialization</h3>
+ * <p>The {@link #toXForwardedHeaders()} and {@link #toForwardedHeader()} methods emit the
+ * resolved state back as proxy headers, so a resolved request can be forwarded upstream and
+ * round-trip-tested. <strong>Asymmetry:</strong> RFC 7239 {@code Forwarded} has no prefix
+ * directive, so {@code contextPath} is expressible only through {@code X-Forwarded-Prefix}
+ * (via {@link #toXForwardedHeaders()}), never through {@link #toForwardedHeader()}.</p>
+ *
+ * <h3>Usage Example</h3>
+ * <pre>{@code
+ * ResolvedForwarding forwarding = resolver.resolve(request::getHeader);
+ * String scheme = forwarding.scheme().orElse("http");
+ * int port = forwarding.port().orElse(scheme.equals("https") ? 443 : 80);
+ * String prefix = forwarding.contextPath(); // "" when none / not honored
+ * forwarding.clientIp().ifPresent(ip -> log.info("client %s", ip));
+ * }</pre>
+ *
+ * <p>This record is immutable and thread-safe.</p>
+ *
+ * @param scheme      the resolved request scheme ({@code "http"} or {@code "https"}), empty when
+ *                    absent or not honored
+ * @param host        the resolved host without a port, empty when absent or not honored
+ * @param port        the resolved port in the range {@code 1..65535}, empty when absent or not honored
+ * @param contextPath the normalized context-path prefix (exactly one leading slash, no trailing
+ *                    slash), or the empty string when none is present or honored
+ * @param clientIp    the resolved originating client IP in canonical form, empty when absent or
+ *                    not honored
+ *
+ * @since 1.0
+ */
+public record ResolvedForwarding(
+Optional<String> scheme,
+Optional<String> host,
+OptionalInt port,
+String contextPath,
+Optional<String> clientIp
+) {
+
+    private static final ResolvedForwarding EMPTY =
+            new ResolvedForwarding(Optional.empty(), Optional.empty(), OptionalInt.empty(), "", Optional.empty());
+
+    /**
+     * Defensive, null-tolerant canonical constructor: a {@code null} {@link Optional} field
+     * becomes {@link Optional#empty()}, a {@code null} {@code port} becomes
+     * {@link OptionalInt#empty()}, and a {@code null} {@code contextPath} becomes the empty string.
+     */
+    public ResolvedForwarding {
+        scheme = scheme == null ? Optional.empty() : scheme;
+        host = host == null ? Optional.empty() : host;
+        port = port == null ? OptionalInt.empty() : port;
+        contextPath = contextPath == null ? "" : contextPath;
+        clientIp = clientIp == null ? Optional.empty() : clientIp;
+    }
+
+    /**
+     * Returns the empty result: no scheme, host, port, or client IP, and an empty context-path.
+     * This is what a secure-by-default resolver returns for an un-proxied or fully un-honored request.
+     *
+     * @return the shared empty {@link ResolvedForwarding} instance
+     */
+    public static ResolvedForwarding empty() {
+        return EMPTY;
+    }
+
+    /**
+     * Serializes this result to the de-facto {@code X-Forwarded-*} header family.
+     *
+     * <p>Only present fields are emitted; absent fields are omitted from the map. A non-empty
+     * {@code contextPath} is emitted as {@code X-Forwarded-Prefix}.</p>
+     *
+     * @return an insertion-ordered, modifiable map of header name to value (empty when this
+     *         result carries no fields)
+     */
+    public Map<String, String> toXForwardedHeaders() {
+        Map<String, String> headers = new LinkedHashMap<>();
+        scheme.ifPresent(value -> headers.put(ForwardedHeaderNames.X_FORWARDED_PROTO, value));
+        host.ifPresent(value -> headers.put(ForwardedHeaderNames.X_FORWARDED_HOST, value));
+        port.ifPresent(value -> headers.put(ForwardedHeaderNames.X_FORWARDED_PORT, Integer.toString(value)));
+        if (!contextPath.isEmpty()) {
+            headers.put(ForwardedHeaderNames.X_FORWARDED_PREFIX, contextPath);
+        }
+        clientIp.ifPresent(value -> headers.put(ForwardedHeaderNames.X_FORWARDED_FOR, value));
+        return headers;
+    }
+
+    /**
+     * Serializes this result to a single RFC 7239 {@code Forwarded} header value.
+     *
+     * <p>Emits the {@code for}, {@code host}, and {@code proto} directives for whichever fields
+     * are present. When a {@code port} accompanies a {@code host}, it is folded into the
+     * {@code host} directive ({@code host="name:port"}). IPv6 client addresses are bracketed and
+     * the value quoted per RFC 7239; other values are quoted only when they are not a valid
+     * RFC 7239 token.</p>
+     *
+     * <p><strong>Note:</strong> {@code contextPath} is intentionally absent — RFC 7239 defines no
+     * prefix/context-path directive. Use {@link #toXForwardedHeaders()} to preserve it.</p>
+     *
+     * @return the {@code Forwarded} value, or {@link Optional#empty()} when no
+     *         {@code Forwarded}-expressible field ({@code proto}/{@code host}/{@code for}) is present
+     */
+    public Optional<String> toForwardedHeader() {
+        StringBuilder builder = new StringBuilder();
+        clientIp.ifPresent(ip -> append(builder, "for", forwardedForValue(ip)));
+        host.ifPresent(name -> append(builder, "host", port.isPresent() ? name + ":" + port.getAsInt() : name));
+        scheme.ifPresent(value -> append(builder, "proto", value));
+        return builder.isEmpty() ? Optional.empty() : Optional.of(builder.toString());
+    }
+
+    private static void append(StringBuilder builder, String directive, String value) {
+        if (!builder.isEmpty()) {
+            builder.append(';');
+        }
+        builder.append(directive).append('=').append(quoteIfNeeded(value));
+    }
+
+    /**
+     * Wraps the IPv6 form of a client address in brackets ({@code [2001:db8::1]}); IPv4
+     * addresses pass through unchanged. Bracketing (and the subsequent quoting) satisfies the
+     * RFC 7239 {@code for} node-identifier syntax.
+     */
+    private static String forwardedForValue(String ip) {
+        return ip.indexOf(':') >= 0 ? "[" + ip + "]" : ip;
+    }
+
+    /**
+     * Returns the value unchanged when it is a valid RFC 7239 token, otherwise wraps it in a
+     * double-quoted string (escaping backslashes and quotes).
+     */
+    private static String quoteIfNeeded(String value) {
+        if (isToken(value)) {
+            return value;
+        }
+        return '"' + value.replace("\\", "\\\\").replace("\"", "\\\"") + '"';
+    }
+
+    private static boolean isToken(String value) {
+        if (value.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            if (!isTokenChar(value.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * RFC 7230 {@code tchar}: {@code ALPHA / DIGIT} plus a fixed punctuation set. Values outside
+     * this set (colon-bearing host:port, bracketed IPv6) fall back to a quoted-string.
+     */
+    private static boolean isTokenChar(char c) {
+        return (c >= 'A' && c <= 'Z')
+                || (c >= 'a' && c <= 'z')
+                || (c >= '0' && c <= '9')
+                || "!#$%&'*+-.^_`|~".indexOf(c) >= 0;
+    }
+}

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ResolvedForwarding.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ResolvedForwarding.java
@@ -69,19 +69,6 @@ Optional<String> clientIp
             new ResolvedForwarding(Optional.empty(), Optional.empty(), OptionalInt.empty(), "", Optional.empty());
 
     /**
-     * Defensive, null-tolerant canonical constructor: a {@code null} {@link Optional} field
-     * becomes {@link Optional#empty()}, a {@code null} {@code port} becomes
-     * {@link OptionalInt#empty()}, and a {@code null} {@code contextPath} becomes the empty string.
-     */
-    public ResolvedForwarding {
-        scheme = scheme == null ? Optional.empty() : scheme;
-        host = host == null ? Optional.empty() : host;
-        port = port == null ? OptionalInt.empty() : port;
-        contextPath = contextPath == null ? "" : contextPath;
-        clientIp = clientIp == null ? Optional.empty() : clientIp;
-    }
-
-    /**
      * Returns the empty result: no scheme, host, port, or client IP, and an empty context-path.
      * This is what a secure-by-default resolver returns for an un-proxied or fully un-honored request.
      *

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/RfcForwardedParser.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/RfcForwardedParser.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Minimal RFC 7239 {@code Forwarded} header parser.
+ *
+ * <p>Grammar (RFC 7239 §4):</p>
+ * <pre>
+ * Forwarded         = 1#forwarded-element
+ * forwarded-element = [ forwarded-pair ] *( ";" [ forwarded-pair ] )
+ * forwarded-pair    = token "=" value
+ * value             = token / quoted-string
+ * </pre>
+ *
+ * <p>Extracts the first {@code proto} and {@code host} directives (case-insensitive names) and the
+ * ordered list of {@code for} node identifiers across all comma-separated elements. Comma and
+ * semicolon separators inside quoted strings are honored. Note: {@code Forwarded} has no
+ * prefix/context-path directive, so none is extracted.</p>
+ */
+final class RfcForwardedParser {
+
+    private RfcForwardedParser() {
+    }
+
+    /**
+     * The relevant directives pulled from a {@code Forwarded} header value.
+     *
+     * @param proto     the first {@code proto} directive, if any
+     * @param host      the first {@code host} directive, if any
+     * @param forValues the ordered {@code for} node identifiers (unquoted), possibly empty
+     */
+    record Parsed(Optional<String> proto, Optional<String> host, List<String> forValues) {
+    }
+
+    static Parsed parse(String headerValue) {
+        Optional<String> proto = Optional.empty();
+        Optional<String> host = Optional.empty();
+        List<String> forValues = new ArrayList<>();
+
+        for (String element : splitTopLevel(headerValue, ',')) {
+            for (String pair : splitTopLevel(element, ';')) {
+                int eq = pair.indexOf('=');
+                if (eq <= 0) {
+                    continue;
+                }
+                String name = pair.substring(0, eq).strip().toLowerCase(Locale.ROOT);
+                String value = unquote(pair.substring(eq + 1).strip());
+                if (value.isEmpty()) {
+                    continue;
+                }
+                switch (name) {
+                    case "proto" -> {
+                        if (proto.isEmpty()) {
+                            proto = Optional.of(value);
+                        }
+                    }
+                    case "host" -> {
+                        if (host.isEmpty()) {
+                            host = Optional.of(value);
+                        }
+                    }
+                    case "for" -> forValues.add(value);
+                    default -> { /* ignore by, ext, and unknown directives */
+                    }
+                }
+            }
+        }
+        return new Parsed(proto, host, forValues);
+    }
+
+    /**
+     * Splits on {@code separator} at the top level only — separators inside a double-quoted string
+     * are not split points (backslash escapes are honored inside quotes).
+     */
+    private static List<String> splitTopLevel(String input, char separator) {
+        List<String> parts = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        boolean escaped = false;
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (escaped) {
+                current.append(c);
+                escaped = false;
+            } else if (c == '\\' && inQuotes) {
+                current.append(c);
+                escaped = true;
+            } else if (c == '"') {
+                inQuotes = !inQuotes;
+                current.append(c);
+            } else if (c == separator && !inQuotes) {
+                parts.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(c);
+            }
+        }
+        parts.add(current.toString());
+        return parts;
+    }
+
+    /**
+     * Strips surrounding double quotes and unescapes {@code \\x} sequences; returns non-quoted
+     * input unchanged.
+     */
+    private static String unquote(String value) {
+        if (value.length() < 2 || value.charAt(0) != '"' || value.charAt(value.length() - 1) != '"') {
+            return value;
+        }
+        StringBuilder out = new StringBuilder(value.length() - 2);
+        boolean escaped = false;
+        for (int i = 1; i < value.length() - 1; i++) {
+            char c = value.charAt(i);
+            if (escaped) {
+                out.append(c);
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else {
+                out.append(c);
+            }
+        }
+        return out.toString();
+    }
+}

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/RfcForwardedParser.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/RfcForwardedParser.java
@@ -52,39 +52,43 @@ final class RfcForwardedParser {
     }
 
     static Parsed parse(String headerValue) {
-        Optional<String> proto = Optional.empty();
-        Optional<String> host = Optional.empty();
-        List<String> forValues = new ArrayList<>();
-
+        Accumulator acc = new Accumulator();
         for (String element : splitTopLevel(headerValue, ',')) {
             for (String pair : splitTopLevel(element, ';')) {
-                int eq = pair.indexOf('=');
-                if (eq <= 0) {
-                    continue;
-                }
-                String name = pair.substring(0, eq).strip().toLowerCase(Locale.ROOT);
-                String value = unquote(pair.substring(eq + 1).strip());
-                if (value.isEmpty()) {
-                    continue;
-                }
-                switch (name) {
-                    case "proto" -> {
-                        if (proto.isEmpty()) {
-                            proto = Optional.of(value);
-                        }
-                    }
-                    case "host" -> {
-                        if (host.isEmpty()) {
-                            host = Optional.of(value);
-                        }
-                    }
-                    case "for" -> forValues.add(value);
-                    default -> { /* ignore by, ext, and unknown directives */
-                    }
+                acc.apply(pair);
+            }
+        }
+        return new Parsed(Optional.ofNullable(acc.proto), Optional.ofNullable(acc.host), acc.forValues);
+    }
+
+    /**
+     * Mutable accumulator that applies one {@code token=value} pair, keeping the first
+     * {@code proto}/{@code host} and appending every {@code for} in appearance order.
+     */
+    private static final class Accumulator {
+
+        private String proto;
+        private String host;
+        private final List<String> forValues = new ArrayList<>();
+
+        private void apply(String pair) {
+            int eq = pair.indexOf('=');
+            if (eq <= 0) {
+                return;
+            }
+            String name = pair.substring(0, eq).strip().toLowerCase(Locale.ROOT);
+            String value = unquote(pair.substring(eq + 1).strip());
+            if (value.isEmpty()) {
+                return;
+            }
+            switch (name) {
+                case "proto" -> proto = proto == null ? value : proto;
+                case "host" -> host = host == null ? value : host;
+                case "for" -> forValues.add(value);
+                default -> { /* ignore by, ext, and unknown directives */
                 }
             }
         }
-        return new Parsed(proto, host, forValues);
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/package-info.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Reusable reverse-proxy / forwarded-header resolution with built-in sanitization.
+ *
+ * <p>Reverse proxies communicate the original request scheme, host, port, context-path
+ * prefix, and client IP through a family of overlapping headers that sit at different
+ * points on the standards spectrum:</p>
+ * <table border="1">
+ *   <caption>Forwarded header family</caption>
+ *   <tr><th>Header(s)</th><th>Status</th></tr>
+ *   <tr><td>{@code X-Forwarded-For / -Proto / -Host / -Port}</td><td>de-facto convention</td></tr>
+ *   <tr><td>{@code X-Forwarded-Prefix}</td><td>de-facto (Spring Cloud Gateway, Traefik, …)</td></tr>
+ *   <tr><td>{@code Forwarded} (RFC 7239)</td><td>IETF standard — but no prefix directive</td></tr>
+ *   <tr><td>{@code X-ProxyScheme / -Host / -Port / -ContextPath}</td><td>Apache NiFi-proprietary</td></tr>
+ * </table>
+ *
+ * <p>This package folds the three otherwise-duplicated concerns into one component:
+ * <strong>precedence</strong> across the overlapping headers, <strong>normalization</strong>
+ * (context-path slashes, default ports), and <strong>injection hardening</strong> (CR/LF,
+ * protocol-relative {@code //host}, backslashes) — the last of which reuses the existing
+ * {@link de.cuioss.http.security} validation pipelines rather than hand-rolling guards.</p>
+ *
+ * <h3>Components</h3>
+ * <ul>
+ *   <li>{@link de.cuioss.http.forwarded.ForwardedHeaderResolver} - resolves the header family
+ *       into a single sanitized result</li>
+ *   <li>{@link de.cuioss.http.forwarded.ResolvedForwarding} - the immutable result, plus
+ *       serialization back to proxy headers</li>
+ *   <li>{@link de.cuioss.http.forwarded.ForwardedResolverConfig} - trust model and precedence
+ *       configuration</li>
+ * </ul>
+ *
+ * <h3>Secure by default</h3>
+ * <p>The resolver is transport-agnostic (it consumes a {@link java.util.function.Function
+ * Function&lt;String,String&gt;} header accessor, so no servlet/Jetty type leaks in) and
+ * secure-by-default: with no allowlist and no explicit {@code trustAll} opt-in, client-supplied
+ * forwarded values are ignored (never trusted), only logged. See
+ * {@link de.cuioss.http.forwarded.ForwardedResolverConfig} for the trust model.</p>
+ *
+ * <h3>Usage Example</h3>
+ * <pre>{@code
+ * ForwardedResolverConfig config = ForwardedResolverConfig.builder()
+ *     .trustAll(true)                       // deployment sits fully behind a trusted proxy
+ *     .trustedProxies(Set.of("10.0.0.0/8")) // for X-Forwarded-For client-IP resolution
+ *     .build();
+ * ForwardedHeaderResolver resolver =
+ *     new ForwardedHeaderResolver(config, new SecurityEventCounter());
+ *
+ * ResolvedForwarding forwarding = resolver.resolve(request::getHeader);
+ * String scheme = forwarding.scheme().orElse("http");
+ * String prefix = forwarding.contextPath(); // "" when none / not honored
+ * }</pre>
+ *
+ * <h3>Package Nullability</h3>
+ * <p>This package follows strict nullability conventions using JSpecify annotations:
+ * all parameters and return values are non-null by default; nullable ones are explicitly
+ * annotated with {@code @Nullable}.</p>
+ *
+ * @since 1.0
+ * @see de.cuioss.http.security.pipeline.PipelineFactory
+ */
+@NullMarked
+package de.cuioss.http.forwarded;
+
+import org.jspecify.annotations.NullMarked;

--- a/cui-http-core/src/main/java/module-info.java
+++ b/cui-http-core/src/main/java/module-info.java
@@ -27,6 +27,9 @@ module de.cuioss.http {
     exports de.cuioss.http.client.handler;
     exports de.cuioss.http.client.result;
 
+    // Reverse-proxy / forwarded-header resolution
+    exports de.cuioss.http.forwarded;
+
     // Security validation core
     exports de.cuioss.http.security.core;
     exports de.cuioss.http.security.config;

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @EnableTestLogger
 @DisplayName("ForwardedHeaderResolver")
+@SuppressWarnings("java:S5778") // assertThrows lambdas intentionally wrap the whole failing call chain
 class ForwardedHeaderResolverTest {
 
     private static Function<String, String> headers(Map<String, String> values) {

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.test.juli.LogAsserts;
+import de.cuioss.test.juli.TestLogLevel;
+import de.cuioss.test.juli.junit5.EnableTestLogger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@EnableTestLogger
+@DisplayName("ForwardedHeaderResolver")
+class ForwardedHeaderResolverTest {
+
+    private static Function<String, String> headers(Map<String, String> values) {
+        return new HashMap<>(values)::get;
+    }
+
+    private static ForwardedHeaderResolver resolver(ForwardedResolverConfig config) {
+        return new ForwardedHeaderResolver(config, new SecurityEventCounter());
+    }
+
+    private static ForwardedHeaderResolver trustAllResolver() {
+        return resolver(ForwardedResolverConfig.builder().trustAll(true).build());
+    }
+
+    @Nested
+    @DisplayName("Constructor")
+    class Constructor {
+
+        @Test
+        @DisplayName("rejects null arguments")
+        void rejectsNullArguments() {
+            assertThrows(NullPointerException.class,
+                    () -> new ForwardedHeaderResolver(null, new SecurityEventCounter()));
+            assertThrows(NullPointerException.class,
+                    () -> new ForwardedHeaderResolver(ForwardedResolverConfig.secureDefault(), null));
+        }
+
+        @Test
+        @DisplayName("resolve rejects a null header lookup")
+        void resolveRejectsNullLookup() {
+            assertThrows(NullPointerException.class, () -> trustAllResolver().resolve(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("Secure default")
+    class SecureDefault {
+
+        @Test
+        @DisplayName("ignores every forwarded header")
+        void ignoresEverything() {
+            var lookup = headers(Map.of(
+                    "X-Forwarded-Proto", "https",
+                    "X-Forwarded-Host", "app.example.com",
+                    "X-Forwarded-Port", "8443",
+                    "X-Forwarded-Prefix", "/ui",
+                    "X-Forwarded-For", "203.0.113.7"));
+
+            assertEquals(ResolvedForwarding.empty(), resolver(ForwardedResolverConfig.secureDefault()).resolve(lookup));
+        }
+
+        @Test
+        @DisplayName("resolves an un-proxied request to empty")
+        void unproxiedRequestIsEmpty() {
+            assertEquals(ResolvedForwarding.empty(), trustAllResolver().resolve(headers(Map.of())));
+        }
+    }
+
+    @Nested
+    @DisplayName("Scheme")
+    class Scheme {
+
+        @Test
+        @DisplayName("honors X-Forwarded-Proto and lowercases it")
+        void honorsXForwardedProto() {
+            var result = trustAllResolver().resolve(headers(Map.of("X-Forwarded-Proto", "HTTPS")));
+            assertEquals("https", result.scheme().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("falls back to X-ProxyScheme then RFC 7239 proto")
+        void precedence() {
+            assertEquals("http", trustAllResolver()
+                    .resolve(headers(Map.of("X-ProxyScheme", "http"))).scheme().orElseThrow());
+            assertEquals("https", trustAllResolver()
+                    .resolve(headers(Map.of("Forwarded", "proto=https;host=x"))).scheme().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("takes the first token of a comma-separated list")
+        void firstTokenOfList() {
+            assertEquals("https", trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Proto", "https, http"))).scheme().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("drops a non-http(s) scheme")
+        void dropsUnknownScheme() {
+            assertTrue(trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Proto", "ftp"))).scheme().isEmpty());
+        }
+
+        @Test
+        @DisplayName("is not honored without trustAll")
+        void notHonoredWithoutTrustAll() {
+            assertTrue(resolver(ForwardedResolverConfig.secureDefault())
+                    .resolve(headers(Map.of("X-Forwarded-Proto", "https"))).scheme().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Host and port")
+    class HostAndPort {
+
+        @Test
+        @DisplayName("honors a plain host")
+        void plainHost() {
+            var result = trustAllResolver().resolve(headers(Map.of("X-Forwarded-Host", "app.example.com")));
+            assertEquals("app.example.com", result.host().orElseThrow());
+            assertTrue(result.port().isEmpty());
+        }
+
+        @Test
+        @DisplayName("splits host:port into host and port")
+        void splitsHostPort() {
+            var result = trustAllResolver().resolve(headers(Map.of("X-Forwarded-Host", "app.example.com:8443")));
+            assertEquals("app.example.com", result.host().orElseThrow());
+            assertEquals(8443, result.port().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("keeps bracketed IPv6 host and its port")
+        void bracketedIpv6Host() {
+            var result = trustAllResolver().resolve(headers(Map.of("X-Forwarded-Host", "[2001:db8::1]:8443")));
+            assertEquals("[2001:db8::1]", result.host().orElseThrow());
+            assertEquals(8443, result.port().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("X-Forwarded-Port overrides a port carried by the host")
+        void explicitPortOverridesHostPort() {
+            var result = trustAllResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Host", "app.example.com:8443",
+                    "X-Forwarded-Port", "9000")));
+            assertEquals(9000, result.port().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("falls back to X-ProxyHost and RFC 7239 host")
+        void hostPrecedence() {
+            assertEquals("proxy.example.com", trustAllResolver()
+                    .resolve(headers(Map.of("X-ProxyHost", "proxy.example.com"))).host().orElseThrow());
+            assertEquals("rfc.example.com", trustAllResolver()
+                    .resolve(headers(Map.of("Forwarded", "host=rfc.example.com"))).host().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("drops an out-of-range or non-numeric port")
+        void dropsInvalidPort() {
+            assertTrue(trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Port", "70000"))).port().isEmpty());
+            assertTrue(trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Port", "abc"))).port().isEmpty());
+            assertTrue(trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Port", "0"))).port().isEmpty());
+        }
+
+        @Test
+        @DisplayName("rejects a host carrying a path separator")
+        void rejectsHostWithPath() {
+            assertTrue(trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Host", "evil.com/path"))).host().isEmpty());
+        }
+
+        @Test
+        @DisplayName("host and port are not honored without trustAll")
+        void notHonoredWithoutTrustAll() {
+            var result = resolver(ForwardedResolverConfig.secureDefault())
+                    .resolve(headers(Map.of("X-Forwarded-Host", "app.example.com:8443")));
+            assertTrue(result.host().isEmpty());
+            assertTrue(result.port().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Context path")
+    class ContextPath {
+
+        @Test
+        @DisplayName("honors and normalizes X-ProxyContextPath under trustAll")
+        void honorsAndNormalizes() {
+            assertEquals("/app", trustAllResolver()
+                    .resolve(headers(Map.of("X-ProxyContextPath", "/app/"))).contextPath());
+        }
+
+        @Test
+        @DisplayName("falls back to X-Forwarded-Prefix")
+        void prefixFallback() {
+            assertEquals("/ui", trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Prefix", "ui"))).contextPath());
+        }
+
+        @Test
+        @DisplayName("honors only allowlisted paths when trustAll is false")
+        void allowlistGated() {
+            ForwardedResolverConfig config = ForwardedResolverConfig.builder()
+                    .allowedContextPaths(Set.of("/app"))
+                    .build();
+
+            assertEquals("/app", resolver(config)
+                    .resolve(headers(Map.of("X-ProxyContextPath", "/app/"))).contextPath());
+            assertEquals("", resolver(config)
+                    .resolve(headers(Map.of("X-ProxyContextPath", "/attacker"))).contextPath());
+        }
+
+        @Test
+        @DisplayName("rejects a protocol-relative prefix and warns")
+        void rejectsProtocolRelative() {
+            assertEquals("", trustAllResolver()
+                    .resolve(headers(Map.of("X-ProxyContextPath", "//attacker.com"))).contextPath());
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN,
+                    "protocol-relative URL injection");
+        }
+
+        @Test
+        @DisplayName("rejects a backslash-bearing prefix")
+        void rejectsBackslash() {
+            assertEquals("", trustAllResolver()
+                    .resolve(headers(Map.of("X-ProxyContextPath", "/\\attacker.com"))).contextPath());
+        }
+
+        @Test
+        @DisplayName("a bare Forwarded header yields no context path")
+        void forwardedHasNoPrefix() {
+            assertEquals("", trustAllResolver()
+                    .resolve(headers(Map.of("Forwarded", "proto=https;host=x"))).contextPath());
+        }
+    }
+
+    @Nested
+    @DisplayName("Client IP")
+    class ClientIp {
+
+        private ForwardedResolverConfig trustingProxies(String... cidrs) {
+            return ForwardedResolverConfig.builder()
+                    .trustAll(true)
+                    .trustedProxies(Set.of(cidrs))
+                    .build();
+        }
+
+        @Test
+        @DisplayName("resolves the first untrusted hop from the right")
+        void resolvesFirstUntrusted() {
+            var result = resolver(trustingProxies("10.0.0.0/8"))
+                    .resolve(headers(Map.of("X-Forwarded-For", "203.0.113.7, 10.0.0.5")));
+            assertEquals("203.0.113.7", result.clientIp().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("ignores a spoofed prepended entry")
+        void ignoresSpoofedEntry() {
+            var result = resolver(trustingProxies("10.0.0.0/8"))
+                    .resolve(headers(Map.of("X-Forwarded-For", "1.2.3.4, 203.0.113.7, 10.0.0.5")));
+            assertEquals("203.0.113.7", result.clientIp().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("returns empty when every hop is trusted")
+        void allTrustedIsEmpty() {
+            var result = resolver(trustingProxies("10.0.0.0/8"))
+                    .resolve(headers(Map.of("X-Forwarded-For", "10.0.0.1, 10.0.0.5")));
+            assertTrue(result.clientIp().isEmpty());
+        }
+
+        @Test
+        @DisplayName("returns empty (and warns) on an unparseable rightmost hop")
+        void unparseableHopIsEmpty() {
+            var result = resolver(trustingProxies("10.0.0.0/8"))
+                    .resolve(headers(Map.of("X-Forwarded-For", "203.0.113.7, garbage")));
+            assertTrue(result.clientIp().isEmpty());
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "unparseable entry");
+        }
+
+        @Test
+        @DisplayName("resolves a bare IPv6 client to its canonical form")
+        void ipv6Client() {
+            var result = resolver(trustingProxies("10.0.0.0/8"))
+                    .resolve(headers(Map.of("X-Forwarded-For", "2001:db8::1, 10.0.0.5")));
+            assertEquals("2001:db8:0:0:0:0:0:1", result.clientIp().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("handles IPv6 CIDR trusted proxies")
+        void ipv6TrustedProxy() {
+            var result = resolver(trustingProxies("2001:db8::/32"))
+                    .resolve(headers(Map.of("X-Forwarded-For", "203.0.113.7, 2001:db8::5")));
+            assertEquals("203.0.113.7", result.clientIp().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("uses the RFC 7239 for chain when X-Forwarded-For is absent")
+        void rfcForChain() {
+            var result = resolver(trustingProxies("10.0.0.0/8"))
+                    .resolve(headers(Map.of("Forwarded", "for=203.0.113.7, for=\"10.0.0.5\"")));
+            assertEquals("203.0.113.7", result.clientIp().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("strips a port from a for entry")
+        void stripsPort() {
+            var result = resolver(trustingProxies("10.0.0.0/8"))
+                    .resolve(headers(Map.of("X-Forwarded-For", "203.0.113.7:51234, 10.0.0.5")));
+            assertEquals("203.0.113.7", result.clientIp().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("is not honored when no trusted proxies are configured")
+        void noTrustedProxiesIsEmpty() {
+            var result = trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-For", "203.0.113.7")));
+            assertTrue(result.clientIp().isEmpty(),
+                    "Without trusted proxies the chain is not honored even under trustAll");
+        }
+    }
+
+    @Nested
+    @DisplayName("Fail-safe sanitization")
+    class FailSafe {
+
+        @Test
+        @DisplayName("drops a CRLF-injecting header value without throwing and warns")
+        void dropsCrlfInjection() {
+            var result = trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Host", "evil.com\r\nInjected: 1")));
+            assertTrue(result.host().isEmpty());
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "failed security sanitization");
+        }
+    }
+
+    @Nested
+    @DisplayName("Round trip")
+    class RoundTrip {
+
+        @Test
+        @DisplayName("re-resolves X-Forwarded-* serialization to the same result")
+        void xForwardedRoundTrip() {
+            ForwardedResolverConfig config = ForwardedResolverConfig.builder()
+                    .trustAll(true)
+                    .trustedProxies(Set.of("10.0.0.0/8"))
+                    .build();
+            ForwardedHeaderResolver resolver = resolver(config);
+
+            var original = resolver.resolve(headers(Map.of(
+                    "X-Forwarded-Proto", "https",
+                    "X-Forwarded-Host", "app.example.com:8443",
+                    "X-Forwarded-Prefix", "/ui/",
+                    "X-Forwarded-For", "203.0.113.7, 10.0.0.5")));
+
+            assertEquals("https", original.scheme().orElseThrow());
+            assertEquals("app.example.com", original.host().orElseThrow());
+            assertEquals(8443, original.port().orElseThrow());
+            assertEquals("/ui", original.contextPath());
+            assertEquals("203.0.113.7", original.clientIp().orElseThrow());
+
+            var reResolved = resolver.resolve(headers(original.toXForwardedHeaders()));
+            assertEquals(original, reResolved);
+        }
+
+        @Test
+        @DisplayName("re-resolves the RFC 7239 Forwarded serialization (context path excepted)")
+        void forwardedRoundTrip() {
+            ForwardedResolverConfig config = ForwardedResolverConfig.builder()
+                    .trustAll(true)
+                    .trustedProxies(Set.of("10.0.0.0/8"))
+                    .build();
+            ForwardedHeaderResolver resolver = resolver(config);
+
+            var original = resolver.resolve(headers(Map.of(
+                    "X-Forwarded-Proto", "https",
+                    "X-Forwarded-Host", "app.example.com:8443",
+                    "X-Forwarded-For", "203.0.113.7, 10.0.0.5")));
+
+            String forwarded = original.toForwardedHeader().orElseThrow();
+            var reResolved = resolver.resolve(headers(Map.of("Forwarded", forwarded)));
+
+            assertEquals(original.scheme(), reResolved.scheme());
+            assertEquals(original.host(), reResolved.host());
+            assertEquals(original.port(), reResolved.port());
+            assertEquals(original.clientIp(), reResolved.clientIp());
+            assertEquals("", reResolved.contextPath());
+        }
+
+        @Test
+        @DisplayName("context path is lost through Forwarded but kept through X-Forwarded-Prefix")
+        void contextPathAsymmetry() {
+            var forwarding = new ResolvedForwarding(Optional.empty(), Optional.empty(),
+                    OptionalInt.empty(), "/ui", Optional.empty());
+            assertTrue(forwarding.toForwardedHeader().isEmpty());
+            assertFalse(forwarding.toXForwardedHeaders().isEmpty());
+        }
+    }
+}

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedResolverConfigTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedResolverConfigTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("ForwardedResolverConfig")
+@SuppressWarnings("java:S5778") // assertThrows lambdas intentionally wrap the whole failing call chain
 class ForwardedResolverConfigTest {
 
     @Nested
@@ -77,12 +78,10 @@ class ForwardedResolverConfigTest {
         @Test
         @DisplayName("rejects null setters")
         void rejectsNullSetters() {
-            assertThrows(IllegalArgumentException.class,
-                    () -> ForwardedResolverConfig.builder().allowedContextPaths(null));
-            assertThrows(IllegalArgumentException.class,
-                    () -> ForwardedResolverConfig.builder().trustedProxies(null));
-            assertThrows(IllegalArgumentException.class,
-                    () -> ForwardedResolverConfig.builder().securityConfig(null));
+            ForwardedResolverConfig.Builder builder = ForwardedResolverConfig.builder();
+            assertThrows(NullPointerException.class, () -> builder.allowedContextPaths(null));
+            assertThrows(NullPointerException.class, () -> builder.trustedProxies(null));
+            assertThrows(NullPointerException.class, () -> builder.securityConfig(null));
         }
 
         @ParameterizedTest(name = "rejects malformed trusted proxy \"{0}\"")

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedResolverConfigTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedResolverConfigTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import de.cuioss.http.security.config.SecurityConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ForwardedResolverConfig")
+class ForwardedResolverConfigTest {
+
+    @Nested
+    @DisplayName("Defaults")
+    class Defaults {
+
+        @Test
+        @DisplayName("secureDefault honors nothing")
+        void secureDefaultHonorsNothing() {
+            ForwardedResolverConfig config = ForwardedResolverConfig.secureDefault();
+
+            assertFalse(config.trustAll());
+            assertTrue(config.allowedContextPaths().isEmpty());
+            assertTrue(config.trustedProxies().isEmpty());
+            assertEquals(SecurityConfiguration.defaults(), config.securityConfig());
+        }
+    }
+
+    @Nested
+    @DisplayName("Builder")
+    class Builder {
+
+        @Test
+        @DisplayName("normalizes allowed context paths and drops empties")
+        void normalizesAllowedContextPaths() {
+            ForwardedResolverConfig config = ForwardedResolverConfig.builder()
+                    .allowedContextPaths(new LinkedHashSet<>(List.of("app/", "/gw", "/", "  ")))
+                    .build();
+
+            assertEquals(Set.of("/app", "/gw"), config.allowedContextPaths());
+        }
+
+        @Test
+        @DisplayName("returns unmodifiable views")
+        void returnsUnmodifiableViews() {
+            ForwardedResolverConfig config = ForwardedResolverConfig.builder()
+                    .allowedContextPaths(Set.of("/app"))
+                    .trustedProxies(Set.of("10.0.0.0/8"))
+                    .build();
+
+            assertThrows(UnsupportedOperationException.class, () -> config.allowedContextPaths().add("/x"));
+            assertThrows(UnsupportedOperationException.class, () -> config.trustedProxies().add("x"));
+        }
+
+        @Test
+        @DisplayName("rejects null setters")
+        void rejectsNullSetters() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> ForwardedResolverConfig.builder().allowedContextPaths(null));
+            assertThrows(IllegalArgumentException.class,
+                    () -> ForwardedResolverConfig.builder().trustedProxies(null));
+            assertThrows(IllegalArgumentException.class,
+                    () -> ForwardedResolverConfig.builder().securityConfig(null));
+        }
+
+        @ParameterizedTest(name = "rejects malformed trusted proxy \"{0}\"")
+        @ValueSource(strings = {"not-an-ip", "10.0.0.0/99", "example.com", "10.0.0.0/", "999.1.1.1/8"})
+        @DisplayName("rejects malformed trusted-proxy specs")
+        void rejectsMalformedTrustedProxies(String spec) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> ForwardedResolverConfig.builder().trustedProxies(Set.of(spec)));
+        }
+
+        @Test
+        @DisplayName("accepts IPv4, IPv6, CIDR, and bare-literal trusted proxies")
+        void acceptsValidTrustedProxies() {
+            ForwardedResolverConfig config = ForwardedResolverConfig.builder()
+                    .trustedProxies(new LinkedHashSet<>(List.of("10.0.0.0/8", "192.168.1.1", "2001:db8::/32")))
+                    .build();
+
+            assertEquals(3, config.trustedProxies().size());
+        }
+
+        @Test
+        @DisplayName("skips blank trusted-proxy entries")
+        void skipsBlankTrustedProxies() {
+            ForwardedResolverConfig config = ForwardedResolverConfig.builder()
+                    .trustedProxies(new LinkedHashSet<>(List.of("10.0.0.0/8", "   ")))
+                    .build();
+
+            assertEquals(Set.of("10.0.0.0/8"), config.trustedProxies());
+        }
+    }
+
+    @Nested
+    @DisplayName("parseAllowlist")
+    class ParseAllowlist {
+
+        @Test
+        @DisplayName("normalizes and preserves input order, dropping empties")
+        void normalizesAndOrders() {
+            Set<String> allowed = ForwardedResolverConfig.parseAllowlist("nifi-proxy, /gw/, , /, //attacker.com");
+
+            assertEquals(List.of("/nifi-proxy", "/gw"), new ArrayList<>(allowed));
+        }
+
+        @Test
+        @DisplayName("returns an empty unmodifiable set for null/blank input")
+        void emptyForNullOrBlank() {
+            assertTrue(ForwardedResolverConfig.parseAllowlist(null).isEmpty());
+            assertTrue(ForwardedResolverConfig.parseAllowlist("   ").isEmpty());
+            assertThrows(UnsupportedOperationException.class,
+                    () -> ForwardedResolverConfig.parseAllowlist("/app").add("/x"));
+        }
+    }
+}

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/IpAddressesTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/IpAddressesTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.InetAddress;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("IP utilities")
+class IpAddressesTest {
+
+    @Nested
+    @DisplayName("IpAddresses.parseChainEntry")
+    class ParseChainEntry {
+
+        @Test
+        @DisplayName("parses IPv4, IPv4:port, bracketed IPv6, and bare IPv6")
+        void parsesUsableForms() {
+            assertNotNull(IpAddresses.parseChainEntry("192.0.2.7"));
+            assertNotNull(IpAddresses.parseChainEntry("192.0.2.7:443"));
+            assertNotNull(IpAddresses.parseChainEntry("[2001:db8::1]:443"));
+            assertNotNull(IpAddresses.parseChainEntry("2001:db8::1"));
+        }
+
+        @ParameterizedTest(name = "\"{0}\" is not a usable node identifier")
+        @ValueSource(strings = {"unknown", "UNKNOWN", "_hidden", "not-an-ip", "[2001:db8::1", "", "   "})
+        @DisplayName("rejects unknown/obfuscated/malformed entries")
+        void rejectsUnusable(String entry) {
+            assertNull(IpAddresses.parseChainEntry(entry));
+        }
+
+        @Test
+        @DisplayName("canonicalizes to the host address form")
+        void canonicalizes() {
+            InetAddress address = IpAddresses.parseChainEntry("192.0.2.7:443");
+            assertNotNull(address);
+            assertEquals("192.0.2.7", IpAddresses.canonical(address));
+        }
+    }
+
+    @Nested
+    @DisplayName("CidrRange")
+    class Cidr {
+
+        @Test
+        @DisplayName("a bare literal matches only itself")
+        void bareLiteralMatchesItself() {
+            CidrRange range = CidrRange.parse("192.168.1.1");
+            assertTrue(range.contains(IpAddresses.parse("192.168.1.1")));
+            assertFalse(range.contains(IpAddresses.parse("192.168.1.2")));
+        }
+
+        @Test
+        @DisplayName("an IPv4 range never matches an IPv6 candidate")
+        void familyMismatch() {
+            CidrRange range = CidrRange.parse("10.0.0.0/8");
+            assertFalse(range.contains(IpAddresses.parse("2001:db8::1")));
+        }
+
+        @Test
+        @DisplayName("matches within a sub-byte prefix boundary")
+        void subBytePrefix() {
+            CidrRange range = CidrRange.parse("203.0.113.0/28");
+            assertTrue(range.contains(IpAddresses.parse("203.0.113.5")));
+            assertFalse(range.contains(IpAddresses.parse("203.0.113.20")));
+        }
+    }
+}

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ResolvedForwardingTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ResolvedForwardingTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ResolvedForwarding")
+class ResolvedForwardingTest {
+
+    @Nested
+    @DisplayName("Construction")
+    class Construction {
+
+        @Test
+        @DisplayName("empty() carries no fields and an empty context path")
+        void emptyHasNoFields() {
+            ResolvedForwarding empty = ResolvedForwarding.empty();
+
+            assertTrue(empty.scheme().isEmpty());
+            assertTrue(empty.host().isEmpty());
+            assertTrue(empty.port().isEmpty());
+            assertEquals("", empty.contextPath());
+            assertTrue(empty.clientIp().isEmpty());
+        }
+
+        @Test
+        @DisplayName("null components are normalized to empty by the canonical constructor")
+        void nullComponentsNormalized() {
+            ResolvedForwarding value = new ResolvedForwarding(null, null, null, null, null);
+
+            assertEquals(ResolvedForwarding.empty(), value,
+                    "A fully-null construction must equal the empty result");
+        }
+    }
+
+    @Nested
+    @DisplayName("toXForwardedHeaders")
+    class ToXForwardedHeaders {
+
+        @Test
+        @DisplayName("emits only the present fields")
+        void emitsOnlyPresentFields() {
+            var forwarding = new ResolvedForwarding(Optional.of("https"), Optional.of("app.example.com"),
+                    OptionalInt.of(8443), "/ui", Optional.of("203.0.113.7"));
+
+            Map<String, String> headers = forwarding.toXForwardedHeaders();
+
+            assertEquals("https", headers.get("X-Forwarded-Proto"));
+            assertEquals("app.example.com", headers.get("X-Forwarded-Host"));
+            assertEquals("8443", headers.get("X-Forwarded-Port"));
+            assertEquals("/ui", headers.get("X-Forwarded-Prefix"));
+            assertEquals("203.0.113.7", headers.get("X-Forwarded-For"));
+            assertEquals(5, headers.size());
+        }
+
+        @Test
+        @DisplayName("omits absent fields, including an empty context path")
+        void omitsAbsentFields() {
+            var forwarding = new ResolvedForwarding(Optional.of("http"), Optional.empty(),
+                    OptionalInt.empty(), "", Optional.empty());
+
+            Map<String, String> headers = forwarding.toXForwardedHeaders();
+
+            assertEquals(Map.of("X-Forwarded-Proto", "http"), headers);
+        }
+
+        @Test
+        @DisplayName("empty() serializes to no headers")
+        void emptySerializesToNoHeaders() {
+            assertTrue(ResolvedForwarding.empty().toXForwardedHeaders().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("toForwardedHeader")
+    class ToForwardedHeader {
+
+        @Test
+        @DisplayName("emits for/host/proto directives; folds port into host")
+        void emitsDirectives() {
+            var forwarding = new ResolvedForwarding(Optional.of("https"), Optional.of("app.example.com"),
+                    OptionalInt.of(8443), "/ui", Optional.of("203.0.113.7"));
+
+            assertEquals(Optional.of("for=203.0.113.7;host=\"app.example.com:8443\";proto=https"),
+                    forwarding.toForwardedHeader());
+        }
+
+        @Test
+        @DisplayName("brackets and quotes an IPv6 client address")
+        void bracketsIpv6ClientAddress() {
+            var forwarding = new ResolvedForwarding(Optional.empty(), Optional.empty(),
+                    OptionalInt.empty(), "", Optional.of("2001:db8::1"));
+
+            assertEquals(Optional.of("for=\"[2001:db8::1]\""), forwarding.toForwardedHeader());
+        }
+
+        @Test
+        @DisplayName("omits the context path (RFC 7239 has no prefix directive)")
+        void omitsContextPath() {
+            var forwarding = new ResolvedForwarding(Optional.empty(), Optional.empty(),
+                    OptionalInt.empty(), "/ui", Optional.empty());
+
+            assertTrue(forwarding.toForwardedHeader().isEmpty(),
+                    "A result carrying only a context path has no Forwarded-expressible field");
+        }
+
+        @Test
+        @DisplayName("emits an unquoted host when it is a valid token")
+        void emitsUnquotedTokenHost() {
+            var forwarding = new ResolvedForwarding(Optional.of("http"), Optional.of("example.com"),
+                    OptionalInt.empty(), "", Optional.empty());
+
+            assertEquals(Optional.of("host=example.com;proto=http"), forwarding.toForwardedHeader());
+        }
+
+        @Test
+        @DisplayName("empty() serializes to no Forwarded value")
+        void emptySerializesToNothing() {
+            assertTrue(ResolvedForwarding.empty().toForwardedHeader().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Interplay")
+    class Interplay {
+
+        @Test
+        @DisplayName("X-Forwarded-Prefix carries the context path that Forwarded cannot")
+        void prefixCarriesContextPath() {
+            var forwarding = new ResolvedForwarding(Optional.empty(), Optional.empty(),
+                    OptionalInt.empty(), "/gateway", Optional.empty());
+
+            assertTrue(forwarding.toForwardedHeader().isEmpty());
+            assertEquals("/gateway", forwarding.toXForwardedHeaders().get("X-Forwarded-Prefix"));
+            assertFalse(forwarding.toXForwardedHeaders().containsKey("X-Forwarded-Proto"));
+        }
+    }
+}

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ResolvedForwardingTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ResolvedForwardingTest.java
@@ -43,15 +43,6 @@ class ResolvedForwardingTest {
             assertEquals("", empty.contextPath());
             assertTrue(empty.clientIp().isEmpty());
         }
-
-        @Test
-        @DisplayName("null components are normalized to empty by the canonical constructor")
-        void nullComponentsNormalized() {
-            ResolvedForwarding value = new ResolvedForwarding(null, null, null, null, null);
-
-            assertEquals(ResolvedForwarding.empty(), value,
-                    "A fully-null construction must equal the empty result");
-        }
     }
 
     @Nested

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/RfcForwardedParserTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/RfcForwardedParserTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("RfcForwardedParser")
+class RfcForwardedParserTest {
+
+    @Test
+    @DisplayName("extracts proto, host, and the ordered for chain")
+    void extractsDirectives() {
+        RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse(
+                "for=203.0.113.7;host=app.example.com;proto=https, for=10.0.0.5");
+
+        assertEquals("https", parsed.proto().orElseThrow());
+        assertEquals("app.example.com", parsed.host().orElseThrow());
+        assertEquals(List.of("203.0.113.7", "10.0.0.5"), parsed.forValues());
+    }
+
+    @Test
+    @DisplayName("unquotes quoted values and keeps commas inside quotes")
+    void handlesQuotedValues() {
+        RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse("for=\"[2001:db8::1]:443\";host=\"a,b\"");
+
+        assertEquals("[2001:db8::1]:443", parsed.forValues().getFirst());
+        assertEquals("a,b", parsed.host().orElseThrow());
+    }
+
+    @Test
+    @DisplayName("takes the first proto/host across elements")
+    void firstProtoWins() {
+        RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse("proto=https, proto=http");
+
+        assertEquals("https", parsed.proto().orElseThrow());
+    }
+
+    @Test
+    @DisplayName("is case-insensitive on directive names and ignores unknown directives")
+    void caseInsensitiveAndIgnoresUnknown() {
+        RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse("Proto=https;By=10.0.0.1;ext=x");
+
+        assertEquals("https", parsed.proto().orElseThrow());
+        assertTrue(parsed.host().isEmpty());
+        assertTrue(parsed.forValues().isEmpty());
+    }
+
+    @Test
+    @DisplayName("ignores malformed pairs without a value")
+    void ignoresMalformedPairs() {
+        RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse("proto=;host");
+
+        assertTrue(parsed.proto().isEmpty());
+        assertTrue(parsed.host().isEmpty());
+    }
+}


### PR DESCRIPTION
Closes #88.

## What

Adds `de.cuioss.http.forwarded`, a transport-agnostic component that resolves the reverse-proxy header family into a single sanitized, immutable `ResolvedForwarding` (scheme / host / port / context-path prefix / client IP), folding the three otherwise-duplicated concerns — **precedence**, **normalization**, and **injection hardening** — into one place.

### Key types
- `ForwardedHeaderResolver` — `resolve(Function<String,String>)`, so it works with any transport (Jetty `Request`, `HttpServletRequest`, …) without leaking a servlet/Jetty type.
- `ResolvedForwarding` — the immutable result, plus `toXForwardedHeaders()` / `toForwardedHeader()` serialization.
- `ForwardedResolverConfig` — trust model (`trustAll`, `allowedContextPaths`, `trustedProxies`) + `secureDefault()`.

### Behavior
- **Precedence per field**: proprietary (`X-Proxy*`) → de-facto (`X-Forwarded-*`) → RFC 7239 `Forwarded`. The `Forwarded` prefix resolves empty by design (no prefix directive in RFC 7239).
- **Sanitization** reuses the existing `de.cuioss.http.security` header-value pipeline (rejects CR/LF, NUL, control chars, over-length, suspicious patterns). Context-path injection guards (protocol-relative `//`, backslash) run on the **raw** value before the pipeline can mask a `//host` prefix by collapsing it.
- **Secure by default**: with no allowlist and no `trustAll`, client-supplied values are ignored (only logged). Context-path is honored under `trustAll` **or** an allowlist match; scheme/host/port only under `trustAll`.
- **Client IP**: walks the `X-Forwarded-For` / RFC 7239 `for` chain right-to-left against a trusted-proxy **CIDR** set (IPv4 + IPv6, literal-only parsing — never DNS). An empty `trustedProxies` set honors no client IP; an unparseable hop aborts resolution.
- **Serialization asymmetry** (documented): `contextPath` round-trips only through `X-Forwarded-Prefix`, never through RFC 7239 `Forwarded`.

## Tests & benchmarks
- Full unit coverage (precedence, RFC 7239 parsing, normalization, injection guard, scheme/host/port, client-IP CIDR walk incl. spoof/all-trusted/unparseable, trust model, fail-safe, serialization, round-trip); every new class ≥ 80% line coverage.
- Adds `ForwardedResolverBenchmark` (JMH) to the benchmarking module.
- `./mvnw -Ppre-commit clean verify` passes.

## Follow-up (separate)
Once released, `nifi-extensions` can depend on this and drop its local `ProxyContextPathResolver` / `ProxyContextPathServlet` copies.