### PR TITLE
chore(steward): enable finalize review lanes and fix sonar provider config

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -81,16 +81,16 @@
           "lane": "minimal"
         },
         "default:pre-submission-self-review": {
-          "lane": "off"
+          "lane": "minimal"
         },
         "default:finalize-step-simplify": {
           "lane": "standard"
         },
         "default:finalize-step-security-audit": {
-          "lane": "off"
+          "lane": "full"
         },
         "default:architecture-refresh": {
-          "lane": "off"
+          "lane": "full"
         },
         "plan-marshall:automatic-review": {
           "review_bot_buffer_seconds": 180,
@@ -100,10 +100,11 @@
           "re_review_on_timeout": "ask",
           "review_rate_window_await": false,
           "review_rate_window_timeout_seconds": 3600,
-          "required_bots": "",
-          "optional_bots": "",
+          "required_bots": "coderabbit,pr-agent",
+          "optional_bots": "sourcery",
           "review_completion_poll_timeout_seconds": 600,
-          "lane": "ask"
+          "lane": "standard",
+          "bot_lists_provenance": "answered"
         },
         "default:push": {
           "lane": "minimal"
@@ -118,7 +119,7 @@
           "touched_file_cleanup": "new_code_only",
           "do_transition": false,
           "ce_wait_timeout_seconds": 600,
-          "lane": "ask"
+          "lane": "standard"
         },
         "default:adr-propose": {
           "lane": "off"
@@ -196,6 +197,13 @@
           "build_class": "verify"
         }
       ]
+    }
+  },
+  "credentials_config": {
+    "workflow-integration-sonar": {
+      "url": "https://sonarcloud.io",
+      "organization": "cuioss",
+      "project_key": "cuioss_cui-http"
     }
   },
   "project": {


### PR DESCRIPTION
Plan-marshall configuration only — no production code, no build impact.

## Finalize lanes

Resolves the two adversarial infra steps off `ask` and enables the self-review gate:

| Step | Before | After |
|---|---|---|
| `default:pre-submission-self-review` | `off` | `minimal` |
| `plan-marshall:automatic-review` | `ask` | `standard` |
| `default:sonar-roundtrip` | `ask` | `standard` |
| `default:finalize-step-security-audit` | `off` | `full` |
| `default:architecture-refresh` | `off` | `full` |

`minimal` on the self-review maps to ceremony gate `always` and grants immunity from the `scope_gated_finalize` drop, so it runs on every plan.

## Review-bot participation

Both lists shipped empty (`bot_lists_provenance` was never set), so bot silence gated nothing. Now recorded as `answered`:

- `required_bots`: `coderabbit`, `pr-agent` — silence blocks the merge gate
- `optional_bots`: `sourcery` — silence never gates

## Sonar provider

`credentials_config.workflow-integration-sonar` was absent entirely, so `get_authenticated_client` resolved an empty base URL and `credentials verify` failed with `ValueError: HTTPS required when authentication is configured`. The `https://sonarcloud.io` visible in `list-providers` comes from the separate `providers` array, which that resolver never reads.

Seeded `url`, `organization`, and `project_key` (the latter from `.github/project.yml`). The credential file was not touched — the token was already valid. `credentials verify` now returns `verified: true` against `/api/system/status`.

This matters because `sonar-roundtrip` is now `standard`: the compose-time `unresolved_ask_provider_drop` safety net only covers unresolved `ask` steps, so without this fix the step would have been selected and then failed at dispatch.

## Verification

`verify` green — 5454 tests, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Kjbn1QTrQJcKn4U2bqf5n