### PR TITLE
chore(release): prepare release 2.1.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,8 +2,8 @@ name: cui-http
 description: CUI HTTP client utilities
 
 release:
-  current-version: 2.0.0
-  next-version: 2.1-SNAPSHOT
+  current-version: 2.1.0
+  next-version: 2.2-SNAPSHOT
   create-github-release: true
 
 maven-build:


### PR DESCRIPTION
Bump current-version to 2.1.0, next-version to 2.2-SNAPSHOT. Triggers the automated Release workflow on merge.