### PR TITLE
ci: trigger maven build on merge_group (merge-queue prerequisite)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,6 +3,9 @@
 name: Maven Build
 
 on:
+  # Required so the 'build / conclusion' status check runs on the merge-queue
+  # branch; without it, queued PRs stay CLEAN but never merge (queue times out).
+  merge_group:
   push:
     branches: [main, "feature/*", "fix/*", "chore/*", "release/*", "dependabot/**"]
   pull_request:


### PR DESCRIPTION
Prerequisite for enabling a merge queue on `main`. **This must land before the queue is turned on.**

## Why

`cui-http` has no merge queue today (`mergeQueue: null`); `cuioss-parent-pom` does. Comparing the two turned up a hard ordering constraint.

The ruleset `main-branch-protection` requires exactly one status check:

```
build / conclusion
```

That check is produced by `maven.yml`. A merge queue does not build the PR ref — it builds a candidate on `refs/heads/gh-readonly-queue/main/...` and dispatches the **`merge_group`** event. `maven.yml` currently triggers only on `push`, `pull_request` and `workflow_dispatch`.

So if the queue were enabled first:

1. GitHub creates the queue entry and its `gh-readonly-queue/**` ref
2. No workflow listens for `merge_group`, so nothing runs
3. `build / conclusion` never reports
4. The entry is ejected on `check_response_timeout_minutes`

Net effect: **nothing can merge into `main`.** Enabling the queue before this trigger exists would brick merging on the repository.

## The fix

One trigger, matching `cuioss-parent-pom`'s `maven.yml` exactly — comment included, since it already documents this trap upstream:

```yaml
on:
  # Required so the 'build / conclusion' status check runs on the merge-queue
  # branch; without it, queued PRs stay CLEAN but never merge (queue times out).
  merge_group:
```

Both repos share the same reusable workflow and the same required check name, so no other change is needed.

## Effect on its own

None on current behaviour — `merge_group` events are only dispatched by a merge queue, and there isn't one yet. This is inert until the ruleset is created, which is the deliberate ordering.

## Next step (after this merges)

Create a `main-merge-queue` ruleset mirroring `cuioss-parent-pom`'s (ruleset `19167390`): SQUASH, ALLGREEN, 60-minute check timeout, 1–5 entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132ErRU3iuypMncd9FidWu7