### PR TITLE
refactor: suppress S3776 on CharacterValidationStage.isCharacterAllowed

### DIFF
--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
@@ -282,6 +282,10 @@ public final class CharacterValidationStage implements HttpSecurityValidator {
     /**
      * Checks if a character is allowed based on configuration flags and character sets.
      */
+    // S3776: cognitive complexity is 16 vs the 15 limit — the sequential per-character-class
+    // guards (null byte, control chars incl. the unconditional CR/LF header rejection, extended
+    // ASCII, Unicode) are each simple and clearer inline than split across helpers.
+    @SuppressWarnings("java:S3776")
     private boolean isCharacterAllowed(char ch) {
         // Null byte (0) - should be allowed if configured (already checked earlier but may reach here)
         if (ch == 0) {


### PR DESCRIPTION
Suppresses the lone open SonarCloud finding on `main`: `java:S3776` (cognitive complexity 16 vs the 15 limit — one over) on `CharacterValidationStage.isCharacterAllowed`.

The method is a flat sequence of per-character-class guards (null byte, control chars including the unconditional CR/LF header rejection, extended ASCII, Unicode). Each branch is trivial and reads more clearly inline than fragmented across helper methods, so it's suppressed with a justifying comment rather than split.

No behavior change; existing `CharacterValidationStageTest` (27 tests) passes.