### PR TITLE
fix(benchmark): guard forwarded benchmark cycle index against int overflow

### DIFF
--- a/cui-http-benchmarking/src/main/java/de/cuioss/http/forwarded/benchmark/ForwardedBenchmarkState.java
+++ b/cui-http-benchmarking/src/main/java/de/cuioss/http/forwarded/benchmark/ForwardedBenchmarkState.java
@@ -83,16 +83,16 @@ public class ForwardedBenchmarkState {
 
     /** @return the next clean {@code X-Forwarded-*} header accessor, cycling. */
     public Function<String, String> nextCleanXForwarded() {
-        return CLEAN_XFORWARDED.get(cleanIndex.getAndIncrement() % CLEAN_XFORWARDED.size())::get;
+        return CLEAN_XFORWARDED.get((cleanIndex.getAndIncrement() & Integer.MAX_VALUE) % CLEAN_XFORWARDED.size())::get;
     }
 
     /** @return the next RFC 7239 {@code Forwarded} header accessor, cycling. */
     public Function<String, String> nextForwarded() {
-        return FORWARDED_RFC.get(forwardedIndex.getAndIncrement() % FORWARDED_RFC.size())::get;
+        return FORWARDED_RFC.get((forwardedIndex.getAndIncrement() & Integer.MAX_VALUE) % FORWARDED_RFC.size())::get;
     }
 
     /** @return the next injection header accessor, cycling. */
     public Function<String, String> nextAttack() {
-        return ATTACK_XFORWARDED.get(attackIndex.getAndIncrement() % ATTACK_XFORWARDED.size())::get;
+        return ATTACK_XFORWARDED.get((attackIndex.getAndIncrement() & Integer.MAX_VALUE) % ATTACK_XFORWARDED.size())::get;
     }
 }


### PR DESCRIPTION
Follow-up to #89. The `AtomicInteger` overflow fix Gemini requested on that PR was pushed after auto-merge had already squashed at the prior commit, so it never reached `main`.

Masks each `AtomicInteger.getAndIncrement()` with `& Integer.MAX_VALUE` before the modulo in `ForwardedBenchmarkState`, so a long-running JMH throughput run cannot wrap the counter to a negative value and throw `IndexOutOfBoundsException`.

No production code affected (benchmarking module only).