### PR TITLE
fix(security): enforce RFC 7230 header-name tokens and content-type allow-list

### DIFF
--- a/.plan/project-architecture/_project.json
+++ b/.plan/project-architecture/_project.json
@@ -6,10 +6,22 @@
     "pm-documents"
   ],
   "modules": {
-    "cui-http": {},
-    "cui-http-benchmarking": {},
-    "cui-http-parent": {},
-    "documentation": {}
+    "cui-http": {
+      "description": "The library core (artifactId cui-http, directory cui-http-core): security validation pipelines for HTTP components (paths, parameters, headers, bodies, cookies) with attack-pattern detection, RFC 7239 forwarded-header resolution, and HTTP client infrastructure (HttpHandler, SSL/TLS context provider, HttpResult error handling, resilient/ETag-aware adapters, content converters).",
+      "generation": {}
+    },
+    "cui-http-benchmarking": {
+      "description": "JMH micro-benchmarks measuring latency and throughput of the security validation pipelines and the forwarded-header resolver; results feed the GitHub Pages benchmark dashboard via benchmark-pages.py.",
+      "generation": {}
+    },
+    "cui-http-parent": {
+      "description": "Maven aggregator and parent POM for the CUI HTTP library. Centralizes dependency management, plugin configuration, and build profiles (pre-commit quality gate, coverage, benchmark) for the core and benchmarking modules.",
+      "generation": {}
+    },
+    "documentation": {
+      "description": "AsciiDoc project documentation under doc/, primarily the HTTP security specification (pipeline architecture standards, attack databases, forwarded/reverse-proxy header resolution guide).",
+      "generation": {}
+    }
   },
   "name": "cui-http"
 }

--- a/.plan/project-architecture/cui-http-benchmarking/enriched.json
+++ b/.plan/project-architecture/cui-http-benchmarking/enriched.json
@@ -105,5 +105,6 @@
     }
   },
   "skills_by_profile_reasoning": "Java library using Lombok and JSpecify; user-selected optionals java-null-safety, java-lombok, java-maintenance; Quarkus/CDI/Weld optionals excluded (plain Java library, no CDI runtime)",
-  "tips": []
+  "tips": [],
+  "type": "module"
 }

--- a/.plan/project-architecture/cui-http-parent/enriched.json
+++ b/.plan/project-architecture/cui-http-parent/enriched.json
@@ -94,5 +94,6 @@
     }
   },
   "skills_by_profile_reasoning": "Java library using Lombok and JSpecify; user-selected optionals java-null-safety, java-lombok, java-maintenance; Quarkus/CDI/Weld optionals excluded (plain Java library, no CDI runtime)",
-  "tips": []
+  "tips": [],
+  "type": "module"
 }

--- a/.plan/project-architecture/cui-http/enriched.json
+++ b/.plan/project-architecture/cui-http/enriched.json
@@ -111,5 +111,6 @@
     }
   },
   "skills_by_profile_reasoning": "Java library using Lombok and JSpecify; user-selected optionals java-null-safety, java-lombok, java-maintenance; Quarkus/CDI/Weld optionals excluded (plain Java library, no CDI runtime)",
-  "tips": []
+  "tips": [],
+  "type": "module"
 }

--- a/.plan/project-architecture/documentation/enriched.json
+++ b/.plan/project-architecture/documentation/enriched.json
@@ -10,6 +10,30 @@
   "responsibility": "AsciiDoc project documentation under doc/, primarily the HTTP security specification (pipeline architecture standards, attack databases, forwarded/reverse-proxy header resolution guide).",
   "responsibility_reasoning": "doc/ tree with http-security README and specification files",
   "skills_by_profile": {
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "AsciiDoc formatting, validation, link verification, and template creation",
+          "skill": "pm-documents:ref-asciidoc"
+        },
+        {
+          "description": "Content quality, tone analysis, organization standards, and review orchestration",
+          "skill": "pm-documents:ref-documentation"
+        },
+        {
+          "description": "Narrative styles for technical documentation — tone, voice, and arc for the engineering-narrative style",
+          "skill": "pm-documents:ref-narrative-styles"
+        },
+        {
+          "description": "SVG diagram authoring standards — visual language, theme handling, AsciiDoc embedding, per-diagram-type patterns",
+          "skill": "pm-documents:ref-svg-diagrams"
+        }
+      ]
+    },
     "documentation": {
       "defaults": [
         {
@@ -31,6 +55,6 @@
       ]
     }
   },
-  "skills_by_profile_reasoning": "documentation: AsciiDoc doc/ tree with http-security specification",
+  "skills_by_profile_reasoning": "documentation: AsciiDoc doc/ tree with http-security specification. implementation: mirrors the documentation profile (plus the foundational agent rules) because plan-marshall's active_profiles are implementation/module_testing/quality — a task that edits doc/ resolves the implementation profile, so leaving that key undeclared forced a persona-augmentation fallback instead of a declared skill set.",
   "tips": []
 }

--- a/.plan/project-architecture/documentation/enriched.json
+++ b/.plan/project-architecture/documentation/enriched.json
@@ -10,30 +10,6 @@
   "responsibility": "AsciiDoc project documentation under doc/, primarily the HTTP security specification (pipeline architecture standards, attack databases, forwarded/reverse-proxy header resolution guide).",
   "responsibility_reasoning": "doc/ tree with http-security README and specification files",
   "skills_by_profile": {
-    "implementation": {
-      "defaults": [
-        {
-          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
-          "skill": "plan-marshall:persona-plan-marshall-agent"
-        },
-        {
-          "description": "AsciiDoc formatting, validation, link verification, and template creation",
-          "skill": "pm-documents:ref-asciidoc"
-        },
-        {
-          "description": "Content quality, tone analysis, organization standards, and review orchestration",
-          "skill": "pm-documents:ref-documentation"
-        },
-        {
-          "description": "Narrative styles for technical documentation — tone, voice, and arc for the engineering-narrative style",
-          "skill": "pm-documents:ref-narrative-styles"
-        },
-        {
-          "description": "SVG diagram authoring standards — visual language, theme handling, AsciiDoc embedding, per-diagram-type patterns",
-          "skill": "pm-documents:ref-svg-diagrams"
-        }
-      ]
-    },
     "documentation": {
       "defaults": [
         {
@@ -53,8 +29,33 @@
           "skill": "pm-documents:ref-svg-diagrams"
         }
       ]
+    },
+    "implementation": {
+      "defaults": [
+        {
+          "description": "Foundational agent behavior rules (user interaction, tool usage, research, dependency management)",
+          "skill": "plan-marshall:persona-plan-marshall-agent"
+        },
+        {
+          "description": "AsciiDoc formatting, validation, link verification, and template creation",
+          "skill": "pm-documents:ref-asciidoc"
+        },
+        {
+          "description": "Content quality, tone analysis, organization standards, and review orchestration",
+          "skill": "pm-documents:ref-documentation"
+        },
+        {
+          "description": "Narrative styles for technical documentation \u2014 tone, voice, and arc for the engineering-narrative style",
+          "skill": "pm-documents:ref-narrative-styles"
+        },
+        {
+          "description": "SVG diagram authoring standards \u2014 visual language, theme handling, AsciiDoc embedding, per-diagram-type patterns",
+          "skill": "pm-documents:ref-svg-diagrams"
+        }
+      ]
     }
   },
-  "skills_by_profile_reasoning": "documentation: AsciiDoc doc/ tree with http-security specification. implementation: mirrors the documentation profile (plus the foundational agent rules) because plan-marshall's active_profiles are implementation/module_testing/quality — a task that edits doc/ resolves the implementation profile, so leaving that key undeclared forced a persona-augmentation fallback instead of a declared skill set.",
-  "tips": []
+  "skills_by_profile_reasoning": "documentation: AsciiDoc doc/ tree with http-security specification. implementation: mirrors the documentation profile (plus the foundational agent rules) because plan-marshall's active_profiles are implementation/module_testing/quality \u2014 a task that edits doc/ resolves the implementation profile, so leaving that key undeclared forced a persona-augmentation fallback instead of a declared skill set.",
+  "tips": [],
+  "type": "module"
 }

