### PR TITLE
fix: clear remaining Sonar findings on forwarded package

### DIFF
--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedResolverConfig.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedResolverConfig.java
@@ -16,6 +16,7 @@
 package de.cuioss.http.forwarded;
 
 import de.cuioss.http.security.config.SecurityConfiguration;
+import org.jspecify.annotations.Nullable;
 
 import java.net.InetAddress;
 import java.util.*;
@@ -132,7 +133,7 @@ public final class ForwardedResolverConfig {
      * @param commaSeparated the raw comma-separated allowlist (may be {@code null})
      * @return an unmodifiable set of normalized context paths in input order
      */
-    public static Set<String> parseAllowlist(String commaSeparated) {
+    public static Set<String> parseAllowlist(@Nullable String commaSeparated) {
         Set<String> allowed = new LinkedHashSet<>();
         if (commaSeparated == null || commaSeparated.isBlank()) {
             return Collections.unmodifiableSet(allowed);

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/RfcForwardedParser.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/RfcForwardedParser.java
@@ -89,6 +89,30 @@ final class RfcForwardedParser {
                 }
             }
         }
+
+        /**
+         * Strips surrounding double quotes and unescapes {@code \\x} sequences; returns non-quoted
+         * input unchanged.
+         */
+        private static String unquote(String value) {
+            if (value.length() < 2 || value.charAt(0) != '"' || value.charAt(value.length() - 1) != '"') {
+                return value;
+            }
+            StringBuilder out = new StringBuilder(value.length() - 2);
+            boolean escaped = false;
+            for (int i = 1; i < value.length() - 1; i++) {
+                char c = value.charAt(i);
+                if (escaped) {
+                    out.append(c);
+                    escaped = false;
+                } else if (c == '\\') {
+                    escaped = true;
+                } else {
+                    out.append(c);
+                }
+            }
+            return out.toString();
+        }
     }
 
     /**
@@ -120,29 +144,5 @@ final class RfcForwardedParser {
         }
         parts.add(current.toString());
         return parts;
-    }
-
-    /**
-     * Strips surrounding double quotes and unescapes {@code \\x} sequences; returns non-quoted
-     * input unchanged.
-     */
-    private static String unquote(String value) {
-        if (value.length() < 2 || value.charAt(0) != '"' || value.charAt(value.length() - 1) != '"') {
-            return value;
-        }
-        StringBuilder out = new StringBuilder(value.length() - 2);
-        boolean escaped = false;
-        for (int i = 1; i < value.length() - 1; i++) {
-            char c = value.charAt(i);
-            if (escaped) {
-                out.append(c);
-                escaped = false;
-            } else if (c == '\\') {
-                escaped = true;
-            } else {
-                out.append(c);
-            }
-        }
-        return out.toString();
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/RfcForwardedParserTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/RfcForwardedParserTest.java
@@ -47,6 +47,16 @@ class RfcForwardedParserTest {
     }
 
     @Test
+    @DisplayName("unescapes backslash-escaped characters inside a quoted value")
+    void unescapesEscapedCharacters() {
+        // host="a\"b" -> a"b ; for="x\\y" -> x\y
+        RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse("host=\"a\\\"b\";for=\"x\\\\y\"");
+
+        assertEquals("a\"b", parsed.host().orElseThrow());
+        assertEquals("x\\y", parsed.forValues().getFirst());
+    }
+
+    @Test
     @DisplayName("takes the first proto/host across elements")
     void firstProtoWins() {
         RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse("proto=https, proto=http");


### PR DESCRIPTION
Follow-up to #89 clearing the two remaining SonarCloud issues on the new `de.cuioss.http.forwarded` package so it reports zero:

- **S2589** (`ForwardedResolverConfig.parseAllowlist`): the `commaSeparated == null` check was flagged "always false" because the `@NullMarked` package makes the parameter implicitly non-null — yet the method genuinely accepts null (per its Javadoc). Annotating the parameter `@Nullable` makes the nullable contract explicit and the null-check legitimate.
- **S3398** (`RfcForwardedParser`): `unquote` is only used by the inner `Accumulator`, so it is moved into that class.

No behavior change; existing tests unaffected.