### PR TITLE
chore: initialize plan-marshall project configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,11 @@
 .factorypath
 
 # Planning system (managed by /marshall-steward)
+# Runtime state (plans, run-configuration, lessons-learned, memory, logs — managed by plan-marshall)
 .plan/*
 !.plan/marshal.json
-!.plan/project-structure.json
 !.plan/project-architecture/
+!.plan/plugin-doctor.yml
+.plan/local/worktrees/
+!.plan/project-structure.json
+

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -1,0 +1,216 @@
+{
+  "extension_defaults": {
+    "build.maven.profiles.map.canonical": "quick:benchmark"
+  },
+  "plan": {
+    "effort": "level-3",
+    "open_in_ide": true,
+    "coverage": {
+      "thoroughness": "inherit",
+      "scope": "inherit"
+    },
+    "finding_raw_input_max_bytes": 65536,
+    "phase-1-init": {
+      "branch_strategy": "feature",
+      "use_worktree": true,
+      "init_without_asking": true,
+      "deep_lane": "auto",
+      "escalation": "auto",
+      "auto_route_recipe": true,
+      "auto_route_recipe_threshold": 0.6,
+      "lane_selection": "ask",
+      "lane_prune_thresholds": {
+        "confidence_complete": 95,
+        "linear_change_max_deliverables": 1
+      }
+    },
+    "phase-2-refine": {
+      "confidence_threshold": 95,
+      "compatibility": "breaking",
+      "simplicity": "lean",
+      "effort": "level-3",
+      "revalidation": "auto"
+    },
+    "phase-3-outline": {
+      "plan_without_asking": false,
+      "q_gate_validation": "once",
+      "effort": "level-4"
+    },
+    "phase-4-plan": {
+      "execute_without_asking": true,
+      "q_gate_validation": "once",
+      "effort": "level-3"
+    },
+    "phase-5-execute": {
+      "commit_and_push": true,
+      "max_iterations": 5,
+      "per_deliverable_build": [
+        "default:verify:compile",
+        "default:verify:module-tests"
+      ],
+      "cost_size_token_table": {
+        "XS": "5K",
+        "S": "25K",
+        "M": "60K",
+        "L": "130K",
+        "XL": "260K",
+        "XXL": "520K"
+      },
+      "per_envelope_budget_tokens": "400K",
+      "verification_steps": {
+        "default:verify:quality-gate": {},
+        "default:verify:module-tests": {}
+      },
+      "effort": {
+        "default": "level-4",
+        "verification-feedback": "level-3"
+      }
+    },
+    "phase-6-finalize": {
+      "max_iterations": 3,
+      "finalize_without_asking": true,
+      "loop_back_without_asking": false,
+      "qgate": "auto",
+      "checks_wait_timeout_seconds": 600,
+      "steps": {
+        "default:finalize-step-sync-baseline": {
+          "auto_rebase_threshold": "no_overlap_only"
+        },
+        "default:pre-push-quality-gate": {},
+        "default:finalize-step-simplify": {
+          "simplify": "auto"
+        },
+        "default:push": {},
+        "default:create-pr": {},
+        "default:ci-verify": {},
+        "default:automated-review": {
+          "review_bot_buffer_seconds": 180,
+          "re_review_on_loopback": false,
+          "re_review_on_branch_cleanup": true,
+          "re_review_await_timeout_seconds": 600,
+          "re_review_on_timeout": "ask",
+          "review_rate_window_await": false,
+          "review_rate_window_timeout_seconds": 3600
+        },
+        "default:sonar-roundtrip": {
+          "touched_file_cleanup": "new_code_only",
+          "do_transition": false,
+          "ce_wait_timeout_seconds": 600
+        },
+        "default:lessons-capture": {},
+        "default:branch-cleanup": {
+          "pr_merge_strategy": "squash",
+          "final_merge_without_asking": false,
+          "auto_rebase_threshold": "no_overlap_only",
+          "merge_queue_wait_budget_seconds": 1800,
+          "merge_hold_window": "full_window_release_at_waits",
+          "merge_hold_budget_seconds": 3600,
+          "use_merge_queue": true,
+          "admin_merge_on_stuck_state": false
+        },
+        "default:record-metrics": {},
+        "default:archive-plan": {}
+      },
+      "effort": {
+        "default": "level-3",
+        "verification-feedback": "level-3",
+        "post-run-review": "level-4"
+      }
+    }
+  },
+  "build": {
+    "queue": {
+      "max_slots": 5,
+      "max_retries": 10,
+      "upper_limit_seconds": 600
+    },
+    "map": {
+      "java": [
+        {
+          "glob": "*/src/main/*.java",
+          "role": "production",
+          "build_class": "compile"
+        },
+        {
+          "glob": "*/src/test/*.java",
+          "role": "test",
+          "build_class": "module-tests"
+        },
+        {
+          "glob": "pom.xml",
+          "role": "config",
+          "build_class": "verify"
+        }
+      ]
+    }
+  },
+  "project": {
+    "default_base_branch": "main",
+    "working_prefixes": [
+      "feature/",
+      "fix/",
+      "chore/"
+    ]
+  },
+  "providers": [
+    {
+      "skill_name": "plan-marshall:workflow-integration-sonar",
+      "category": "other",
+      "description": "SonarCloud/SonarQube code analysis platform",
+      "url": "https://sonarcloud.io"
+    },
+    {
+      "skill_name": "plan-marshall:workflow-integration-github",
+      "category": "ci",
+      "verify_command": "gh auth status",
+      "description": "GitHub CI provider via gh CLI — PRs, issues, CI status, reviews",
+      "url": "https://api.github.com"
+    },
+    {
+      "skill_name": "plan-marshall:workflow-integration-git",
+      "category": "version-control",
+      "verify_command": "git config user.name",
+      "description": "Git version control via git CLI — commit, push, branch operations",
+      "url": "https://github.com/cuioss/cui-http.git"
+    }
+  ],
+  "skill_domains": {
+    "system": {
+      "defaults": [],
+      "optionals": []
+    },
+    "general-dev": {
+      "bundle": "plan-marshall"
+    },
+    "java": {
+      "bundle": "pm-dev-java",
+      "workflow_skill_extensions": {
+        "triage": "pm-dev-java:ext-triage-java"
+      }
+    },
+    "java-cui": {
+      "bundle": "pm-dev-java-cui"
+    },
+    "documentation": {
+      "bundle": "pm-documents",
+      "workflow_skill_extensions": {
+        "triage": "pm-documents:ext-triage-docs"
+      }
+    },
+    "active_profiles": [
+      "implementation",
+      "module_testing",
+      "quality"
+    ]
+  },
+  "system": {
+    "retention": {
+      "logs_days": 1,
+      "archived_plans_days": 5,
+      "lessons_superseded_days": 0,
+      "temp_on_maintenance": true
+    },
+    "provisioned_version": "0.1.1082",
+    "config_seed_fingerprint": "0acf5eb5"
+  }
+}

--- a/.plan/project-architecture/_project.json
+++ b/.plan/project-architecture/_project.json
@@ -1,0 +1,15 @@
+{
+  "description": "Security-focused HTTP utilities library providing validation pipelines with comprehensive attack pattern detection, SSL/TLS context management, resilient HTTP client handlers/adapters, and RFC 7239 forwarded-header resolution.",
+  "description_reasoning": "source: README.adoc 'What is it?' section plus root pom description",
+  "extensions_used": [
+    "plan-marshall",
+    "pm-documents"
+  ],
+  "modules": {
+    "cui-http": {},
+    "cui-http-benchmarking": {},
+    "cui-http-parent": {},
+    "documentation": {}
+  },
+  "name": "cui-http"
+}

--- a/.plan/project-architecture/cui-http-benchmarking/enriched.json
+++ b/.plan/project-architecture/cui-http-benchmarking/enriched.json
@@ -1,0 +1,109 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [
+    "cui-http"
+  ],
+  "key_dependencies": [
+    "org.openjdk.jmh:jmh-core"
+  ],
+  "key_dependencies_reasoning": "JMH is the benchmark harness; benchmarks exercise the cui-http validation pipelines and forwarded resolver",
+  "key_packages": {
+    "de.cuioss.http.forwarded.benchmark": {
+      "description": "JMH benchmarks for the forwarded-header resolver."
+    },
+    "de.cuioss.http.security.benchmark": {
+      "description": "JMH benchmarks for pipeline latency/throughput and per-stage validation cost."
+    }
+  },
+  "purpose": "benchmark",
+  "purpose_reasoning": "JMH benchmark classes only",
+  "responsibility": "JMH micro-benchmarks measuring latency and throughput of the security validation pipelines and the forwarded-header resolver; results feed the GitHub Pages benchmark dashboard via benchmark-pages.py.",
+  "responsibility_reasoning": "source: pom description 'JMH micro-benchmarks' and benchmark package contents",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging",
+        "pm-dev-java-cui:cui-http",
+        "pm-dev-java:java-null-safety",
+        "pm-dev-java:java-lombok",
+        "pm-dev-java:java-maintenance"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging",
+        "pm-dev-java-cui:cui-testing",
+        "pm-dev-java-cui:cui-http-testing",
+        "pm-dev-java:java-null-safety",
+        "pm-dev-java:java-lombok"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging",
+        "pm-dev-java:java-null-safety",
+        "pm-dev-java:java-lombok"
+      ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "Java library using Lombok and JSpecify; user-selected optionals java-null-safety, java-lombok, java-maintenance; Quarkus/CDI/Weld optionals excluded (plain Java library, no CDI runtime)",
+  "tips": []
+}

--- a/.plan/project-architecture/cui-http-parent/enriched.json
+++ b/.plan/project-architecture/cui-http-parent/enriched.json
@@ -1,0 +1,98 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "parent",
+  "purpose_reasoning": "packaging=pom at root",
+  "responsibility": "Maven aggregator and parent POM for the CUI HTTP library. Centralizes dependency management, plugin configuration, and build profiles (pre-commit quality gate, coverage, benchmark) for the core and benchmarking modules.",
+  "responsibility_reasoning": "packaging=pom at repo root, aggregates cui-http-core and cui-http-benchmarking",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging",
+        "pm-dev-java-cui:cui-http",
+        "pm-dev-java:java-null-safety",
+        "pm-dev-java:java-lombok",
+        "pm-dev-java:java-maintenance"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging",
+        "pm-dev-java-cui:cui-testing",
+        "pm-dev-java-cui:cui-http-testing",
+        "pm-dev-java:java-null-safety",
+        "pm-dev-java:java-lombok"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging",
+        "pm-dev-java:java-null-safety",
+        "pm-dev-java:java-lombok"
+      ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "Java library using Lombok and JSpecify; user-selected optionals java-null-safety, java-lombok, java-maintenance; Quarkus/CDI/Weld optionals excluded (plain Java library, no CDI runtime)",
+  "tips": []
+}

--- a/.plan/project-architecture/cui-http/enriched.json
+++ b/.plan/project-architecture/cui-http/enriched.json
@@ -1,0 +1,115 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [
+    "de.cuioss:cui-java-tools",
+    "org.projectlombok:lombok",
+    "org.jspecify:jspecify"
+  ],
+  "key_dependencies_reasoning": "cui-java-tools supplies CuiLogger and core utilities; Lombok generates builders/values; JSpecify provides null-safety annotations mandated by CUI standards",
+  "key_packages": {
+    "de.cuioss.http.client.adapter": {
+      "description": "Async HTTP adapters layering ETag-aware caching and resilient retry (RetryConfig) over HttpHandler; HttpResult-based error handling."
+    },
+    "de.cuioss.http.forwarded": {
+      "description": "RFC 7239 Forwarded and X-Forwarded-* header resolution with trusted-proxy CIDR matching and configurable sanitization (ForwardedHeaderResolver, ForwardedResolverConfig, RfcForwardedParser)."
+    },
+    "de.cuioss.http.security.pipeline": {
+      "description": "Composed validation pipelines per HTTP component type (URL path, parameters, headers, cookies, body) built via PipelineFactory; the primary public entry point for security validation."
+    },
+    "de.cuioss.http.security.validation": {
+      "description": "Individual validation stages (decoding, normalization, character/length validation, pattern matching, allow/block lists) chained by the pipelines; each implements HttpSecurityValidator."
+    }
+  },
+  "purpose": "library",
+  "purpose_reasoning": "packaging=jar, no runtime entry point, published to Maven Central",
+  "responsibility": "The library core (artifactId cui-http, directory cui-http-core): security validation pipelines for HTTP components (paths, parameters, headers, bodies, cookies) with attack-pattern detection, RFC 7239 forwarded-header resolution, and HTTP client infrastructure (HttpHandler, SSL/TLS context provider, HttpResult error handling, resilient/ETag-aware adapters, content converters).",
+  "responsibility_reasoning": "source: package-info files and CLAUDE.md architecture section; packages de.cuioss.http.security.*, .forwarded, .client.*",
+  "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        "pm-dev-java-cui:cui-logging",
+        "pm-dev-java-cui:cui-http",
+        "pm-dev-java:java-null-safety",
+        "pm-dev-java:java-lombok",
+        "pm-dev-java:java-maintenance"
+      ]
+    },
+    "module_testing": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality principles (SRP, CQS, complexity, error handling)",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Language-agnostic testing methodology (AAA, coverage, reliability, determinism)",
+          "skill": "plan-marshall:persona-module-tester"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JUnit 5 testing patterns with AAA structure, coverage analysis, and assertion standards",
+          "skill": "pm-dev-java:junit-core"
+        },
+        "pm-dev-java-cui:cui-logging",
+        "pm-dev-java-cui:cui-testing",
+        "pm-dev-java-cui:cui-http-testing",
+        "pm-dev-java:java-null-safety",
+        "pm-dev-java:java-lombok"
+      ]
+    },
+    "quality": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "Language-agnostic code quality, refactoring, and documentation principles",
+          "skill": "plan-marshall:ref-code-quality"
+        },
+        {
+          "description": "Core Java patterns including modern features and performance optimization",
+          "skill": "pm-dev-java:java-core"
+        },
+        {
+          "description": "JavaDoc documentation standards including class, method, and code example patterns",
+          "skill": "pm-dev-java:javadoc"
+        },
+        "pm-dev-java-cui:cui-logging",
+        "pm-dev-java:java-null-safety",
+        "pm-dev-java:java-lombok"
+      ]
+    },
+    "security": {
+      "defaults": [
+        "pm-dev-java-cui:cui-logging",
+        {
+          "description": "CUI HTTP request-sanitization security surface",
+          "skill": "pm-dev-java-cui:cui-http"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "Java library using Lombok and JSpecify; user-selected optionals java-null-safety, java-lombok, java-maintenance; Quarkus/CDI/Weld optionals excluded (plain Java library, no CDI runtime)",
+  "tips": []
+}

--- a/.plan/project-architecture/documentation/enriched.json
+++ b/.plan/project-architecture/documentation/enriched.json
@@ -1,0 +1,36 @@
+{
+  "best_practices": [],
+  "insights": [],
+  "internal_dependencies": [],
+  "key_dependencies": [],
+  "key_dependencies_reasoning": "",
+  "key_packages": {},
+  "purpose": "documentation",
+  "purpose_reasoning": "documentation build system, no source files",
+  "responsibility": "AsciiDoc project documentation under doc/, primarily the HTTP security specification (pipeline architecture standards, attack databases, forwarded/reverse-proxy header resolution guide).",
+  "responsibility_reasoning": "doc/ tree with http-security README and specification files",
+  "skills_by_profile": {
+    "documentation": {
+      "defaults": [
+        {
+          "description": "AsciiDoc formatting, validation, link verification, and template creation",
+          "skill": "pm-documents:ref-asciidoc"
+        },
+        {
+          "description": "Content quality, tone analysis, organization standards, and review orchestration",
+          "skill": "pm-documents:ref-documentation"
+        },
+        {
+          "description": "Narrative styles for technical documentation \u2014 tone, voice, and arc for the engineering-narrative style",
+          "skill": "pm-documents:ref-narrative-styles"
+        },
+        {
+          "description": "SVG diagram authoring standards \u2014 visual language, theme handling, AsciiDoc embedding, per-diagram-type patterns",
+          "skill": "pm-documents:ref-svg-diagrams"
+        }
+      ]
+    }
+  },
+  "skills_by_profile_reasoning": "documentation: AsciiDoc doc/ tree with http-security specification",
+  "tips": []
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,33 +18,18 @@ cui-http/                         (root, packaging=pom, artifactId=cui-http-pare
 └── .github/workflows/benchmark.yml
 ```
 
-## Build Commands
+### Build Commands
 
-```bash
-# Build and install locally (all modules)
-./mvnw clean install
+Never hard-code build tool commands (`./mvnw`, `mvn`) — invoke builds via the canonical executor commands below:
 
-# Run tests (core module only)
-./mvnw test -pl cui-http-core
+- Compile: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "compile"`
+- Quality gate: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Ppre-commit"`
+- Full verify: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify"`
+- Coverage: `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pcoverage"`
+- Tests (cui-http): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "test -pl cui-http-core -am"` — only on cui-http
+- Benchmark (cui-http-benchmarking): `python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Pquick -pl cui-http-benchmarking -am"` — only on cui-http-benchmarking
 
-# Run specific test
-./mvnw test -pl cui-http-core -Dtest=ClassName#methodName
-
-# Run pre-commit checks (MANDATORY before commits)
-./mvnw -Ppre-commit clean verify
-
-# Generate coverage report
-./mvnw -Pcoverage clean verify
-
-# Build with skipping tests
-./mvnw clean install -DskipTests
-
-# Run benchmarks (quick profile for local testing)
-./mvnw verify -pl cui-http-benchmarking -am -Pbenchmark -Pquick
-
-# Run benchmarks (full)
-./mvnw verify -pl cui-http-benchmarking -am -Pbenchmark
-```
+Use a 10-minute Bash timeout (600000ms) for build invocations. Analyze each build's TOON result: `status`, `errors[N]{file,line,message,category}`, `log_file`.
 
 ## Git Workflow
 
@@ -176,3 +161,8 @@ All cuioss repositories have branch protection on `main`. Direct pushes to `main
    - Every comment MUST get a reply (reason for fix or reason for not fixing) and MUST be resolved
 7. Do **NOT** enable auto-merge unless explicitly instructed. Wait for user approval.
 8. Return to main: `git checkout main && git pull`
+
+## Tool Usage
+
+- Use proper tools (Edit, Read, Write) instead of shell commands (echo, cat)
+- Never use Bash for file operations (find, grep, cat, ls) — use Glob, Read, Grep tools instead


### PR DESCRIPTION
Initializes the plan-marshall planning system for this repository via the /marshall-steward first-run wizard:

- `.plan/marshal.json` — skill domains (general-dev, java, java-cui, documentation), seeded build map, verification steps (quality-gate, module-tests), full finalize-step preset, review gates, merge-queue opt-in
- `.plan/project-architecture/` — discovered and enriched architecture data for cui-http, cui-http-benchmarking, cui-http-parent, and documentation
- `CLAUDE.md` — hand-written build commands replaced with canonical executor commands
- `.gitignore` — managed block extended for `.plan/` runtime state