### PR TITLE
chore(steward): align use_merge_queue with the repo's actual branch rule

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -131,7 +131,7 @@
           "merge_queue_wait_budget_seconds": 1800,
           "merge_hold_window": "full_window_release_at_waits",
           "merge_hold_budget_seconds": 3600,
-          "use_merge_queue": false,
+          "use_merge_queue": true,
           "admin_merge_on_stuck_state": false,
           "pre_merge_comment_barrier": "fail_into_loopback",
           "lane": "minimal"


### PR DESCRIPTION
One-line plan-marshall config fix. No production code, no build impact.

## Problem

`main` has a merge queue active, but `marshal.json` said it didn't:

```
$ ci repo merge-queue probe
eligibility: eligible_configured
detail: merge_queue rule active on branch
merge_method: SQUASH
externally_managed: true
```

vs. `plan.phase-6-finalize.steps["default:branch-cleanup"].use_merge_queue: false`

A plan-driven `phase-6-finalize` would have taken the non-queue merge path and stalled on a branch that only the queue can land.

## Evidence

Surfaced while merging #150 manually — both symptoms of the queue the config denied:

- `gh pr merge --squash` → `! The merge strategy for main is set by the merge queue` (PR stayed `OPEN`, though it had in fact been enqueued)
- `gh pr merge --delete-branch` → `X Cannot use -d or --delete-branch when merge queue enabled`

## Change

`use_merge_queue: false` → `true`.

`pr_merge_strategy` is already `squash`, matching the queue's `SQUASH` method, so no other knob needed changing. `merge_queue_wait_budget_seconds` stays at 1800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Kjbn1QTrQJcKn4U2bqf5n