--- a/cui-http-benchmarking/src/main/java/de/cuioss/http/forwarded/benchmark/ForwardedBenchmarkState.java
+++ b/cui-http-benchmarking/src/main/java/de/cuioss/http/forwarded/benchmark/ForwardedBenchmarkState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-benchmarking/src/main/java/de/cuioss/http/forwarded/benchmark/ForwardedResolverBenchmark.java
+++ b/cui-http-benchmarking/src/main/java/de/cuioss/http/forwarded/benchmark/ForwardedResolverBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-benchmarking/src/main/java/de/cuioss/http/security/benchmark/SecurityBenchmarkRunner.java
+++ b/cui-http-benchmarking/src/main/java/de/cuioss/http/security/benchmark/SecurityBenchmarkRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-benchmarking/src/main/java/de/cuioss/http/security/benchmark/SecurityBenchmarkState.java
+++ b/cui-http-benchmarking/src/main/java/de/cuioss/http/security/benchmark/SecurityBenchmarkState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-benchmarking/src/main/java/de/cuioss/http/security/benchmark/standard/PipelineLatencyBenchmark.java
+++ b/cui-http-benchmarking/src/main/java/de/cuioss/http/security/benchmark/standard/PipelineLatencyBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-benchmarking/src/main/java/de/cuioss/http/security/benchmark/standard/PipelineThroughputBenchmark.java
+++ b/cui-http-benchmarking/src/main/java/de/cuioss/http/security/benchmark/standard/PipelineThroughputBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-benchmarking/src/main/java/de/cuioss/http/security/benchmark/standard/ValidationStageBenchmark.java
+++ b/cui-http-benchmarking/src/main/java/de/cuioss/http/security/benchmark/standard/ValidationStageBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/ContentType.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/ContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/HttpLogMessages.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/HttpLogMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/HttpMethod.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/HttpMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/CacheKeyHeaderFilter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/CacheKeyHeaderFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/HttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/HttpAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ResilientHttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ResilientHttpAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/RetryConfig.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/RetryConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/converter/HttpRequestConverter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/converter/HttpRequestConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/converter/HttpResponseConverter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/converter/HttpResponseConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/converter/StringContentConverter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/converter/StringContentConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/converter/VoidResponseConverter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/converter/VoidResponseConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/converter/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/converter/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpStatusFamily.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpStatusFamily.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/SecureSSLContextProvider.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/SecureSSLContextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/result/HttpErrorCategory.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/result/HttpErrorCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/result/HttpResult.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/result/HttpResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/client/result/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/result/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/CidrRange.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/CidrRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ContextPaths.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ContextPaths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderNames.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedLogMessages.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedLogMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedResolverConfig.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedResolverConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/IpAddresses.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/IpAddresses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ResolvedForwarding.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ResolvedForwarding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/RfcForwardedParser.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/RfcForwardedParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityConfigurationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/SecurityDefaults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/config/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/config/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/core/HttpSecurityValidator.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/core/HttpSecurityValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/core/UrlSecurityFailureType.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/core/UrlSecurityFailureType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/core/ValidationType.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/core/ValidationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/core/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/core/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/data/AttributeParser.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/data/AttributeParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/data/Cookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/data/HTTPBody.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/data/HTTPBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/data/URLParameter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/data/URLParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/data/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/data/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/exceptions/UrlSecurityException.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/exceptions/UrlSecurityException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/exceptions/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/exceptions/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/monitoring/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/monitoring/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/AbstractValidationPipeline.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/AbstractValidationPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/ContentTypeValidationPipeline.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/ContentTypeValidationPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/ContentTypeValidationPipeline.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/ContentTypeValidationPipeline.java
@@ -31,11 +31,26 @@ import java.util.Objects;
  * Validation pipeline for HTTP {@code Content-Type} values, enforcing the configured
  * content-type allow/block lists.
  *
