### PR TITLE
fix: allow AskUserQuestion in the release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -2,7 +2,7 @@
 name: release
 description: Cut a cui-http release — bump .github/project.yml version, open and merge the release PR, wait for the automated Release workflow, verify the release landed, then reformat the generated GitHub release notes
 user-invocable: true
-allowed-tools: Bash, Read, Edit
+allowed-tools: Bash, Read, Edit, AskUserQuestion
 ---
 
 # Release Skill


### PR DESCRIPTION
## Problem

Das Release-Skill weist den Agenten an, `AskUserQuestion` zu nutzen, wenn die Release-Version mehrdeutig ist — aber `allowed-tools` listete nur `Bash, Read, Edit`.

Damit konnte es ausgerechnet am riskantesten Schritt — der Wahl der Versionsnummer — genau das nicht tun, worauf es selbst besteht. Es hätte raten oder blockieren müssen.

## Fix

```diff
-allowed-tools: Bash, Read, Edit
+allowed-tools: Bash, Read, Edit, AskUserQuestion
```

## Herkunft

Gefunden durch Review auf cuioss/cui-test-juli-logger#123, wo dasselbe Frontmatter aus diesen Skills übernommen worden war. Ein Audit über alle Repos mit Release-Skill zeigte **sechs betroffene**; alle werden identisch korrigiert.

Reine Dokumentationsänderung — keine Build- oder Quellcode-Auswirkung.