### PR TITLE
chore: set use_merge_queue=false after merge-queue ruleset removal

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -105,7 +105,7 @@
           "merge_queue_wait_budget_seconds": 1800,
           "merge_hold_window": "full_window_release_at_waits",
           "merge_hold_budget_seconds": 3600,
-          "use_merge_queue": true,
+          "use_merge_queue": false,
           "admin_merge_on_stuck_state": false
         },
         "default:record-metrics": {},


### PR DESCRIPTION
Follow-up to #95: the `plan-marshall-merge-queue` ruleset was removed because GitHub merge groups are currently broken, so the `use_merge_queue` param on the `default:branch-cleanup` finalize step must be turned off until the queue is re-enabled.