- * <p>A content type travels as a header value, so this pipeline reports {@link ValidationType#HEADER_VALUE}.
- * It applies {@link AllowBlockListStage#forContentTypes(SecurityConfiguration)}: a value present in
- * {@code blockedContentTypes} is rejected, and - if {@code allowedContentTypes} is non-empty - any
- * value not in it is rejected (empty allow-list = allow-all). Security violations are recorded on the
- * supplied {@link SecurityEventCounter}, consistent with the other pipelines.</p>
+ * <h3>Scope</h3>
+ * <p><strong>This pipeline performs allow/block-list enforcement ONLY.</strong> It consists of a
+ * single stage: {@link AllowBlockListStage#forContentTypes(SecurityConfiguration)}. It applies
+ * <em>no</em> length limit and <em>no</em> character validation. A caller that also needs those
+ * checks on a {@code Content-Type} value must apply the header-value pipeline
+ * ({@link PipelineFactory#createHeaderValuePipeline(SecurityConfiguration, SecurityEventCounter)})
+ * to that value separately - this pipeline does not do it for them.</p>
+ *
+ * <p>The list check itself: a value present in {@code blockedContentTypes} is rejected, and - if
+ * {@code allowedContentTypes} is non-empty - any value not in it is rejected (empty allow-list =
+ * allow-all). Matching is on the media type only, so parameters such as {@code ; charset=UTF-8}
+ * cannot defeat the lists. Security violations are recorded on the supplied
+ * {@link SecurityEventCounter}, consistent with the other pipelines.</p>
+ *
+ * <h3>Why HEADER_VALUE is the reported type</h3>
+ * <p>A content type travels as a header value and there is no dedicated {@link ValidationType}
+ * constant for it, so {@link ValidationType#HEADER_VALUE} is the type reported in emitted
+ * exceptions and on the event counter. <strong>This reporting choice does not imply the
+ * header-value pipeline's stage set</strong> - as stated under Scope, this pipeline runs the
+ * allow/block-list stage alone.</p>
  *
  * @since 1.0
  */

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java
@@ -22,8 +22,6 @@ import de.cuioss.http.security.monitoring.SecurityEventCounter;
 import de.cuioss.http.security.validation.AllowBlockListStage;
 import de.cuioss.http.security.validation.CharacterValidationStage;
 import de.cuioss.http.security.validation.LengthValidationStage;
-import de.cuioss.http.security.validation.NormalizationStage;
-import de.cuioss.http.security.validation.PatternMatchingStage;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -39,10 +37,6 @@ import java.util.Objects;
  * <ol>
  *   <li><strong>Length Validation</strong> - Enforces maximum header length limits</li>
  *   <li><strong>Character Validation</strong> - Validates RFC 7230 header characters</li>
- *   <li><strong>Normalization</strong> - Pass-through for header values; RFC 3986 dot-segment
- *       resolution only applies to path components, so this stage does not rewrite header data
- *       (traversal-style patterns are caught by Pattern Matching below)</li>
- *   <li><strong>Pattern Matching</strong> - Detects injection attacks and suspicious patterns</li>
  *   <li><strong>Allow/Block List</strong> - (header names only) enforces the configured
  *       {@code allowedHeaderNames}/{@code blockedHeaderNames} lists</li>
  * </ol>
@@ -60,7 +54,8 @@ import java.util.Objects;
  *   <li><strong>Header Injection Prevention</strong> - Detects CRLF injection attempts</li>
  *   <li><strong>RFC 7230 Compliance</strong> - Enforces HTTP header character restrictions</li>
  *   <li><strong>Length Limits</strong> - Prevents header-based DoS attacks</li>
- *   <li><strong>Pattern Detection</strong> - Identifies malicious header values</li>
+ *   <li><strong>Control-Character Rejection</strong> - CR, LF and other control characters are
+ *       rejected by RFC 7230 character validation</li>
  * </ul>
  *
  * <h3>Usage Example</h3>
@@ -118,12 +113,13 @@ public final class HTTPHeaderValidationPipeline extends AbstractValidationPipeli
         Objects.requireNonNull(validationType, "ValidationType must not be null");
 
         // Create validation stages in the correct order for HTTP headers
-        // Note: Headers typically don't need URL decoding, so we skip DecodingStage
+        // Note: Headers typically don't need URL decoding, so we skip DecodingStage.
+        // Normalization and pattern matching are omitted because both are pass-throughs for the
+        // header validation types: dot-segment resolution applies to path components only, and the
+        // pattern databases cover URL_PATH, PARAMETER_NAME and PARAMETER_VALUE only.
         List<HttpSecurityValidator> stages = new ArrayList<>(List.of(
                 new LengthValidationStage(config, validationType),
-                new CharacterValidationStage(config, validationType),
-                new NormalizationStage(config, validationType),
-                new PatternMatchingStage(config, validationType)
+                new CharacterValidationStage(config, validationType)
         ));
         // Header-name allow/block list enforcement (empty lists => no-op, allow-all).
         if (validationType == ValidationType.HEADER_NAME) {

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/PipelineFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLParameterNameValidationPipeline.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLParameterNameValidationPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLParameterNameValidationPipeline.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLParameterNameValidationPipeline.java
@@ -42,8 +42,13 @@ import java.util.Objects;
  *   <li><strong>Character Validation</strong> - Validates RFC 3986 query characters</li>
  *   <li><strong>Decoding</strong> - URL decodes with security checks (name-strict CR/LF and
  *       delimiter rejection on the decoded output)</li>
- *   <li><strong>Normalization</strong> - Normalization and security checks</li>
- *   <li><strong>Pattern Matching</strong> - Detects suspicious parameter names and injection attacks</li>
+ *   <li><strong>Normalization</strong> - Pass-through for {@link ValidationType#PARAMETER_NAME}:
+ *       RFC 3986 dot-segment resolution applies to {@link ValidationType#URL_PATH} only, so this
+ *       stage does not rewrite parameter names. It is retained here solely for stage-order
+ *       symmetry with the parameter-value pipeline; removing it is out of this plan's scope.</li>
+ *   <li><strong>Pattern Matching</strong> - Path-traversal detection is unconditional.
+ *       Suspicious-parameter-name detection fires only when {@code failOnSuspiciousPatterns} is
+ *       enabled, which is <em>not</em> the default.</li>
  * </ol>
  *
  * @since 1.0

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLParameterValidationPipeline.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLParameterValidationPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/URLPathValidationPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/pipeline/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/AllowBlockListStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/AllowBlockListStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/AllowBlockListStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/AllowBlockListStage.java
@@ -42,6 +42,9 @@ import java.util.*;
  *   <li><strong>Empty allow-list = allow-all</strong> - an empty allow-list imposes no restriction
  *       (it does <em>not</em> deny-all); a non-empty allow-list rejects any value not in it.</li>
  *   <li><strong>Case-insensitive</strong> - comparison is done on the lowercased value.</li>
+ *   <li><strong>The empty value is not exempt</strong> - an empty value is evaluated against both
+ *       lists like any other value. A configured non-empty allow-list therefore rejects it, and a
+ *       block-list containing the empty string rejects it too.</li>
  * </ul>
  *
  * <p>Use {@link #forHeaderNames(SecurityConfiguration)} for the header-name lists (wired into the
@@ -131,9 +134,6 @@ public final class AllowBlockListStage implements HttpSecurityValidator {
     public Optional<String> validate(@Nullable String value) throws UrlSecurityException {
         if (value == null) {
             return Optional.empty();
-        }
-        if (value.isEmpty()) {
-            return Optional.of(value);
         }
 
         String lower = comparisonKey(value);

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java
@@ -46,7 +46,8 @@ import java.util.function.IntPredicate;
  *   <li><strong>RFC3986_UNRESERVED</strong> - Basic unreserved characters from RFC 3986</li>
  *   <li><strong>RFC3986_PATH_CHARS</strong> - Characters allowed in URL paths</li>
  *   <li><strong>RFC3986_QUERY_CHARS</strong> - Characters allowed in URL query parameters</li>
- *   <li><strong>RFC7230_HEADER_CHARS</strong> - Characters allowed in HTTP headers</li>
+ *   <li><strong>RFC7230_TOKEN_CHARS</strong> - Characters allowed in HTTP header names (tchar)</li>
+ *   <li><strong>RFC7230_HEADER_CHARS</strong> - Characters allowed in HTTP header field values</li>
  *   <li><strong>HTTP_BODY_CHARS</strong> - Characters allowed in HTTP request/response bodies</li>
  * </ul>
  *
@@ -121,8 +122,21 @@ public final class CharacterValidationConstants {
     public static final IntPredicate RFC3986_QUERY_CHARS;
 
     /**
-     * RFC 7230 header field characters (visible ASCII minus delimiters).
-     * <p>Includes space through tilde (32-126) plus tab character.</p>
+     * RFC 7230 token characters ({@code tchar}), the character set of an HTTP header <em>name</em>.
+     * <p>Per RFC 7230 section 3.2.6: ALPHA, DIGIT and the punctuation
+     * {@code ! # $ % &amp; ' * + - . ^ _ ` | ~}. Notably this set excludes space, colon and every
+     * other delimiter, so a header name containing them is rejected.</p>
+     * <p>This is deliberately narrower than {@link #RFC7230_HEADER_CHARS}, which is the broader
+     * header <em>field-value</em> set.</p>
+     * <p>Immutable membership test; the backing {@link BitSet} is private and cannot be mutated.</p>
+     */
+    public static final IntPredicate RFC7230_TOKEN_CHARS;
+
+    /**
+     * RFC 7230 header field-value characters: visible ASCII plus SP and HTAB.
+     * <p>Includes space through tilde (32-126) plus the tab character. Delimiters such as colon,
+     * comma, semicolon and parentheses are all members — for the narrow, delimiter-free header
+     * <em>name</em> set see {@link #RFC7230_TOKEN_CHARS}.</p>
      * <p>Immutable membership test; the backing {@link BitSet} is private and cannot be mutated.</p>
      */
     public static final IntPredicate RFC7230_HEADER_CHARS;
@@ -170,6 +184,17 @@ public final class CharacterValidationConstants {
         "!$'()*+,;".chars().forEach(queryChars::set);
         RFC3986_QUERY_CHARS = queryChars::get;
 
+        // Initialize RFC7230_TOKEN_CHARS (RFC 7230 section 3.2.6 tchar - header NAME characters)
+        BitSet tokenChars = new BitSet(256);
+        // ALPHA
+        for (int i = 'A'; i <= 'Z'; i++) tokenChars.set(i);
+        for (int i = 'a'; i <= 'z'; i++) tokenChars.set(i);
+        // DIGIT
+        for (int i = '0'; i <= '9'; i++) tokenChars.set(i);
+        // tchar punctuation: "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+        "!#$%&'*+-.^_`|~".chars().forEach(tokenChars::set);
+        RFC7230_TOKEN_CHARS = tokenChars::get;
+
         // Initialize RFC7230_HEADER_CHARS
         BitSet headerChars = new BitSet(256);
         // RFC 7230: For header values, allow most visible ASCII plus space and tab
@@ -215,7 +240,8 @@ public final class CharacterValidationConstants {
      * <ul>
      *   <li>{@code URL_PATH} → {@link #RFC3986_PATH_CHARS}</li>
      *   <li>{@code PARAMETER_NAME, PARAMETER_VALUE} → {@link #RFC3986_QUERY_CHARS}</li>
-     *   <li>{@code HEADER_NAME, HEADER_VALUE} → {@link #RFC7230_HEADER_CHARS}</li>
+     *   <li>{@code HEADER_NAME} → {@link #RFC7230_TOKEN_CHARS}</li>
+     *   <li>{@code HEADER_VALUE} → {@link #RFC7230_HEADER_CHARS}</li>
      *   <li>{@code BODY} → {@link #HTTP_BODY_CHARS}</li>
      *   <li>{@code COOKIE_NAME, COOKIE_VALUE} → {@link #RFC3986_UNRESERVED}</li>
      * </ul>
@@ -226,6 +252,7 @@ public final class CharacterValidationConstants {
      * @see ValidationType
      * @see #RFC3986_PATH_CHARS
      * @see #RFC3986_QUERY_CHARS
+     * @see #RFC7230_TOKEN_CHARS
      * @see #RFC7230_HEADER_CHARS
      * @see #HTTP_BODY_CHARS
      * @see #RFC3986_UNRESERVED
@@ -234,7 +261,8 @@ public final class CharacterValidationConstants {
         return switch (type) {
             case URL_PATH -> RFC3986_PATH_CHARS;
             case PARAMETER_NAME, PARAMETER_VALUE -> RFC3986_QUERY_CHARS;
-            case HEADER_NAME, HEADER_VALUE -> RFC7230_HEADER_CHARS;
+            case HEADER_NAME -> RFC7230_TOKEN_CHARS;
+            case HEADER_VALUE -> RFC7230_HEADER_CHARS;
             case BODY -> HTTP_BODY_CHARS;
             case COOKIE_NAME, COOKIE_VALUE -> RFC3986_UNRESERVED;
         };

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/CookiePrefixValidationStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/LengthValidationStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/LengthValidationStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java
@@ -36,8 +36,11 @@ import java.util.regex.Pattern;
  * and cookie values, and body content) the input is passed through unchanged — it is opaque
  * application data rather than a filesystem path, so resolving {@code ..} segments would
  * silently rewrite caller data and could consume a traversal pattern before downstream
- * pattern matching inspects it. Traversal-style patterns in non-path contexts are handled by
- * {@code PatternMatchingStage}.</p>
+ * pattern matching inspects it. Traversal-style patterns are handled downstream by
+ * {@code PatternMatchingStage} for the <em>parameter</em> types only
+ * ({@link ValidationType#PARAMETER_NAME}, {@link ValidationType#PARAMETER_VALUE}). That redirect
+ * does not hold for the header types: the header pipeline runs neither this stage nor
+ * {@code PatternMatchingStage}, and relies on RFC 7230 character validation instead.</p>
  *
  * <p>For path types, this stage performs RFC 3986 Section 5.2.4 path normalization to resolve
  * relative path segments (. and ..) while detecting and preventing path traversal
@@ -231,8 +234,10 @@ ValidationType validationType) implements HttpSecurityValidator {
         // For non-path validation types (parameter/header/cookie values and bodies) a segment
         // like "a/b/../c" is opaque application data, not a filesystem path: rewriting it to
         // "a/c" would silently alter caller data and could consume a traversal pattern before
-        // PatternMatchingStage inspects it. Non-path inputs therefore pass through unchanged;
-        // traversal-style patterns in those contexts are detected downstream by PatternMatchingStage.
+        // PatternMatchingStage inspects it. Non-path inputs therefore pass through unchanged.
+        // Traversal-style patterns are detected downstream by PatternMatchingStage for the
+        // parameter types only; the header pipeline runs neither this stage nor
+        // PatternMatchingStage and relies on RFC 7230 character validation instead.
         if (!validationType.isPath()) {
             return Optional.of(value);
         }

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java
@@ -43,6 +43,14 @@ import java.util.stream.Collectors;
  *   <li><strong>Parameter Attack Patterns</strong> - Identifies malicious parameter usage</li>
  * </ol>
  *
+ * <h3>Supported Validation Types</h3>
+ * <p>The pattern databases apply to {@link ValidationType#URL_PATH},
+ * {@link ValidationType#PARAMETER_VALUE} and {@link ValidationType#PARAMETER_NAME} only. For every
+ * other validation type - including {@link ValidationType#HEADER_NAME} and
+ * {@link ValidationType#HEADER_VALUE} - this stage is an intentional pass-through: no pattern set
+ * is selected, so the input is returned unchanged. Header components are therefore not covered by
+ * this stage, and the header pipeline does not include it.</p>
+ *
  * <h3>Design Principles</h3>
  * <ul>
  *   <li><strong>Signature-Based Detection</strong> - Uses known attack patterns from OWASP and CVE databases</li>
@@ -186,6 +194,12 @@ ValidationType validationType) implements HttpSecurityValidator {
      *   <li>Pattern matching - tests against known attack signatures</li>
      *   <li>Policy enforcement - applies configured response to pattern matches</li>
      * </ol>
+     *
+     * <p>Pattern selection is driven by the validation type: only {@link ValidationType#URL_PATH},
+     * {@link ValidationType#PARAMETER_VALUE} and {@link ValidationType#PARAMETER_NAME} select a
+     * pattern set. For every other type - including {@link ValidationType#HEADER_NAME} and
+     * {@link ValidationType#HEADER_VALUE} - this method is an intentional pass-through that returns
+     * the input unchanged and never throws.</p>
      *
      * @param value The input string to validate against attack patterns
      * @return The original input wrapped in Optional if validation passes, or Optional.empty() if input was null

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/RequestCollectionValidator.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/RequestCollectionValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/de/cuioss/http/security/validation/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/security/validation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/main/java/module-info.java
+++ b/cui-http-core/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/ContentTypeTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/ContentTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/HttpMethodTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/HttpMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/CacheKeyHeaderFilterTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/CacheKeyHeaderFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/HttpAdapterTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/HttpAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ResilientHttpAdapterIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ResilientHttpAdapterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ResilientHttpAdapterTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ResilientHttpAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/RetryConfigTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/RetryConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/TestApiDispatcher.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/TestApiDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/converter/HttpRequestConverterTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/converter/HttpRequestConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/converter/HttpResponseConverterTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/converter/HttpResponseConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/converter/StringContentConverterTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/converter/StringContentConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/converter/VoidResponseConverterTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/converter/VoidResponseConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/dispatcher/TestContentDispatcher.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/dispatcher/TestContentDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerHostnameVerificationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerHostnameVerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpStatusFamilyTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpStatusFamilyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/SecureSSLContextProviderTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/SecureSSLContextProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/result/HttpErrorCategoryTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/result/HttpErrorCategoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/result/HttpResultFailureGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/result/HttpResultFailureGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/result/HttpResultSuccessGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/result/HttpResultSuccessGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/result/HttpResultTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/result/HttpResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedResolverConfigTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedResolverConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/IpAddressesTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/IpAddressesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ResolvedForwardingTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ResolvedForwardingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/RfcForwardedParserTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/RfcForwardedParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationBuilderTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/core/HttpSecurityValidatorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/core/HttpSecurityValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/core/ValidationTypeTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/core/ValidationTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/data/AttributeParserTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/data/AttributeParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/data/CookieTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/data/CookieTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/data/HTTPBodyTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/data/HTTPBodyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/data/URLParameterTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/data/URLParameterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/ApacheCVEAttackDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/ApacheCVEAttackDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/AttackDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/AttackDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/AttackTestCase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/AttackTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/EdgeCaseValidURLsDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/EdgeCaseValidURLsDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/HomographAttackDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/HomographAttackDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/IDNAttackDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/IDNAttackDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/IISCVEAttackDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/IISCVEAttackDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/IPv6AttackDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/IPv6AttackDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/LegitimatePathPatternsDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/LegitimatePathPatternsDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/LegitimatePatternDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/LegitimatePatternDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/LegitimateSpecialCharactersDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/LegitimateSpecialCharactersDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/LegitimateTestCase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/LegitimateTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/ModSecurityCRSAttackDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/ModSecurityCRSAttackDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/NginxCVEAttackDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/NginxCVEAttackDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/OWASPTop10AttackDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/OWASPTop10AttackDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/OWASPZAPAttackDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/OWASPZAPAttackDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/ProtocolHandlerAttackDatabase.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/ProtocolHandlerAttackDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/database/package-info.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/database/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/exceptions/UrlSecurityExceptionTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/exceptions/UrlSecurityExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/AllGeneratorsIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/AllGeneratorsIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/SupportedValidationTypeGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/SupportedValidationTypeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/SupportedValidationTypeGeneratorContractTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/SupportedValidationTypeGeneratorContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/CookieNameAsciiWhitespaceGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/CookieNameAsciiWhitespaceGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/CookieNameLegacyParsingGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/CookieNameLegacyParsingGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/CookieNameUnicodeWhitespaceGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/CookieNameUnicodeWhitespaceGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/CookieNameZeroWidthGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/CookieNameZeroWidthGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/ValidCookieGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/ValidCookieGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/ValidCookieGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/ValidCookieGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/BoundaryFuzzingGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/BoundaryFuzzingGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/BoundaryFuzzingGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/BoundaryFuzzingGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/DoubleEncodingAttackGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/DoubleEncodingAttackGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/DoubleEncodingAttackGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/DoubleEncodingAttackGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/EncodingCombinationGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/EncodingCombinationGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/EncodingCombinationGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/EncodingCombinationGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/PathTraversalGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/PathTraversalGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/PathTraversalGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/PathTraversalGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeAttackGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeAttackGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeAttackGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeAttackGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeControlCharacterAttackGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeControlCharacterAttackGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeNormalizationAttackGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeNormalizationAttackGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/HTTPHeaderInjectionGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/HTTPHeaderInjectionGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/HTTPHeaderInjectionGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/HTTPHeaderInjectionGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/HttpHeaderInjectionAttackGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/HttpHeaderInjectionAttackGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/InvalidHTTPHeaderNameGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/InvalidHTTPHeaderNameGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/InvalidHTTPHeaderNameGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/InvalidHTTPHeaderNameGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/ValidHTTPHeaderNameGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/ValidHTTPHeaderNameGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/ValidHTTPHeaderNameGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/ValidHTTPHeaderNameGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/ValidHTTPHeaderValueGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/ValidHTTPHeaderValueGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/HttpRequestSmugglingAttackGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/HttpRequestSmugglingAttackGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/HttpRequestSmugglingAttackGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/HttpRequestSmugglingAttackGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/ProtocolHandlerAttackGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/ProtocolHandlerAttackGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/URLLengthLimitAttackGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/URLLengthLimitAttackGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/AttackURLParameterGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/AttackURLParameterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/InvalidURLGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/InvalidURLGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/InvalidURLGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/InvalidURLGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/NullByteInjectionParameterGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/NullByteInjectionParameterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/NullByteURLGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/NullByteURLGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/NullByteURLGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/NullByteURLGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalParameterGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalParameterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalParameterGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalParameterGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalURLGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalURLGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalURLGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalURLGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/URLLengthLimitAttackGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/URLLengthLimitAttackGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLParameterGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLParameterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLParameterGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLParameterGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLParameterStringGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLParameterStringGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLPathGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLPathGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLPathGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLPathGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/ContentTypeValidationPipelineTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/ContentTypeValidationPipelineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/ContentTypeValidationPipelineTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/ContentTypeValidationPipelineTest.java
@@ -189,12 +189,23 @@ class ContentTypeValidationPipelineTest {
         }
 
         @Test
-        @DisplayName("empty input is accepted and returned unchanged")
-        void emptyInput() {
+        @DisplayName("empty input is rejected by a non-empty allow-list, like any other value")
+        void emptyInputRejectedByAllowList() {
             SecurityConfiguration config = SecurityConfiguration.builder()
                     .allowedContentTypes(Set.of("application/json"))
                     .build();
             ContentTypeValidationPipeline pipeline = pipeline(config);
+
+            UrlSecurityException exception = assertThrows(UrlSecurityException.class,
+                    () -> pipeline.validate(""));
+            assertEquals(UrlSecurityFailureType.INVALID_INPUT, exception.getFailureType());
+            assertEquals("", exception.getOriginalInput());
+        }
+
+        @Test
+        @DisplayName("empty input is returned unchanged when the allow-list is empty (allow-all)")
+        void emptyInputAllowedWhenNoAllowList() {
+            ContentTypeValidationPipeline pipeline = pipeline(SecurityConfiguration.defaults());
             assertEquals(Optional.of(""), pipeline.validate(""));
         }
     }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/ContentTypeValidationPipelineTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/ContentTypeValidationPipelineTest.java
@@ -20,6 +20,7 @@ import de.cuioss.http.security.core.UrlSecurityFailureType;
 import de.cuioss.http.security.core.ValidationType;
 import de.cuioss.http.security.exceptions.UrlSecurityException;
 import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.validation.AllowBlockListStage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -58,6 +59,18 @@ class ContentTypeValidationPipelineTest {
     void reportsHeaderValueType() {
         assertEquals(ValidationType.HEADER_VALUE,
                 pipeline(SecurityConfiguration.defaults()).getValidationType());
+    }
+
+    @Test
+    @DisplayName("scope: allow/block-list enforcement only - a single AllowBlockListStage")
+    void pipelineScopeIsListEnforcementOnly() {
+        ContentTypeValidationPipeline pipeline = pipeline(SecurityConfiguration.defaults());
+
+        // Pins the documented class-level contract: no length limit, no character validation.
+        var stages = pipeline.getStages();
+        assertEquals(1, stages.size(), "Content-type pipeline must consist of exactly one stage");
+        assertInstanceOf(AllowBlockListStage.class, stages.getFirst());
+        assertEquals(ValidationType.HEADER_VALUE, pipeline.getValidationType());
     }
 
     @Nested

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java
@@ -55,8 +55,8 @@ class HTTPHeaderValidationPipelineTest {
             HTTPHeaderValidationPipeline pipeline = new HTTPHeaderValidationPipeline(config, eventCounter, ValidationType.HEADER_NAME);
 
             assertEquals(ValidationType.HEADER_NAME, pipeline.getValidationType());
-            // 4 common stages + the header-name allow/block-list stage (F-08)
-            assertEquals(5, pipeline.getStages().size());
+            // 2 common stages + the header-name allow/block-list stage (F-08)
+            assertEquals(3, pipeline.getStages().size());
             assertSame(eventCounter, pipeline.getEventCounter());
         }
 
@@ -65,7 +65,7 @@ class HTTPHeaderValidationPipelineTest {
             HTTPHeaderValidationPipeline pipeline = new HTTPHeaderValidationPipeline(config, eventCounter, ValidationType.HEADER_VALUE);
 
             assertEquals(ValidationType.HEADER_VALUE, pipeline.getValidationType());
-            assertEquals(4, pipeline.getStages().size());
+            assertEquals(2, pipeline.getStages().size());
             assertSame(eventCounter, pipeline.getEventCounter());
         }
 
@@ -281,12 +281,22 @@ class HTTPHeaderValidationPipelineTest {
             HTTPHeaderValidationPipeline pipeline = new HTTPHeaderValidationPipeline(config, eventCounter, ValidationType.HEADER_VALUE);
 
             var stages = pipeline.getStages();
-            assertEquals(4, stages.size());
+            assertEquals(2, stages.size());
 
             assertTrue(stages.getFirst().getClass().getSimpleName().contains("Length"));
             assertTrue(stages.get(1).getClass().getSimpleName().contains("Character"));
-            assertTrue(stages.get(2).getClass().getSimpleName().contains("Normalization"));
-            assertTrue(stages.get(3).getClass().getSimpleName().contains("Pattern"));
+        }
+
+        @Test
+        void shouldPreserveStageOrderForHeaderName() {
+            HTTPHeaderValidationPipeline pipeline = new HTTPHeaderValidationPipeline(config, eventCounter, ValidationType.HEADER_NAME);
+
+            var stages = pipeline.getStages();
+            assertEquals(3, stages.size());
+
+            assertTrue(stages.getFirst().getClass().getSimpleName().contains("Length"));
+            assertTrue(stages.get(1).getClass().getSimpleName().contains("Character"));
+            assertTrue(stages.get(2).getClass().getSimpleName().contains("AllowBlockList"));
         }
     }
 

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HeaderAndContentTypeEnforcementRegressionTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HeaderAndContentTypeEnforcementRegressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HeaderAndContentTypeEnforcementRegressionTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HeaderAndContentTypeEnforcementRegressionTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.security.pipeline;
+
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.core.HttpSecurityValidator;
+import de.cuioss.http.security.core.UrlSecurityFailureType;
+import de.cuioss.http.security.core.ValidationType;
+import de.cuioss.http.security.exceptions.UrlSecurityException;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.validation.LengthValidationStage;
+import de.cuioss.http.security.validation.NormalizationStage;
+import de.cuioss.http.security.validation.PatternMatchingStage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Cross-cutting, pipeline-level regression tests for the four header and content-type
+ * enforcement gaps corrected by this change.
+ *
+ * <p>Every assertion here goes through a {@link PipelineFactory}-built pipeline rather than
+ * through an individual stage, so each test reproduces the gap from a caller's angle: it fails
+ * against the pre-fix code and passes after. The four behaviours pinned are:</p>
+ * <ol>
+ *   <li>the header-name pipeline enforces the RFC 7230 {@code tchar} set, so a name carrying a
+ *       space or a colon is rejected while a valid token name passes;</li>
+ *   <li>a non-empty allow-list rejects the empty value like any other value, for both the
+ *       content-type and the header-name pipeline;</li>
+ *   <li>the header-value pipeline still rejects CR/LF injection after the removal of the two
+ *       pass-through stages, and its stage list contains neither of them;</li>
+ *   <li>the content-type pipeline enforces its lists while applying no length limit, matching
+ *       its documented allow/block-list-only scope.</li>
+ * </ol>
+ */
+@DisplayName("Header and content-type enforcement regressions")
+class HeaderAndContentTypeEnforcementRegressionTest {
+
+    private SecurityEventCounter eventCounter;
+
+    @BeforeEach
+    void setUp() {
+        eventCounter = new SecurityEventCounter();
+    }
+
+    private List<HttpSecurityValidator> stagesOf(HttpSecurityValidator pipeline) {
+        return assertInstanceOf(AbstractValidationPipeline.class, pipeline,
+                "Factory-built pipelines expose their stages via AbstractValidationPipeline").getStages();
+    }
+
+    @Nested
+    @DisplayName("(1) header names are restricted to the RFC 7230 tchar set")
+    class HeaderNameTokenEnforcement {
+
+        private HttpSecurityValidator pipeline() {
+            return PipelineFactory.createHeaderNamePipeline(SecurityConfiguration.defaults(), eventCounter);
+        }
+
+        @Test
+        @DisplayName("rejects a header name containing a space with INVALID_CHARACTER")
+        void rejectsSpaceInHeaderName() {
+            HttpSecurityValidator pipeline = pipeline();
+
+            UrlSecurityException exception = assertThrows(UrlSecurityException.class,
+                    () -> pipeline.validate("X-Foo bar"));
+
+            assertAll("space is not a tchar",
+                    () -> assertEquals(UrlSecurityFailureType.INVALID_CHARACTER, exception.getFailureType()),
+                    () -> assertEquals(ValidationType.HEADER_NAME, exception.getValidationType()),
+                    () -> assertEquals("X-Foo bar", exception.getOriginalInput()),
+                    () -> assertTrue(eventCounter.getCount(UrlSecurityFailureType.INVALID_CHARACTER) >= 1,
+                            "Security event should be recorded"));
+        }
+
+        @Test
+        @DisplayName("rejects a header name containing a colon with INVALID_CHARACTER")
+        void rejectsColonInHeaderName() {
+            HttpSecurityValidator pipeline = pipeline();
+
+            UrlSecurityException exception = assertThrows(UrlSecurityException.class,
+                    () -> pipeline.validate("X-Foo:"));
+
+            assertAll("colon is a delimiter, not a tchar",
+                    () -> assertEquals(UrlSecurityFailureType.INVALID_CHARACTER, exception.getFailureType()),
+                    () -> assertEquals(ValidationType.HEADER_NAME, exception.getValidationType()),
+                    () -> assertEquals("X-Foo:", exception.getOriginalInput()));
+        }
+
+        @Test
+        @DisplayName("accepts a valid tchar header name unchanged")
+        void acceptsValidTokenName() {
+            assertEquals(Optional.of("X-Correlation-Id"), pipeline().validate("X-Correlation-Id"));
+        }
+    }
+
+    @Nested
+    @DisplayName("(2) a non-empty allow-list rejects the empty value")
+    class EmptyValueAgainstAllowList {
+
+        @Test
+        @DisplayName("content-type pipeline rejects the empty string with INVALID_INPUT")
+        void contentTypePipelineRejectsEmptyValue() {
+            SecurityConfiguration config = SecurityConfiguration.builder()
+                    .allowedContentTypes(Set.of("application/json"))
+                    .build();
+            HttpSecurityValidator pipeline = PipelineFactory.createContentTypePipeline(config, eventCounter);
+
+            UrlSecurityException exception = assertThrows(UrlSecurityException.class,
+                    () -> pipeline.validate(""));
+
+            assertAll("empty value is evaluated against the allow-list like any other value",
+                    () -> assertEquals(UrlSecurityFailureType.INVALID_INPUT, exception.getFailureType()),
+                    () -> assertEquals(ValidationType.HEADER_VALUE, exception.getValidationType()),
+                    () -> assertEquals("", exception.getOriginalInput()));
+        }
+
+        @Test
+        @DisplayName("header-name pipeline rejects the empty string with INVALID_INPUT")
+        void headerNamePipelineRejectsEmptyValue() {
+            SecurityConfiguration config = SecurityConfiguration.builder()
+                    .allowedHeaderNames(Set.of("Accept"))
+                    .build();
+            HttpSecurityValidator pipeline = PipelineFactory.createHeaderNamePipeline(config, eventCounter);
+
+            UrlSecurityException exception = assertThrows(UrlSecurityException.class,
+                    () -> pipeline.validate(""));
+
+            assertAll("the empty name reaches the allow/block-list stage and is rejected there",
+                    () -> assertEquals(UrlSecurityFailureType.INVALID_INPUT, exception.getFailureType()),
+                    () -> assertEquals(ValidationType.HEADER_NAME, exception.getValidationType()),
+                    () -> assertEquals("", exception.getOriginalInput()));
+        }
+
+        @Test
+        @DisplayName("an allow-listed value still passes, so the rejection is list-driven")
+        void allowListedValueStillPasses() {
+            SecurityConfiguration config = SecurityConfiguration.builder()
+                    .allowedHeaderNames(Set.of("Accept"))
+                    .build();
+            HttpSecurityValidator pipeline = PipelineFactory.createHeaderNamePipeline(config, eventCounter);
+
+            assertEquals(Optional.of("Accept"), pipeline.validate("Accept"));
+        }
+    }
+
+    @Nested
+    @DisplayName("(3) header values reject CR/LF after the two-stage removal")
+    class HeaderValueCrlfAfterStageRemoval {
+
+        private HttpSecurityValidator pipeline() {
+            return PipelineFactory.createHeaderValuePipeline(SecurityConfiguration.defaults(), eventCounter);
+        }
+
+        @Test
+        @DisplayName("rejects CR/LF header injection with INVALID_CHARACTER")
+        void rejectsCrlfInjection() {
+            HttpSecurityValidator pipeline = pipeline();
+
+            UrlSecurityException exception = assertThrows(UrlSecurityException.class,
+                    () -> pipeline.validate("value\r\nX-Injected: 1"));
+
+            assertAll("CR/LF rejection does not depend on the removed stages",
+                    () -> assertEquals(UrlSecurityFailureType.INVALID_CHARACTER, exception.getFailureType()),
+                    () -> assertEquals(ValidationType.HEADER_VALUE, exception.getValidationType()),
+                    () -> assertEquals("value\r\nX-Injected: 1", exception.getOriginalInput()));
+        }
+
+        @Test
+        @DisplayName("stage list contains neither a PatternMatchingStage nor a NormalizationStage")
+        void stageListOmitsBothRemovedStages() {
+            List<HttpSecurityValidator> stages = stagesOf(pipeline());
+
+            assertAll("both stages were pass-throughs for header types and are gone",
+                    () -> assertTrue(stages.stream().noneMatch(PatternMatchingStage.class::isInstance),
+                            "Header-value pipeline must not contain a PatternMatchingStage"),
+                    () -> assertTrue(stages.stream().noneMatch(NormalizationStage.class::isInstance),
+                            "Header-value pipeline must not contain a NormalizationStage"));
+        }
+    }
+
+    @Nested
+    @DisplayName("(4) the content-type pipeline enforces lists but applies no length limit")
+    class ContentTypeScope {
+
+        private static final String ALLOWED_MEDIA_TYPE = "application/json";
+
+        private HttpSecurityValidator pipeline() {
+            SecurityConfiguration config = SecurityConfiguration.builder()
+                    .allowedContentTypes(Set.of(ALLOWED_MEDIA_TYPE))
+                    .build();
+            return PipelineFactory.createContentTypePipeline(config, eventCounter);
+        }
+
+        @Test
+        @DisplayName("accepts an allow-listed media type whose parameters exceed the header-value limit")
+        void appliesNoLengthLimit() {
+            int headerValueLimit = SecurityConfiguration.defaults().maxHeaderValueLength();
+            String overlongValue = ALLOWED_MEDIA_TYPE + "; boundary=" + syntheticToken(headerValueLimit + 100);
+            assertTrue(overlongValue.length() > headerValueLimit,
+                    "Test input must exceed the header-value length limit to be meaningful");
+
+            assertEquals(Optional.of(overlongValue), pipeline().validate(overlongValue));
+        }
+
+        @Test
+        @DisplayName("still rejects a media type absent from the allow-list")
+        void stillEnforcesTheAllowList() {
+            UrlSecurityException exception = assertThrows(UrlSecurityException.class,
+                    () -> pipeline().validate("application/octet-stream"));
+
+            assertEquals(UrlSecurityFailureType.INVALID_INPUT, exception.getFailureType());
+        }
+
+        @Test
+        @DisplayName("stage list carries no LengthValidationStage")
+        void stageListOmitsLengthValidation() {
+            List<HttpSecurityValidator> stages = stagesOf(pipeline());
+
+            assertTrue(stages.stream().noneMatch(LengthValidationStage.class::isInstance),
+                    "Content-type pipeline must not contain a LengthValidationStage");
+        }
+
+        /**
+         * Builds a varied token of the requested length without {@code String.repeat}, matching the
+         * long-value construction style used by the sibling pipeline tests.
+         */
+        private String syntheticToken(int length) {
+            StringBuilder token = new StringBuilder(length);
+            String alphabet = "abcdefghij";
+            for (int i = 0; i < length; i++) {
+                token.append(alphabet.charAt(i % alphabet.length()));
+            }
+            return token.toString();
+        }
+    }
+}

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/PipelineFactoryTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/PipelineFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLParameterNameValidationPipelineBehaviorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLParameterNameValidationPipelineBehaviorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/ApacheCVEAttackDatabaseTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/ApacheCVEAttackDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/DoubleEncodingAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/DoubleEncodingAttackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/EdgeCaseValidURLsDatabaseTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/EdgeCaseValidURLsDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/EncodedPathTraversalAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/EncodedPathTraversalAttackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/HomographAttackDatabaseTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/HomographAttackDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/Http1VulnerabilitiesTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/Http1VulnerabilitiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/IDNAttackDatabaseTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/IDNAttackDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/IISCVEAttackDatabaseTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/IISCVEAttackDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/IPv6AttackDatabaseTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/IPv6AttackDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/LegitimatePathPatternsDatabaseTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/LegitimatePathPatternsDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/LegitimateSpecialCharactersDatabaseTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/LegitimateSpecialCharactersDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/MixedEncodingAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/MixedEncodingAttackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/ModSecurityCRSAttackDatabaseTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/ModSecurityCRSAttackDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/NginxCVEAttackDatabaseTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/NginxCVEAttackDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/NullBytePathTraversalAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/NullBytePathTraversalAttackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPZAPAttackDatabaseTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPZAPAttackDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/ProtocolHandlerAttackDatabaseTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/ProtocolHandlerAttackDatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/ProtocolHandlerAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/ProtocolHandlerAttackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/URLLengthLimitAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/URLLengthLimitAttackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodeControlCharacterAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodeControlCharacterAttackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodeNormalizationAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodeNormalizationAttackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodePathTraversalAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodePathTraversalAttackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/AllowBlockListStageTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/AllowBlockListStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/AllowBlockListStageTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/AllowBlockListStageTest.java
@@ -67,6 +67,24 @@ class AllowBlockListStageTest {
     }
 
     @Test
+    @DisplayName("Non-empty allow-list rejects the empty value")
+    void shouldRejectEmptyValueAgainstAllowList() {
+        var stage = new AllowBlockListStage(Set.of("Accept"), Set.of(), ValidationType.HEADER_NAME);
+        var exception = assertThrows(UrlSecurityException.class, () -> stage.validate(""));
+        assertEquals(UrlSecurityFailureType.INVALID_INPUT, exception.getFailureType());
+        assertTrue(exception.getDetail().orElse("").contains("allow-list"));
+    }
+
+    @Test
+    @DisplayName("Block-listed empty value is rejected")
+    void shouldRejectEmptyValueAgainstBlockList() {
+        var stage = new AllowBlockListStage(Set.of(), Set.of(""), ValidationType.HEADER_NAME);
+        var exception = assertThrows(UrlSecurityException.class, () -> stage.validate(""));
+        assertEquals(UrlSecurityFailureType.INVALID_INPUT, exception.getFailureType());
+        assertTrue(exception.getDetail().orElse("").contains("block-listed"));
+    }
+
+    @Test
     @DisplayName("Block-list takes precedence over allow-list")
     void shouldPreferBlockOverAllow() {
         var stage = new AllowBlockListStage(Set.of("X-Debug"), Set.of("X-Debug"), ValidationType.HEADER_NAME);

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationConstantsTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationConstantsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationConstantsTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationConstantsTest.java
@@ -142,6 +142,47 @@ class CharacterValidationConstantsTest {
     }
 
     @Test
+    @SuppressWarnings("java:S5961") // Exhaustive RFC 7230 tchar (token) character-set membership check
+    void shouldInitializeRFC7230TokenCharacters() {
+        IntPredicate tokenChars = CharacterValidationConstants.RFC7230_TOKEN_CHARS;
+
+        // Should include ALPHA
+        for (char c = 'A'; c <= 'Z'; c++) {
+            assertTrue(tokenChars.test(c), "Uppercase letter " + c + " should be allowed");
+        }
+        for (char c = 'a'; c <= 'z'; c++) {
+            assertTrue(tokenChars.test(c), "Lowercase letter " + c + " should be allowed");
+        }
+
+        // Should include DIGIT
+        for (char c = '0'; c <= '9'; c++) {
+            assertTrue(tokenChars.test(c), "Digit " + c + " should be allowed");
+        }
+
+        // Should include every tchar punctuation member (RFC 7230 section 3.2.6)
+        for (char c : "!#$%&'*+-.^_`|~".toCharArray()) {
+            assertTrue(tokenChars.test(c), "tchar punctuation " + c + " should be allowed");
+        }
+
+        // Should reject delimiters - these are the characters a header NAME must never contain
+        assertFalse(tokenChars.test(' '), "Space must be rejected in a header name");
+        assertFalse(tokenChars.test(':'), "Colon must be rejected in a header name");
+        assertFalse(tokenChars.test(','));
+        assertFalse(tokenChars.test(';'));
+        assertFalse(tokenChars.test('('));
+        assertFalse(tokenChars.test(')'));
+        assertFalse(tokenChars.test('@'));
+        assertFalse(tokenChars.test('/'));
+        assertFalse(tokenChars.test('"'));
+
+        // Should reject control characters and DEL
+        assertFalse(tokenChars.test('\t'));
+        assertFalse(tokenChars.test('\r'));
+        assertFalse(tokenChars.test('\n'));
+        assertFalse(tokenChars.test(127)); // DEL
+    }
+
+    @Test
     void shouldReturnCorrectCharacterSetForValidationType() {
         // The accessor now returns the shared immutable predicate instance (no defensive
         // copy), so identity equality is both correct and the strongest available assertion.
@@ -153,7 +194,7 @@ class CharacterValidationConstantsTest {
         assertSame(CharacterValidationConstants.RFC3986_QUERY_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.PARAMETER_VALUE));
 
-        assertSame(CharacterValidationConstants.RFC7230_HEADER_CHARS,
+        assertSame(CharacterValidationConstants.RFC7230_TOKEN_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.HEADER_NAME));
         assertSame(CharacterValidationConstants.RFC7230_HEADER_CHARS,
                 CharacterValidationConstants.getCharacterSet(ValidationType.HEADER_VALUE));

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/CookiePrefixValidationStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/LengthValidationStageTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/LengthValidationStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/NormalizationStageTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/NormalizationStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/PatternMatchingStageTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/PatternMatchingStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/validation/RequestCollectionValidatorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/validation/RequestCollectionValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/doc/http-security/analysis/http1-vulnerabilities-analysis.adoc
+++ b/doc/http-security/analysis/http1-vulnerabilities-analysis.adoc
@@ -327,7 +327,7 @@ The cui-http library provides HTTP **component** validation (headers, paths, par
 
 * **HTTP Component Syntax Validation:** Validating individual headers, paths, parameters for malicious patterns
 * **Injection Attack Detection:** CRLF injection, header injection, control characters
-* **Pattern Matching:** Detecting smuggling-related patterns in component values
+* **Pattern Matching:** Detecting attack patterns in URL path and parameter values. This stage does **not** apply to header components — the header pipeline excludes it (see below).
 * **Test Coverage:** Comprehensive test suite demonstrating attack pattern detection
 
 ==== Infrastructure Scope (Outside Library)
@@ -346,7 +346,7 @@ The cui-http library provides HTTP **component** validation (headers, paths, par
 
 2. **Character Validation:** link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - CRLF, control character detection
 
-3. **Pattern Matching:** link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage] - Attack pattern detection
+3. **Header Name Token Validation:** link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java[CharacterValidationConstants] - RFC 7230 §3.2.6 `tchar` token set for `HEADER_NAME`, rejecting the delimiters (space, `:`, `,`, `;`, `"`, parentheses) a smuggled header name would need
 
 4. **Test Coverage:** 553 tests total across the two generator-driven attack-test classes below
    (the `Http1VulnerabilitiesTest` focused regression suite of 11 parameterized methods is separate)
@@ -581,8 +581,15 @@ All request smuggling patterns are tested using parameterized tests with generat
 
 * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipeline.java[HTTPHeaderValidationPipeline] - Header component validation
 * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationStage.java[CharacterValidationStage] - CRLF and control character detection
-* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage] - Attack pattern detection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java[CharacterValidationConstants] - RFC 7230 `tchar` token set for header names
 * Comprehensive test coverage (553 tests across HttpRequestSmugglingAttackTest and HttpHeaderInjectionAttackTest)
+
+NOTE: `PatternMatchingStage` is deliberately **not** part of the header pipeline. Its pattern
+databases are path- and parameter-semantic, and it was a verified pass-through for `HEADER_NAME`
+and `HEADER_VALUE`; it is therefore excluded from `HTTPHeaderValidationPipeline` rather than wired
+in as a no-op. Header-smuggling defence at this layer comes from the RFC 7230 `tchar` token set
+(header names), `CharacterValidationStage` (CRLF and control characters), and the length and
+allow/block-list stages.
 
 **Infrastructure-Level Protection (Required):**
 

--- a/doc/http-security/configuration.adoc
+++ b/doc/http-security/configuration.adoc
@@ -66,6 +66,10 @@ defense (that is a UTS #39 capability).
 
 Enforced by `PatternMatchingStage`.
 
+`PatternMatchingStage` runs in the URL path and URL parameter (name and value) pipelines only, so
+`caseSensitiveComparison` and `failOnSuspiciousPatterns` have no effect on header or content-type
+validation.
+
 [cols="3,1,1,1", options="header"]
 |===
 | Setting | default | strict | lenient
@@ -111,6 +115,11 @@ Meaningful only for attribute-bearing (Set-Cookie) cookies, not request `Cookie`
 
 Case-insensitive allow/block lists (default empty). Block-list takes precedence; an empty
 allow-list means allow-all. Enforced by `AllowBlockListStage`.
+
+The empty *value* is a separate matter from the empty *list*: an empty value is evaluated against
+the lists like any other value and is not exempt. A non-empty `allowedContentTypes` or
+`allowedHeaderNames` therefore rejects the empty string, and a block-list containing the empty
+string rejects it too.
 
 [cols="3,1,3", options="header"]
 |===

--- a/doc/http-security/functional-requirements.adoc
+++ b/doc/http-security/functional-requirements.adoc
@@ -138,7 +138,8 @@ These requirements are derived from:
 * Must support different character sets for different validation types:
   ** Path segments: alphanumeric, hyphen, underscore, period
   ** Query parameters: extended ASCII subset
-  ** Headers: visible ASCII characters
+  ** Header names: RFC 7230 token characters (tchar) - ALPHA, DIGIT and the tchar punctuation set; delimiters such as space and colon are rejected
+  ** Header values: visible ASCII (32-126) plus horizontal tab
 
 * Must detect and block control characters
 * Reference: xref:specification/specification.adoc#_validation_stages[Validation Stages]

--- a/doc/http-security/specification/specification.adoc
+++ b/doc/http-security/specification/specification.adoc
@@ -161,10 +161,10 @@ The following classes implement the validation stages:
 * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/DecodingStage.java[DecodingStage] - URL decoding with security checks and Unicode canonicalization (OWASP canonicalize-then-validate: normalize-and-continue, rejecting only folds that introduce a structural separator; NFKC for paths, NFC for parameter values). Legitimate international text passes; NFKC is not confusable/homograph defense.
 
 [#_normalizationstage]
-* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage] - Path normalization per RFC 3986
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/NormalizationStage.java[NormalizationStage] - Path normalization per RFC 3986; a pass-through for every non-path validation type
 
 [#_patternmatchingstage]
-* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage] - Attack pattern detection
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/PatternMatchingStage.java[PatternMatchingStage] - Attack pattern detection for URL_PATH, PARAMETER_NAME and PARAMETER_VALUE; an intentional pass-through for header and cookie types
 * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/AllowBlockListStage.java[AllowBlockListStage] - Case-insensitive header-name / content-type allow/block lists
 * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/validation/CharacterValidationConstants.java[CharacterValidationConstants] - RFC-compliant character sets
 
@@ -202,6 +202,14 @@ The following classes implement the validation pipeline system:
 There are five concrete pipelines (all extending `AbstractValidationPipeline`), each optimized
 for its specific HTTP component. All but `ContentTypeValidationPipeline` run
 `LengthValidationStage` first; `ContentTypeValidationPipeline` is a single `AllowBlockListStage`.
+
+`HTTPHeaderValidationPipeline` is composed of `LengthValidationStage` followed by
+`CharacterValidationStage`, plus an `AllowBlockListStage` for `HEADER_NAME` only.
+`NormalizationStage` and `PatternMatchingStage` are deliberately absent: both are no-ops for
+header types — RFC 3986 dot-segment resolution applies to path components only, and the attack
+pattern databases cover `URL_PATH`, `PARAMETER_NAME` and `PARAMETER_VALUE` only — so including
+them would add stage invocations without adding any check. Header components rely on RFC 7230
+character validation instead, which rejects CR/LF unconditionally.
 
 [#_two_pass_pattern_matching]
 NOTE: `URLPathValidationPipeline` runs `PatternMatchingStage` *twice* by design — once before


### PR DESCRIPTION
## Summary

Closes five contract-vs-implementation gaps between the security-validation-pipeline Javadoc and its
actual behaviour in `cui-http-core`'s `de.cuioss.http.security.validation` and
`de.cuioss.http.security.pipeline` packages:

1. `HEADER_NAME` now enforces its own RFC 7230 §3.2.6 `tchar` predicate instead of sharing the
   broader `RFC7230_HEADER_CHARS` set with `HEADER_VALUE` — a header *name* containing a space or
   colon is now rejected.
2. `PatternMatchingStage` and `NormalizationStage` were confirmed no-ops for `HEADER_NAME` /
   `HEADER_VALUE` (both are pass-throughs for header types); the header pipeline no longer wires
   either stage, and the class-level Javadoc for both stages, and for
   `URLParameterNameValidationPipeline`, now states the real scope honestly.
3. `AllowBlockListStage` no longer exempts the empty value from allow/block-list evaluation — a
   configured non-empty allow-list now rejects an empty value like any other value not on the list.
4. `ContentTypeValidationPipeline`'s single-stage (allow/block-list only) scope is now documented
   prominently at the class level, together with why it reports `ValidationType.HEADER_VALUE`.
5. Cross-cutting regression tests pin all four behavioural/documentation corrections above, each
   going through a `PipelineFactory`-built pipeline and asserting the specific
   `UrlSecurityFailureType`.

## Intent

## Changes

- `CharacterValidationConstants`: added `RFC7230_TOKEN_CHARS` (the RFC 7230 `tchar` set) and routed
  `HEADER_NAME` to it, keeping `RFC7230_HEADER_CHARS` for `HEADER_VALUE` only.
- `HTTPHeaderValidationPipeline`: removed the `NormalizationStage` and `PatternMatchingStage` wiring
  (both were pass-throughs for header types); updated Javadoc accordingly.
- `AllowBlockListStage`: removed the early-return that exempted the empty value from allow/block-list
  checks.
- `ContentTypeValidationPipeline`, `NormalizationStage`, `PatternMatchingStage`,
  `URLParameterNameValidationPipeline`: Javadoc-only scope clarifications, no behavioural change.
- `HeaderAndContentTypeEnforcementRegressionTest` (new): cross-cutting regression tests for the four
  behavioural/documentation corrections above.
- Copyright-header normalization (`2025` → `2025-present`) applied mechanically across the tree by
  the license plugin to keep the pre-commit gate idempotent.
- `doc/http-security/`: reconciled specification, configuration, and functional-requirements
  (`HTTP-10`) prose with the corrected header pipeline; corrected three false
  `PatternMatchingStage` header-smuggling claims in `http1-vulnerabilities-analysis.adoc`; declared
  the documentation module's implementation skills profile.

### Behavioral break

Two observable behaviour changes ship in this PR, both intentional fixes for the gaps above:

- **Empty content types no longer bypass a configured allow-list.** `AllowBlockListStage` used to
  return early on an empty value before either list check ran. A caller relying on that exemption —
  e.g. treating an empty `Content-Type` as implicitly allowed — will now see it rejected when a
  non-empty allow-list is configured.
- **`HTTPHeaderValidationPipeline.getStages()` output changed.** `HEADER_NAME` stage count: 5 → 3.
  `HEADER_VALUE` stage count: 4 → 2. Both removed stages (`NormalizationStage`,
  `PatternMatchingStage`) were confirmed pass-throughs for header validation types, so no detection
  coverage is lost — but any caller introspecting `getStages()` (size, contents, or ordering) is
  affected.

## Test Plan

- [x] Verification command passed (`verify -Ppre-commit -pl cui-http-core -am`, 5471 tests, exit 0)
- [ ] Manual testing completed (if applicable)

## Related Issues

None.

---
Generated by plan-finalize skill

## Intent

**Problem.** Three fail-open defects and two Javadoc-honesty gaps existed in
`de.cuioss.http.security`: `HEADER_NAME` shared the permissive `RFC7230_HEADER_CHARS` set with
`HEADER_VALUE`, so a header name containing a space or colon passed character validation;
`AllowBlockListStage` exempted the empty value from both allow-list and block-list enforcement; and
the header pipeline advertised `NormalizationStage` and `PatternMatchingStage` as active detection
while both were confirmed no-ops for header validation types. `ContentTypeValidationPipeline` and
`URLParameterNameValidationPipeline` also carried Javadoc that overstated what they actually check.

**Approach.** Give `HEADER_NAME` its own RFC 7230 §3.2.6 `tchar` predicate, remove the empty-value
early return from `AllowBlockListStage`, and remove both no-op stages from the header pipeline
rather than leave them advertising work they never perform. Reconcile the two overstated class-level
Javadoc blocks with actual behaviour, and pin all four corrections with a cross-cutting
`PipelineFactory`-level regression suite. Carry the corrections into the three stale AsciiDoc
documents under `doc/http-security/`, including the `HTTP-10` requirement that the header-name fix
falsifies.

**Non-goals.** `NormalizationStage` remains a documented no-op in
`URLParameterNameValidationPipeline` and its sibling value pipeline — not touched

_[Intent truncated — 1395 of 1812 characters shown; full outline in the plan workspace]_
