### PR TITLE
chore(steward): reconcile marshal.json to plan-marshall 0.1.1551

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -271,7 +271,7 @@
       "plugin_cache_keep_versions": 5,
       "plugin_cache_keep_days": 3
     },
-    "provisioned_version": "0.1.1545",
+    "provisioned_version": "0.1.1551",
     "config_seed_fingerprint": "58fc3cfc"
   }
 }


### PR DESCRIPTION
## Summary

Post-upgrade steward reconciliation (`/marshall-steward upgrade`), consumer project kind.

- Regenerated `.plan/execute-script.py` against plugin cache `0.1.1551` (153 scripts, 109 surfaces derived)
- Reconciled `marshal.json`: `sync-defaults` (no additions), `steps-sort` (already ordered), `normalize-keys`
- Pruned 21 superseded plugin-cache version dirs (`0.1.1522`, `0.1.1527` across 11 bundles)
- `build.map` verified in sync with the live-tree derivation — no re-seed needed

The only tracked change is the `system.provisioned_version` stamp: `0.1.1545` → `0.1.1551`.

## Verification

`generate_executor preflight` reports `executor_action: fresh`, `marshal_status: fresh`, all three versions at `0.1.1551`.

Labelled `skip-bot-review` — configuration-stamp change only, no reviewable logic.
