### PR TITLE
chore(release-skill): apply skip-bot-review label on release PR

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -96,10 +96,14 @@ benchmarks) are all dynamic endpoints — there is **no** per-release badge to h
 git add .github/project.yml
 git commit -m "chore(release): prepare release <version>"
 git push -u origin chore/release_<version>
+gh label create skip-bot-review --repo cuioss/cui-http --description "Skip automated bot review" --color ededed 2>/dev/null || true
 gh pr create --repo cuioss/cui-http --base main \
   --title "chore(release): prepare release <version>" \
+  --label "skip-bot-review" \
   --body "Bump current-version to <version>, next-version to <next>-SNAPSHOT. Triggers the automated Release workflow on merge."
 ```
+
+The mechanical release PR carries the `skip-bot-review` label to skip automated bot review.
 
 Use the project commit convention: `Co-Authored-By: Claude <noreply@anthropic.com>` (no
 model name / no "Generated with Claude Code" footer).


### PR DESCRIPTION
Match the other cuioss release skills: apply the skip-bot-review label on the mechanical release PR to skip automated bot review. No merge-step change (this repo has no merge queue).