### PR TITLE
fix(forwarded): close trust-boundary gaps in header resolver

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -79,7 +79,7 @@ xref:doc/forwarded-header-resolution.adoc[Forwarded Header Resolution]:
 * Resolves `X-Forwarded-*`, RFC 7239 `Forwarded`, and NiFi `X-Proxy*` into one sanitized result
 * Scheme / host / port / context-path / client-IP with configurable per-field precedence
 * Secure-by-default trust model (allowlist, `trustAll`, trusted-proxy CIDR walk)
-* Built-in sanitization via the security pipelines; transport-agnostic `Function<String,String>` accessor
+* Built-in sanitization via the security pipelines; transport-agnostic `Function<String, List<String>>` accessor exposing every instance of a repeated header
 
 === Security Testing
 

--- a/cui-http-benchmarking/src/main/java/de/cuioss/http/forwarded/benchmark/ForwardedBenchmarkState.java
+++ b/cui-http-benchmarking/src/main/java/de/cuioss/http/forwarded/benchmark/ForwardedBenchmarkState.java
@@ -45,34 +45,36 @@ public class ForwardedBenchmarkState {
     public ResolvedForwarding resolved;
 
     // Clean, realistic X-Forwarded-* header sets.
-    private static final List<Map<String, String>> CLEAN_XFORWARDED = List.of(
-            Map.of("X-Forwarded-Proto", "https", "X-Forwarded-Host", "app.example.com:8443",
-                    "X-Forwarded-Prefix", "/ui", "X-Forwarded-For", "203.0.113.7, 10.0.0.5"),
-            Map.of("X-Forwarded-Proto", "https", "X-Forwarded-Host", "api.example.com",
-                    "X-Forwarded-Port", "443", "X-Forwarded-For", "198.51.100.23, 10.1.2.3"),
-            Map.of("X-Forwarded-Proto", "http", "X-Forwarded-Host", "gateway.internal:8080",
-                    "X-Forwarded-Prefix", "/service/v1", "X-Forwarded-For", "192.0.2.44, 10.9.9.9"));
+    private static final List<Map<String, List<String>>> CLEAN_XFORWARDED = List.of(
+            Map.of("X-Forwarded-Proto", List.of("https"), "X-Forwarded-Host", List.of("app.example.com:8443"),
+                    "X-Forwarded-Prefix", List.of("/ui"), "X-Forwarded-For", List.of("203.0.113.7, 10.0.0.5")),
+            Map.of("X-Forwarded-Proto", List.of("https"), "X-Forwarded-Host", List.of("api.example.com"),
+                    "X-Forwarded-Port", List.of("443"), "X-Forwarded-For", List.of("198.51.100.23, 10.1.2.3")),
+            Map.of("X-Forwarded-Proto", List.of("http"), "X-Forwarded-Host", List.of("gateway.internal:8080"),
+                    "X-Forwarded-Prefix", List.of("/service/v1"), "X-Forwarded-For", List.of("192.0.2.44, 10.9.9.9")));
 
     // RFC 7239 Forwarded header sets (exercise the quoted-string parser).
-    private static final List<Map<String, String>> FORWARDED_RFC = List.of(
-            Map.of("Forwarded", "for=203.0.113.7;host=app.example.com;proto=https, for=\"10.0.0.5\""),
-            Map.of("Forwarded", "proto=https;host=\"api.example.com:443\";for=\"[2001:db8::1]\", for=10.1.2.3"),
-            Map.of("Forwarded", "for=192.0.2.44;proto=http;host=gateway.internal:8080, for=10.9.9.9"));
+    private static final List<Map<String, List<String>>> FORWARDED_RFC = List.of(
+            Map.of("Forwarded", List.of("for=203.0.113.7;host=app.example.com;proto=https, for=\"10.0.0.5\"")),
+            Map.of("Forwarded", List.of("proto=https;host=\"api.example.com:443\";for=\"[2001:db8::1]\", for=10.1.2.3")),
+            Map.of("Forwarded", List.of("for=192.0.2.44;proto=http;host=gateway.internal:8080, for=10.9.9.9")));
 
     // Injection / attack header sets (expected to be sanitized away).
-    private static final List<Map<String, String>> ATTACK_XFORWARDED = List.of(
-            Map.of("X-Forwarded-Host", "evil.com\r\nInjected: 1", "X-Forwarded-Prefix", "//attacker.com"),
-            Map.of("X-Forwarded-Prefix", "/app\\..\\..", "X-Forwarded-For", "not-an-ip, 10.0.0.5"),
-            Map.of("X-Forwarded-Proto", "javascript:alert(1)", "X-Forwarded-Host", "evil.com/../../etc"));
+    private static final List<Map<String, List<String>>> ATTACK_XFORWARDED = List.of(
+            Map.of("X-Forwarded-Host", List.of("evil.com\r\nInjected: 1"),
+                    "X-Forwarded-Prefix", List.of("//attacker.com")),
+            Map.of("X-Forwarded-Prefix", List.of("/app\\..\\.."), "X-Forwarded-For", List.of("not-an-ip, 10.0.0.5")),
+            Map.of("X-Forwarded-Proto", List.of("javascript:alert(1)"),
+                    "X-Forwarded-Host", List.of("evil.com/../../etc")));
 
     // Pre-built header accessors, one bound {@code map::get} per header set, so no Function is
     // allocated inside the measured region.
-    private static final List<Function<String, String>> CLEAN_ACCESSORS = toAccessors(CLEAN_XFORWARDED);
-    private static final List<Function<String, String>> FORWARDED_ACCESSORS = toAccessors(FORWARDED_RFC);
-    private static final List<Function<String, String>> ATTACK_ACCESSORS = toAccessors(ATTACK_XFORWARDED);
+    private static final List<Function<String, List<String>>> CLEAN_ACCESSORS = toAccessors(CLEAN_XFORWARDED);
+    private static final List<Function<String, List<String>>> FORWARDED_ACCESSORS = toAccessors(FORWARDED_RFC);
+    private static final List<Function<String, List<String>>> ATTACK_ACCESSORS = toAccessors(ATTACK_XFORWARDED);
 
-    private static List<Function<String, String>> toAccessors(List<Map<String, String>> headerSets) {
-        return headerSets.stream().<Function<String, String>>map(m -> m::get).toList();
+    private static List<Function<String, List<String>>> toAccessors(List<Map<String, List<String>>> headerSets) {
+        return headerSets.stream().<Function<String, List<String>>>map(m -> m::get).toList();
     }
 
     // Plain int counters: @State(Scope.Thread) allocates one instance per benchmark thread,
@@ -94,17 +96,17 @@ public class ForwardedBenchmarkState {
     }
 
     /** @return the next clean {@code X-Forwarded-*} header accessor, cycling. */
-    public Function<String, String> nextCleanXForwarded() {
+    public Function<String, List<String>> nextCleanXForwarded() {
         return CLEAN_ACCESSORS.get((cleanIndex++ & Integer.MAX_VALUE) % CLEAN_ACCESSORS.size());
     }
 
     /** @return the next RFC 7239 {@code Forwarded} header accessor, cycling. */
-    public Function<String, String> nextForwarded() {
+    public Function<String, List<String>> nextForwarded() {
         return FORWARDED_ACCESSORS.get((forwardedIndex++ & Integer.MAX_VALUE) % FORWARDED_ACCESSORS.size());
     }
 
     /** @return the next injection header accessor, cycling. */
-    public Function<String, String> nextAttack() {
+    public Function<String, List<String>> nextAttack() {
         return ATTACK_ACCESSORS.get((attackIndex++ & Integer.MAX_VALUE) % ATTACK_ACCESSORS.size());
     }
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ContextPaths.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ContextPaths.java
@@ -22,9 +22,12 @@ import org.jspecify.annotations.Nullable;
  *
  * <p>Lifted from the {@code ProxyContextPathResolver} prior art. The rules: exactly one leading
  * slash, no trailing slash, and an empty string when the value is absent, blank, carries control
- * characters (CR/LF or other), is protocol-relative ({@code //host}), or contains a backslash
- * (which some browsers normalize to {@code /}). Callers that need to log a rejection reason use
- * {@link #containsControlCharacter(String)} / {@link #isProtocolRelativeOrBackslash(String)}.</p>
+ * characters (CR/LF or other), is protocol-relative ({@code //host}), contains a backslash
+ * (which some browsers normalize to {@code /}), or contains a comma or any whitespace character
+ * (defence in depth — a well-formed context path has neither, so their presence signals a
+ * comma-separated header value that reached normalization without nearest-hop token selection).
+ * Callers that need to log a rejection reason use {@link #containsControlCharacter(String)} /
+ * {@link #isProtocolRelativeOrBackslash(String)}.</p>
  */
 final class ContextPaths {
 
@@ -43,7 +46,8 @@ final class ContextPaths {
             return "";
         }
         String trimmed = raw.strip();
-        if (trimmed.isEmpty() || containsControlCharacter(trimmed) || isProtocolRelativeOrBackslash(trimmed)) {
+        if (trimmed.isEmpty() || containsControlCharacter(trimmed) || isProtocolRelativeOrBackslash(trimmed)
+                || containsCommaOrWhitespace(trimmed)) {
             return "";
         }
         String withLeadingSlash = trimmed.startsWith("/") ? trimmed : "/" + trimmed;
@@ -68,6 +72,23 @@ final class ContextPaths {
      */
     static boolean isProtocolRelativeOrBackslash(String trimmed) {
         return trimmed.startsWith("//") || trimmed.indexOf('\\') >= 0;
+    }
+
+    /**
+     * Rejects an interior comma or any whitespace character as defence in depth. A well-formed
+     * context path contains neither, so their presence means a comma-separated header value reached
+     * this point without nearest-hop token selection having been applied — the caller's guard order
+     * is wrong, and normalizing such a value would honor an attacker-supplied token. The check runs
+     * against the already-stripped value, so surrounding whitespace is not affected.
+     */
+    static boolean containsCommaOrWhitespace(String trimmed) {
+        for (int i = 0; i < trimmed.length(); i++) {
+            char c = trimmed.charAt(i);
+            if (c == ',' || Character.isWhitespace(c)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String stripTrailingSlashes(String value) {

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -25,6 +25,7 @@ import org.jspecify.annotations.Nullable;
 import java.net.InetAddress;
 import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static de.cuioss.http.forwarded.ForwardedHeaderNames.*;
 
@@ -98,7 +99,9 @@ import static de.cuioss.http.forwarded.ForwardedHeaderNames.*;
  * ForwardedHeaderResolver resolver =
  *     new ForwardedHeaderResolver(config, new SecurityEventCounter());
  *
- * ResolvedForwarding forwarding = resolver.resolve(request::getHeader);
+ * // The accessor MUST expose every instance of a repeated header, not just the first:
+ * ResolvedForwarding forwarding =
+ *     resolver.resolve(name -> Collections.list(request.getHeaders(name)));
  * }</pre>
  *
  * <p>Instances are immutable and thread-safe (the underlying pipeline and event counter are
@@ -106,9 +109,6 @@ import static de.cuioss.http.forwarded.ForwardedHeaderNames.*;
  *
  * @since 1.0
  */
-// S4276: Function<String,String> is the intentional transport-agnostic header-accessor abstraction
-// (e.g. request::getHeader) per issue #88 — not a UnaryOperator (which implies operating on a value).
-@SuppressWarnings("java:S4276")
 public final class ForwardedHeaderResolver {
 
     private static final CuiLogger LOGGER = new CuiLogger(ForwardedHeaderResolver.class);
@@ -133,21 +133,27 @@ public final class ForwardedHeaderResolver {
     /**
      * Resolves the forwarded-header family from the supplied header accessor.
      *
-     * @param headerLookup maps a header name to its value (or {@code null} when absent); typically
-     *                     {@code request::getHeader}
+     * @param headerLookup maps a header name to <em>every</em> instance of that header present on
+     *                     the request, in wire order; {@code null} or an empty list means the header
+     *                     is absent. A single-valued accessor such as {@code request::getHeader} is
+     *                     <strong>insufficient</strong> — it exposes only the first instance, hiding
+     *                     the remaining ones, and a proxy appends by adding a repeated header just
+     *                     as legitimately as by extending a comma-separated value. Use
+     *                     {@code name -> Collections.list(request.getHeaders(name))} instead.
      * @return the sanitized, honored result (never {@code null}; {@link ResolvedForwarding#empty()}
      *         when nothing is present or honored)
      * @throws NullPointerException if {@code headerLookup} is {@code null}
      */
-    public ResolvedForwarding resolve(Function<String, String> headerLookup) {
+    public ResolvedForwarding resolve(Function<String, List<String>> headerLookup) {
         Objects.requireNonNull(headerLookup, "headerLookup must not be null");
-        RfcForwardedParser.Parsed forwarded = parseForwarded(headerLookup);
+        Function<String, String> lookup = joining(headerLookup);
+        RfcForwardedParser.Parsed forwarded = parseForwarded(lookup);
 
-        Optional<String> scheme = resolveScheme(headerLookup, forwarded);
-        HostPort hostPort = resolveHost(headerLookup, forwarded);
-        OptionalInt port = resolvePort(headerLookup, hostPort.port());
-        String contextPath = resolveContextPath(headerLookup);
-        Optional<String> clientIp = resolveClientIp(headerLookup, forwarded);
+        Optional<String> scheme = resolveScheme(lookup, forwarded);
+        HostPort hostPort = resolveHost(lookup, forwarded);
+        OptionalInt port = resolvePort(lookup, hostPort.port());
+        String contextPath = resolveContextPath(lookup);
+        Optional<String> clientIp = resolveClientIp(lookup, forwarded);
 
         return new ResolvedForwarding(scheme, hostPort.host(), port, contextPath, clientIp);
     }
@@ -352,6 +358,32 @@ public final class ForwardedHeaderResolver {
     }
 
     // --- shared helpers ----------------------------------------------------------------------
+
+    /**
+     * Adapts a multi-instance header accessor to the single-value view every field resolver below
+     * consumes, by joining the instances with {@code ", "}.
+     *
+     * <p>RFC 7230 §3.2.2 makes this equivalence explicit: a recipient MAY combine multiple instances
+     * of a comma-separated-list header into one value by concatenating them in wire order, separated
+     * by commas, without changing the message semantics. Joining here therefore makes a repeated
+     * header indistinguishable from the equivalent single comma-separated header — which is exactly
+     * what the nearest-hop token selection downstream needs in order to see every appended hop.</p>
+     *
+     * @return an accessor yielding the joined value, or {@code null} when the header is absent
+     *         (null list, empty list, or a list holding only {@code null}s)
+     */
+    private static Function<String, String> joining(Function<String, List<String>> headerLookup) {
+        return name -> {
+            List<String> instances = headerLookup.apply(name);
+            if (instances == null || instances.isEmpty()) {
+                return null;
+            }
+            String joined = instances.stream()
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.joining(", "));
+            return joined.isEmpty() ? null : joined;
+        };
+    }
 
     private RfcForwardedParser.Parsed parseForwarded(Function<String, String> lookup) {
         String raw = lookup.apply(FORWARDED);

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -201,7 +201,8 @@ public final class ForwardedHeaderResolver {
 
     /**
      * Splits a {@code host[:port]} token (bracketed IPv6 aware) and validates the host contains no
-     * path/backslash/whitespace. Returns {@link HostPort#EMPTY} for a malformed host.
+     * path/backslash/whitespace/URL-authority-delimiter characters. Returns {@link HostPort#EMPTY}
+     * for a malformed host.
      *
      * <p>The {@code host:port} split here intentionally diverges from
      * {@link IpAddresses#parseChainEntry(String)}: this method reconstructs the <em>host string</em>
@@ -235,10 +236,19 @@ public final class ForwardedHeaderResolver {
         return new HostPort(Optional.of(host), port);
     }
 
+    /**
+     * Rejects a path separator, backslash, whitespace, or any of the URL-authority delimiter
+     * characters ({@code @ # ?}). The consumer composes {@link ResolvedForwarding#host()} back
+     * into an absolute URL (see the package's serialization/usage examples); an embedded
+     * {@code @} would let a forged host smuggle a userinfo component
+     * ({@code https://real-host@attacker.example/}), which most URL parsers resolve to the
+     * <em>attacker's</em> host rather than the trusted one — the same host-confusion class the
+     * path/backslash checks already guard against, just via a different delimiter.
+     */
     private static boolean containsHostSeparator(String host) {
         for (int i = 0; i < host.length(); i++) {
             char c = host.charAt(i);
-            if (c == '/' || c == '\\' || Character.isWhitespace(c)) {
+            if (c == '/' || c == '\\' || c == '@' || c == '#' || c == '?' || Character.isWhitespace(c)) {
                 return true;
             }
         }

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -103,7 +103,9 @@ import static de.cuioss.http.forwarded.ForwardedHeaderNames.*;
  * <pre>{@code
  * ForwardedResolverConfig config = ForwardedResolverConfig.builder()
  *     .trustAll(true)
- *     .trustedProxies(Set.of("10.0.0.0/8"))
+ *     // The ingress proxies themselves, never the enclosing network: every address in the range is
+ *     // skipped by the client-IP walk, so a non-proxy host inside it could spoof the client IP.
+ *     .trustedProxies(Set.of("10.0.7.10/32", "10.0.7.11/32"))
  *     .build();
  * ForwardedHeaderResolver resolver =
  *     new ForwardedHeaderResolver(config, new SecurityEventCounter());

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -25,6 +25,7 @@ import org.jspecify.annotations.Nullable;
 import java.net.InetAddress;
 import java.util.*;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import static de.cuioss.http.forwarded.ForwardedHeaderNames.*;
@@ -90,6 +91,14 @@ import static de.cuioss.http.forwarded.ForwardedHeaderNames.*;
  * A source that is present but resolves to nothing valid also <em>disagrees</em> with a sibling
  * source that resolved successfully, so the conflicting-source rule above drops the field.</p>
  *
+ * <p>This applies to the RFC 7239 {@code Forwarded} header as a whole: when its raw value fails
+ * sanitization, the header is treated as present-but-unresolvable for <em>every</em> field it could
+ * have carried (scheme, host, client-IP), not as absent. A garbage {@code Forwarded} header therefore
+ * disagrees with — and drops — an otherwise clean {@code X-Forwarded-*} value, instead of letting the
+ * de-facto family win by default. Only a header that is genuinely absent, or one that sanitizes and
+ * parses cleanly while simply carrying no directive for a given field, leaves that field's de-facto
+ * value to stand on its own.</p>
+ *
  * <h3>Usage Example</h3>
  * <pre>{@code
  * ForwardedResolverConfig config = ForwardedResolverConfig.builder()
@@ -146,13 +155,13 @@ public final class ForwardedHeaderResolver {
      */
     public ResolvedForwarding resolve(Function<String, List<String>> headerLookup) {
         Objects.requireNonNull(headerLookup, "headerLookup must not be null");
-        Function<String, String> lookup = joining(headerLookup);
-        RfcForwardedParser.Parsed forwarded = parseForwarded(lookup);
+        UnaryOperator<String> lookup = joining(headerLookup);
+        ForwardedResult forwarded = parseForwarded(lookup);
 
         Optional<String> scheme = resolveScheme(lookup, forwarded);
         HostPort hostPort = resolveHost(lookup, forwarded);
         OptionalInt port = resolvePort(lookup, hostPort.port());
-        String contextPath = resolveContextPath(lookup);
+        String contextPath = resolveContextPath(lookup, forwarded);
         Optional<String> clientIp = resolveClientIp(lookup, forwarded);
 
         return new ResolvedForwarding(scheme, hostPort.host(), port, contextPath, clientIp);
@@ -160,15 +169,15 @@ public final class ForwardedHeaderResolver {
 
     // --- scheme ------------------------------------------------------------------------------
 
-    private Optional<String> resolveScheme(Function<String, String> lookup, RfcForwardedParser.Parsed forwarded) {
+    private Optional<String> resolveScheme(UnaryOperator<String> lookup, ForwardedResult forwarded) {
         if (!config.trustAll()) {
             return Optional.empty();
         }
         String deFacto = firstPresent(lookup, X_FORWARDED_PROTO, X_PROXY_SCHEME);
-        String rfc = forwarded.proto().orElse(null);
+        String rfc = forwarded.parsed().proto().orElse(null);
         return reconcileSources("scheme", X_FORWARDED_PROTO,
                 deFacto != null, deFacto == null ? Optional.empty() : schemeOf(deFacto),
-                rfc != null, rfc == null ? Optional.empty() : schemeOf(rfc));
+                forwarded.contributes(rfc != null), rfc == null ? Optional.empty() : schemeOf(rfc));
     }
 
     private Optional<String> schemeOf(String raw) {
@@ -180,15 +189,15 @@ public final class ForwardedHeaderResolver {
 
     // --- host --------------------------------------------------------------------------------
 
-    private HostPort resolveHost(Function<String, String> lookup, RfcForwardedParser.Parsed forwarded) {
+    private HostPort resolveHost(UnaryOperator<String> lookup, ForwardedResult forwarded) {
         if (!config.trustAll()) {
             return HostPort.EMPTY;
         }
         String deFacto = firstPresent(lookup, X_FORWARDED_HOST, X_PROXY_HOST);
-        String rfc = forwarded.host().orElse(null);
+        String rfc = forwarded.parsed().host().orElse(null);
         return reconcileSources("host", X_FORWARDED_HOST,
                 deFacto != null, deFacto == null ? Optional.empty() : hostPortOf(deFacto),
-                rfc != null, rfc == null ? Optional.empty() : hostPortOf(rfc))
+                forwarded.contributes(rfc != null), rfc == null ? Optional.empty() : hostPortOf(rfc))
                 .orElse(HostPort.EMPTY);
     }
 
@@ -257,7 +266,7 @@ public final class ForwardedHeaderResolver {
 
     // --- port --------------------------------------------------------------------------------
 
-    private OptionalInt resolvePort(Function<String, String> lookup, OptionalInt hostPortFallback) {
+    private OptionalInt resolvePort(UnaryOperator<String> lookup, OptionalInt hostPortFallback) {
         String raw = firstPresent(lookup, X_FORWARDED_PORT, X_PROXY_PORT);
         if (raw == null) {
             return hostPortFallback;
@@ -282,10 +291,10 @@ public final class ForwardedHeaderResolver {
 
     // --- context path ------------------------------------------------------------------------
 
-    private String resolveContextPath(Function<String, String> lookup) {
+    private String resolveContextPath(UnaryOperator<String> lookup, ForwardedResult forwarded) {
         String raw = firstPresent(lookup, X_PROXY_CONTEXT_PATH, X_FORWARDED_PREFIX);
         if (raw == null) {
-            if (isPresent(lookup.apply(FORWARDED))) {
+            if (forwarded.present()) {
                 LOGGER.debug("Forwarded header present but carries no context-path directive");
             }
             return "";
@@ -326,7 +335,7 @@ public final class ForwardedHeaderResolver {
 
     // --- client IP ---------------------------------------------------------------------------
 
-    private Optional<String> resolveClientIp(Function<String, String> lookup, RfcForwardedParser.Parsed forwarded) {
+    private Optional<String> resolveClientIp(UnaryOperator<String> lookup, ForwardedResult forwarded) {
         // Secure-by-default: without trusted proxies the immediate peer cannot be trusted, so the
         // forwarded chain (including the nearest hop) is not honored at all.
         if (config.trustedProxies().isEmpty()) {
@@ -334,12 +343,13 @@ public final class ForwardedHeaderResolver {
         }
         String xff = lookup.apply(X_FORWARDED_FOR);
         boolean xffPresent = isPresent(xff);
-        boolean rfcPresent = !forwarded.forValues().isEmpty();
+        List<String> rfcChain = forwarded.parsed().forValues();
+        boolean rfcPresent = forwarded.contributes(!rfcChain.isEmpty());
 
         Optional<String> fromXff = xffPresent
                 ? sanitize(X_FORWARDED_FOR, xff).map(value -> List.of(value.split(","))).flatMap(this::walkChain)
                 : Optional.empty();
-        Optional<String> fromRfc = rfcPresent ? walkChain(forwarded.forValues()) : Optional.empty();
+        Optional<String> fromRfc = rfcChain.isEmpty() ? Optional.empty() : walkChain(rfcChain);
 
         return reconcileSources("client IP", X_FORWARDED_FOR, xffPresent, fromXff, rfcPresent, fromRfc);
     }
@@ -382,7 +392,7 @@ public final class ForwardedHeaderResolver {
      * @return an accessor yielding the joined value, or {@code null} when the header is absent
      *         (null list, empty list, or a list holding only {@code null}s)
      */
-    private static Function<String, String> joining(Function<String, List<String>> headerLookup) {
+    private static UnaryOperator<String> joining(Function<String, List<String>> headerLookup) {
         return name -> {
             List<String> instances = headerLookup.apply(name);
             if (instances == null || instances.isEmpty()) {
@@ -395,15 +405,17 @@ public final class ForwardedHeaderResolver {
         };
     }
 
-    private RfcForwardedParser.Parsed parseForwarded(Function<String, String> lookup) {
+    private ForwardedResult parseForwarded(UnaryOperator<String> lookup) {
         String raw = lookup.apply(FORWARDED);
         if (!isPresent(raw)) {
-            return new RfcForwardedParser.Parsed(Optional.empty(), Optional.empty(), List.of());
+            return ForwardedResult.ABSENT;
         }
-        // Sanitize the Forwarded header value before parsing its directives.
+        // Sanitize the Forwarded header value before parsing its directives. A rejected value must
+        // NOT collapse into the absent case: the header WAS sent, so it stays present-but-unresolvable
+        // and disagrees with any de-facto sibling that resolves (fail closed).
         return sanitize(FORWARDED, raw)
-                .map(RfcForwardedParser::parse)
-                .orElseGet(() -> new RfcForwardedParser.Parsed(Optional.empty(), Optional.empty(), List.of()));
+                .map(value -> new ForwardedResult(true, false, RfcForwardedParser.parse(value)))
+                .orElse(ForwardedResult.UNRESOLVABLE);
     }
 
     /**
@@ -468,7 +480,7 @@ public final class ForwardedHeaderResolver {
         return resolution.map(value -> sanitizeForLog(String.valueOf(value))).orElse("(nothing valid)");
     }
 
-    private static @Nullable String firstPresent(Function<String, String> lookup, String... headerNames) {
+    private static @Nullable String firstPresent(UnaryOperator<String> lookup, String... headerNames) {
         for (String name : headerNames) {
             String value = lookup.apply(name);
             if (isPresent(value)) {
@@ -504,6 +516,50 @@ public final class ForwardedHeaderResolver {
             builder.append(Character.isISOControl(c) ? '?' : c);
         }
         return builder.toString();
+    }
+
+    /**
+     * Outcome of reading the RFC 7239 {@code Forwarded} header, keeping the header's own presence and
+     * its sanitization verdict distinct from the presence of any individual directive.
+     *
+     * <p>Collapsing the three states into "are the parsed directives empty?" is what lets a
+     * present-but-rejected header masquerade as an absent one, so the reconciliation in
+     * {@link #reconcileSources} would silently honor the de-facto sibling instead of dropping the
+     * field. The three states are:</p>
+     * <ol>
+     *   <li>{@link #ABSENT} — no {@code Forwarded} header was sent; the RFC source contributes
+     *       nothing and the de-facto family is honored on its own.</li>
+     *   <li>{@link #UNRESOLVABLE} — the header WAS sent but its raw value failed sanitization
+     *       (CR/LF, control characters, over-length, suspicious pattern). The source counts as
+     *       present for <em>every</em> field, so it disagrees with any de-facto sibling that
+     *       resolves and the field is dropped (fail closed).</li>
+     *   <li>Present and sanitized — the parsed directives decide per field. A well-formed value that
+     *       simply carries no {@code proto} (say) leaves that one field's RFC source with nothing to
+     *       contribute, which is an ordinary fallback rather than a disagreement.</li>
+     * </ol>
+     *
+     * @param present      whether a non-blank {@code Forwarded} header was sent at all
+     * @param unresolvable whether that header's raw value failed sanitization outright
+     * @param parsed       the directives parsed from the sanitized value; empty unless present and
+     *                     sanitized
+     */
+    private record ForwardedResult(boolean present, boolean unresolvable, RfcForwardedParser.Parsed parsed) {
+
+        private static final RfcForwardedParser.Parsed NO_DIRECTIVES =
+                new RfcForwardedParser.Parsed(Optional.empty(), Optional.empty(), List.of());
+
+        private static final ForwardedResult ABSENT = new ForwardedResult(false, false, NO_DIRECTIVES);
+
+        private static final ForwardedResult UNRESOLVABLE = new ForwardedResult(true, true, NO_DIRECTIVES);
+
+        /**
+         * Whether the RFC 7239 source counts as present for a field whose directive presence is
+         * {@code directivePresent}. An unresolvable header counts as present for every field — that
+         * is precisely what forces the disagreement path instead of a silent fallback.
+         */
+        private boolean contributes(boolean directivePresent) {
+            return unresolvable || directivePresent;
+        }
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -144,7 +144,7 @@ public final class ForwardedHeaderResolver {
             return Optional.empty();
         }
         return sanitize(X_FORWARDED_PROTO, raw)
-                .map(ForwardedHeaderResolver::firstToken)
+                .map(ForwardedHeaderResolver::lastToken)
                 .map(value -> value.toLowerCase(Locale.ROOT))
                 .filter(value -> "http".equals(value) || "https".equals(value));
     }
@@ -159,7 +159,7 @@ public final class ForwardedHeaderResolver {
         if (raw == null || !config.trustAll()) {
             return HostPort.EMPTY;
         }
-        Optional<String> sanitized = sanitize(X_FORWARDED_HOST, raw).map(ForwardedHeaderResolver::firstToken);
+        Optional<String> sanitized = sanitize(X_FORWARDED_HOST, raw).map(ForwardedHeaderResolver::lastToken);
         if (sanitized.isEmpty()) {
             return HostPort.EMPTY;
         }
@@ -223,7 +223,7 @@ public final class ForwardedHeaderResolver {
             return OptionalInt.empty();
         }
         return sanitize(X_FORWARDED_PORT, raw)
-                .map(ForwardedHeaderResolver::firstToken)
+                .map(ForwardedHeaderResolver::lastToken)
                 .map(ForwardedHeaderResolver::parsePort)
                 .orElse(OptionalInt.empty());
     }
@@ -250,7 +250,14 @@ public final class ForwardedHeaderResolver {
         // Apply the injection guards to the RAW value first: the header-value pipeline collapses a
         // protocol-relative "//host" prefix to "/host", masking the attack, so the guard must run
         // before sanitization can rewrite it.
-        String trimmed = raw.strip();
+        //
+        // Token selection must in turn precede the guards, because a guard applied to the whole raw
+        // string inspects only its leading characters and so misses an attack carried in a later
+        // token: "/app, //attacker.com" does not itself start with "//", so isProtocolRelativeOrBackslash
+        // would pass the whole string through, and the nearest-hop token "//attacker.com" would then
+        // be honored unguarded. Selecting the last token first means every guard below runs against
+        // the exact value that will be returned.
+        String trimmed = lastToken(raw.strip());
         if (ContextPaths.containsControlCharacter(trimmed)) {
             LOGGER.warn(ForwardedLogMessages.WARN.CONTEXT_PATH_CONTROL_CHARACTERS_REJECTED, sanitizeForLog(trimmed));
             return "";
@@ -259,7 +266,7 @@ public final class ForwardedHeaderResolver {
             LOGGER.warn(ForwardedLogMessages.WARN.CONTEXT_PATH_PROTOCOL_RELATIVE_REJECTED, sanitizeForLog(trimmed));
             return "";
         }
-        Optional<String> sanitized = sanitize(X_FORWARDED_PREFIX, raw);
+        Optional<String> sanitized = sanitize(X_FORWARDED_PREFIX, trimmed);
         if (sanitized.isEmpty()) {
             return "";
         }
@@ -365,9 +372,15 @@ public final class ForwardedHeaderResolver {
         return value != null && !value.isBlank();
     }
 
-    private static String firstToken(String value) {
-        int comma = value.indexOf(',');
-        return (comma < 0 ? value : value.substring(0, comma)).strip();
+    /**
+     * Selects the nearest-hop token of a comma-separated header value: the substring after the last
+     * comma. Each proxy in the chain <em>appends</em> its own value, so the rightmost token is the
+     * one contributed by the closest (and therefore most trustworthy) proxy, while any leading
+     * tokens are attacker-supplied when the client sent the header itself.
+     */
+    private static String lastToken(String value) {
+        int comma = value.lastIndexOf(',');
+        return (comma < 0 ? value : value.substring(comma + 1)).strip();
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -55,20 +55,39 @@ import static de.cuioss.http.forwarded.ForwardedHeaderNames.*;
  *
  * <h3>Precedence</h3>
  * <ul>
- *   <li>scheme: {@code X-Forwarded-Proto} → {@code X-ProxyScheme} → RFC 7239 {@code proto}</li>
- *   <li>host: {@code X-Forwarded-Host} → {@code X-ProxyHost} → RFC 7239 {@code host}</li>
+ *   <li>scheme: {@code X-Forwarded-Proto} → {@code X-ProxyScheme}, reconciled against RFC 7239
+ *       {@code proto}</li>
+ *   <li>host: {@code X-Forwarded-Host} → {@code X-ProxyHost}, reconciled against RFC 7239
+ *       {@code host}</li>
  *   <li>port: {@code X-Forwarded-Port} → {@code X-ProxyPort} → host {@code :port} fallback</li>
  *   <li>context-path: {@code X-ProxyContextPath} → {@code X-Forwarded-Prefix}
  *       ({@code Forwarded} has no prefix directive)</li>
- *   <li>client-IP: {@code X-Forwarded-For} chain → RFC 7239 {@code for} chain</li>
+ *   <li>client-IP: {@code X-Forwarded-For} chain, reconciled against the RFC 7239 {@code for}
+ *       chain</li>
  * </ul>
  *
- * <p><strong>Present-but-invalid = drop (no fall-through).</strong> Precedence selects the first
- * <em>present</em>, non-blank source for a field; that value is then validated. If it fails its
- * field guard it is <em>dropped</em> — lower-precedence sources are <em>not</em> consulted as a
- * fallback. In particular a present-but-invalid {@code X-Forwarded-Port} / {@code X-ProxyPort}
- * (non-numeric or outside {@code 1..65535}) yields no port; the host {@code :port} fallback is used
- * only when no explicit port header is present at all.</p>
+ * <p><strong>Nearest hop wins within a header.</strong> Each proxy in a chain <em>appends</em> its
+ * own value, so for a comma-separated header value the resolver selects the <em>rightmost</em>
+ * token — the one contributed by the closest, most trustworthy proxy. Leading tokens are
+ * attacker-supplied whenever the original client sent the header itself. The same rule applies
+ * across RFC 7239 elements: the <em>last</em> {@code proto} / {@code host} directive wins.</p>
+ *
+ * <p><strong>Conflicting sources = drop (fail closed).</strong> For scheme, host, and client-IP the
+ * de-facto {@code X-Forwarded-*} / {@code X-Proxy*} family and the RFC 7239 {@code Forwarded} header
+ * are resolved <em>independently</em>. When only one source is present its result is honored. When
+ * <em>both</em> are present they must agree: a proxy that populates both families does not
+ * contradict itself, so a disagreement means at least one side is forged. The field is then dropped
+ * and a warning logged, rather than letting the higher-precedence family silently win — preferring
+ * one source is precisely what an attacker exploits by supplying the family the resolver ranks
+ * higher.</p>
+ *
+ * <p><strong>Present-but-invalid = drop (no fall-through).</strong> A present, non-blank source is
+ * validated; if it fails its field guard it is <em>dropped</em> — lower-precedence sources are
+ * <em>not</em> consulted as a fallback. In particular a present-but-invalid
+ * {@code X-Forwarded-Port} / {@code X-ProxyPort} (non-numeric or outside {@code 1..65535}) yields no
+ * port; the host {@code :port} fallback is used only when no explicit port header is present at all.
+ * A source that is present but resolves to nothing valid also <em>disagrees</em> with a sibling
+ * source that resolved successfully, so the conflicting-source rule above drops the field.</p>
  *
  * <h3>Usage Example</h3>
  * <pre>{@code
@@ -136,13 +155,17 @@ public final class ForwardedHeaderResolver {
     // --- scheme ------------------------------------------------------------------------------
 
     private Optional<String> resolveScheme(Function<String, String> lookup, RfcForwardedParser.Parsed forwarded) {
-        String raw = firstPresent(lookup, X_FORWARDED_PROTO, X_PROXY_SCHEME);
-        if (raw == null) {
-            raw = forwarded.proto().orElse(null);
-        }
-        if (raw == null || !config.trustAll()) {
+        if (!config.trustAll()) {
             return Optional.empty();
         }
+        String deFacto = firstPresent(lookup, X_FORWARDED_PROTO, X_PROXY_SCHEME);
+        String rfc = forwarded.proto().orElse(null);
+        return reconcileSources("scheme", X_FORWARDED_PROTO,
+                deFacto != null, deFacto == null ? Optional.empty() : schemeOf(deFacto),
+                rfc != null, rfc == null ? Optional.empty() : schemeOf(rfc));
+    }
+
+    private Optional<String> schemeOf(String raw) {
         return sanitize(X_FORWARDED_PROTO, raw)
                 .map(ForwardedHeaderResolver::lastToken)
                 .map(value -> value.toLowerCase(Locale.ROOT))
@@ -152,18 +175,22 @@ public final class ForwardedHeaderResolver {
     // --- host --------------------------------------------------------------------------------
 
     private HostPort resolveHost(Function<String, String> lookup, RfcForwardedParser.Parsed forwarded) {
-        String raw = firstPresent(lookup, X_FORWARDED_HOST, X_PROXY_HOST);
-        if (raw == null) {
-            raw = forwarded.host().orElse(null);
-        }
-        if (raw == null || !config.trustAll()) {
+        if (!config.trustAll()) {
             return HostPort.EMPTY;
         }
-        Optional<String> sanitized = sanitize(X_FORWARDED_HOST, raw).map(ForwardedHeaderResolver::lastToken);
-        if (sanitized.isEmpty()) {
-            return HostPort.EMPTY;
-        }
-        return parseHostPort(sanitized.get());
+        String deFacto = firstPresent(lookup, X_FORWARDED_HOST, X_PROXY_HOST);
+        String rfc = forwarded.host().orElse(null);
+        return reconcileSources("host", X_FORWARDED_HOST,
+                deFacto != null, deFacto == null ? Optional.empty() : hostPortOf(deFacto),
+                rfc != null, rfc == null ? Optional.empty() : hostPortOf(rfc))
+                .orElse(HostPort.EMPTY);
+    }
+
+    private Optional<HostPort> hostPortOf(String raw) {
+        return sanitize(X_FORWARDED_HOST, raw)
+                .map(ForwardedHeaderResolver::lastToken)
+                .map(ForwardedHeaderResolver::parseHostPort)
+                .filter(hostPort -> hostPort.host().isPresent());
     }
 
     /**
@@ -289,20 +316,16 @@ public final class ForwardedHeaderResolver {
         if (config.trustedProxies().isEmpty()) {
             return Optional.empty();
         }
-        List<String> chain;
         String xff = lookup.apply(X_FORWARDED_FOR);
-        if (isPresent(xff)) {
-            Optional<String> sanitized = sanitize(X_FORWARDED_FOR, xff);
-            if (sanitized.isEmpty()) {
-                return Optional.empty();
-            }
-            chain = List.of(sanitized.get().split(","));
-        } else if (!forwarded.forValues().isEmpty()) {
-            chain = forwarded.forValues();
-        } else {
-            return Optional.empty();
-        }
-        return walkChain(chain);
+        boolean xffPresent = isPresent(xff);
+        boolean rfcPresent = !forwarded.forValues().isEmpty();
+
+        Optional<String> fromXff = xffPresent
+                ? sanitize(X_FORWARDED_FOR, xff).map(value -> List.of(value.split(","))).flatMap(this::walkChain)
+                : Optional.empty();
+        Optional<String> fromRfc = rfcPresent ? walkChain(forwarded.forValues()) : Optional.empty();
+
+        return reconcileSources("client IP", X_FORWARDED_FOR, xffPresent, fromXff, rfcPresent, fromRfc);
     }
 
     /**
@@ -358,6 +381,51 @@ public final class ForwardedHeaderResolver {
         }
     }
 
+    /**
+     * Reconciles a field resolved independently from the de-facto {@code X-Forwarded-*} /
+     * {@code X-Proxy*} family and from the RFC 7239 {@code Forwarded} header.
+     *
+     * <p>When only one source is present, its resolution is returned unchanged. When BOTH are
+     * present the two resolutions must agree: a trustworthy proxy that populates both families does
+     * not contradict itself, so a disagreement means at least one side is forged. The field is then
+     * dropped (fail closed) rather than letting the de-facto header win on precedence — silently
+     * preferring one source is exactly the behaviour an attacker exploits by supplying the family
+     * the resolver happens to rank higher.</p>
+     *
+     * @param field          the field name, for the disagreement log record
+     * @param deFactoHeader  the de-facto header name, for the disagreement log record
+     * @param deFactoPresent whether the de-facto source was present at all (distinct from it being
+     *                       present but unresolvable, which is a real disagreement)
+     * @param fromDeFacto    the de-facto source's independent resolution
+     * @param rfcPresent     whether the RFC 7239 directive was present at all
+     * @param fromRfc        the RFC 7239 source's independent resolution
+     * @return the agreed resolution, or empty when the sources disagree
+     */
+    private <T> Optional<T> reconcileSources(String field, String deFactoHeader,
+            boolean deFactoPresent, Optional<T> fromDeFacto,
+            boolean rfcPresent, Optional<T> fromRfc) {
+        if (!deFactoPresent) {
+            return fromRfc;
+        }
+        if (!rfcPresent) {
+            return fromDeFacto;
+        }
+        if (fromDeFacto.equals(fromRfc)) {
+            return fromDeFacto;
+        }
+        LOGGER.warn(ForwardedLogMessages.WARN.FORWARDED_SOURCES_DISAGREE,
+                field, deFactoHeader, describeForLog(fromDeFacto), describeForLog(fromRfc));
+        return Optional.empty();
+    }
+
+    /**
+     * Renders a resolution for the disagreement log record, routing the value through
+     * {@link #sanitizeForLog(String)} so no untrusted content reaches the log unfiltered.
+     */
+    private static String describeForLog(Optional<?> resolution) {
+        return resolution.map(value -> sanitizeForLog(String.valueOf(value))).orElse("(nothing valid)");
+    }
+
     private static @Nullable String firstPresent(Function<String, String> lookup, String... headerNames) {
         for (String name : headerNames) {
             String value = lookup.apply(name);
@@ -401,5 +469,14 @@ public final class ForwardedHeaderResolver {
      */
     private record HostPort(Optional<String> host, OptionalInt port) {
         private static final HostPort EMPTY = new HostPort(Optional.empty(), OptionalInt.empty());
+
+        /**
+         * Renders as {@code host[:port]} so a disagreement log line reads as the header value it
+         * came from rather than as the record's default field dump.
+         */
+        @Override
+        public String toString() {
+            return host.orElse("(none)") + (port.isPresent() ? ":" + port.getAsInt() : "");
+        }
     }
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedLogMessages.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedLogMessages.java
@@ -62,5 +62,11 @@ public final class ForwardedLogMessages {
                 .identifier(123)
                 .template("Ignoring client IP: forwarded chain carries an unparseable entry: %s")
                 .build();
+
+        public static final LogRecord FORWARDED_SOURCES_DISAGREE = LogRecordModel.builder()
+                .prefix(PREFIX)
+                .identifier(124)
+                .template("Dropping forwarded %s: sources disagree: %s resolves to %s but Forwarded resolves to %s")
+                .build();
     }
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedResolverConfig.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedResolverConfig.java
@@ -33,8 +33,31 @@ import java.util.*;
  *   <li>{@code allowedContextPaths} — honor these specific normalized context paths even when
  *       {@code trustAll} is {@code false} (mirrors NiFi's {@code nifi.web.proxy.context.path}).</li>
  *   <li>{@code trustedProxies} — CIDR ranges / IP literals defining trusted proxy hops; required
- *       for {@code X-Forwarded-For} client-IP resolution. An empty set honors no client IP.</li>
+ *       for {@code X-Forwarded-For} client-IP resolution. An empty set honors no client IP.
+ *       <strong>A configured range must contain only proxies</strong> — see below.</li>
  * </ul>
+ *
+ * <h3 id="trusted-range-composition">Composition rule — a trusted range must contain only proxies</h3>
+ * <p>The client-IP chain walk consumes the forwarded chain right-to-left and <em>skips</em> every
+ * hop that falls inside a configured {@code trustedProxies} range; the first hop that does not is
+ * returned as the client. Membership of that range is therefore a statement that the machine
+ * <em>is a proxy whose appended chain entry can be believed</em> — not merely that it is on a
+ * network you own. Both directions of getting the range wrong are real:</p>
+ * <ul>
+ *   <li><strong>Too broad → no client IP at all.</strong> A range wide enough to cover the whole
+ *       network (or {@code 0.0.0.0/0}) makes <em>every</em> hop trusted, so the walk skips the
+ *       entire chain, falls off the left end, and returns empty. This fails closed — no forged
+ *       address is ever honored — but it is counter-intuitive to operators debugging a missing
+ *       client IP, who typically widen the range further and make the symptom worse.</li>
+ *   <li><strong>Too broad → client-IP spoofing.</strong> A non-proxy machine that happens to fall
+ *       inside a configured range is skipped by the walk exactly as a real proxy would be. Anything
+ *       that machine <em>prepends</em> to the chain is then treated as an earlier, untrusted hop and
+ *       returned as the client IP. A single compromised or merely untrustworthy host inside the
+ *       range is enough to spoof the client IP for every request it forwards.</li>
+ * </ul>
+ * <p>Scope each range to the proxy tier itself — the individual load-balancer / ingress addresses,
+ * or the smallest subnet that holds nothing else — rather than to the enclosing VPC or office
+ * network.</p>
  *
  * <h3>Usage Example</h3>
  * <pre>{@code
@@ -193,8 +216,19 @@ public final class ForwardedResolverConfig {
         }
 
         /**
+         * Sets the trusted-proxy ranges used by the client-IP chain walk.
+         *
+         * <p>Each range must contain <em>only</em> proxies whose appended chain entry can be
+         * believed — see the class-level
+         * <a href="#trusted-range-composition">composition rule</a>. A range that is too broad
+         * fails in both directions: covering the whole network makes every hop trusted, so the walk
+         * exhausts the chain and yields no client IP at all; and any non-proxy machine inside a
+         * configured range is skipped like a real proxy, so whatever it prepends to the chain is
+         * returned as the client IP.</p>
+         *
          * @param trustedProxies CIDR ranges / IP literals defining trusted proxy hops for
-         *                       client-IP resolution
+         *                       client-IP resolution; scope each to the proxy tier itself, never to
+         *                       the enclosing VPC or office network
          * @return this builder
          * @throws NullPointerException if {@code trustedProxies} is {@code null}
          * @throws IllegalArgumentException if any entry is not a valid IP literal / CIDR

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ResolvedForwarding.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ResolvedForwarding.java
@@ -37,7 +37,9 @@ import java.util.OptionalInt;
  *
  * <h3>Usage Example</h3>
  * <pre>{@code
- * ResolvedForwarding forwarding = resolver.resolve(request::getHeader);
+ * // The accessor MUST expose every instance of a repeated header, not just the first:
+ * ResolvedForwarding forwarding =
+ *     resolver.resolve(name -> Collections.list(request.getHeaders(name)));
  * String scheme = forwarding.scheme().orElse("http");
  * int port = forwarding.port().orElse(scheme.equals("https") ? 443 : 80);
  * String prefix = forwarding.contextPath(); // "" when none / not honored

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/RfcForwardedParser.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/RfcForwardedParser.java
@@ -31,10 +31,16 @@ import java.util.Optional;
  * value             = token / quoted-string
  * </pre>
  *
- * <p>Extracts the first {@code proto} and {@code host} directives (case-insensitive names) and the
+ * <p>Extracts the last {@code proto} and {@code host} directives (case-insensitive names) and the
  * ordered list of {@code for} node identifiers across all comma-separated elements. Comma and
  * semicolon separators inside quoted strings are honored. Note: {@code Forwarded} has no
  * prefix/context-path directive, so none is extracted.</p>
+ *
+ * <p><strong>Last directive wins.</strong> Each proxy in the chain appends its own forwarded-element,
+ * so the rightmost {@code proto}/{@code host} is the one contributed by the nearest (and therefore
+ * most trustworthy) hop; any earlier occurrence is attacker-supplied when the client sent a
+ * {@code Forwarded} header of its own. The {@code for} list is unaffected — it stays in appearance
+ * order, because the chain walk consumes it right-to-left itself.</p>
  */
 final class RfcForwardedParser {
 
@@ -44,8 +50,8 @@ final class RfcForwardedParser {
     /**
      * The relevant directives pulled from a {@code Forwarded} header value.
      *
-     * @param proto     the first {@code proto} directive, if any
-     * @param host      the first {@code host} directive, if any
+     * @param proto     the last {@code proto} directive, if any
+     * @param host      the last {@code host} directive, if any
      * @param forValues the ordered {@code for} node identifiers (unquoted), possibly empty
      */
     record Parsed(Optional<String> proto, Optional<String> host, List<String> forValues) {
@@ -62,7 +68,7 @@ final class RfcForwardedParser {
     }
 
     /**
-     * Mutable accumulator that applies one {@code token=value} pair, keeping the first
+     * Mutable accumulator that applies one {@code token=value} pair, keeping the last
      * {@code proto}/{@code host} and appending every {@code for} in appearance order.
      */
     private static final class Accumulator {
@@ -82,8 +88,8 @@ final class RfcForwardedParser {
                 return;
             }
             switch (name) {
-                case "proto" -> proto = proto == null ? value : proto;
-                case "host" -> host = host == null ? value : host;
+                case "proto" -> proto = value;
+                case "host" -> host = value;
                 case "for" -> forValues.add(value);
                 default -> { /* ignore by, ext, and unknown directives */
                 }

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/package-info.java
@@ -46,10 +46,16 @@
  *
  * <h3>Secure by default</h3>
  * <p>The resolver is transport-agnostic (it consumes a {@link java.util.function.Function
- * Function&lt;String,String&gt;} header accessor, so no servlet/Jetty type leaks in) and
- * secure-by-default: with no allowlist and no explicit {@code trustAll} opt-in, client-supplied
- * forwarded values are ignored (never trusted), only logged. See
+ * Function&lt;String,java.util.List&lt;String&gt;&gt;} header accessor, so no servlet/Jetty type
+ * leaks in) and secure-by-default: with no allowlist and no explicit {@code trustAll} opt-in,
+ * client-supplied forwarded values are ignored (never trusted), only logged. See
  * {@link de.cuioss.http.forwarded.ForwardedResolverConfig} for the trust model.</p>
+ * <p>Transport-agnostic does <strong>not</strong> mean obligation-free. The accessor MUST return
+ * <em>every</em> instance of the named header, in wire order — a proxy appends by adding a repeated
+ * header just as legitimately as by extending a comma-separated value, so a single-valued accessor
+ * such as {@code request::getHeader} hides the nearest hop's contribution and leaves the resolver
+ * looking at the attacker's forged first instance. Use
+ * {@code name -> Collections.list(request.getHeaders(name))} or the equivalent for your transport.</p>
  *
  * <h3>Usage Example</h3>
  * <pre>{@code
@@ -60,7 +66,9 @@
  * ForwardedHeaderResolver resolver =
  *     new ForwardedHeaderResolver(config, new SecurityEventCounter());
  *
- * ResolvedForwarding forwarding = resolver.resolve(request::getHeader);
+ * // The accessor MUST expose every instance of a repeated header, not just the first:
+ * ResolvedForwarding forwarding =
+ *     resolver.resolve(name -> Collections.list(request.getHeaders(name)));
  * String scheme = forwarding.scheme().orElse("http");
  * String prefix = forwarding.contextPath(); // "" when none / not honored
  * }</pre>

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/package-info.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/package-info.java
@@ -60,8 +60,10 @@
  * <h3>Usage Example</h3>
  * <pre>{@code
  * ForwardedResolverConfig config = ForwardedResolverConfig.builder()
- *     .trustAll(true)                       // deployment sits fully behind a trusted proxy
- *     .trustedProxies(Set.of("10.0.0.0/8")) // for X-Forwarded-For client-IP resolution
+ *     .trustAll(true) // deployment sits fully behind a trusted proxy
+ *     // The ingress proxies themselves, never the enclosing network: every address in the range is
+ *     // skipped by the client-IP walk, so a non-proxy host inside it could spoof the client IP.
+ *     .trustedProxies(Set.of("10.0.7.10/32", "10.0.7.11/32"))
  *     .build();
  * ForwardedHeaderResolver resolver =
  *     new ForwardedHeaderResolver(config, new SecurityEventCounter());

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedAccessorContractTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedAccessorContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedAccessorContractTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedAccessorContractTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.test.juli.junit5.EnableTestLogger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Pins the {@link ForwardedHeaderResolver#resolve(Function)} accessor contract as executable
+ * behaviour: the accessor MUST return every instance of a repeated header, in wire order.
+ *
+ * <p>Each case is paired with a matched negative control — the same header set read through an
+ * under-supplying accessor that returns only the first instance. The control is what makes the
+ * caller obligation visible and non-optional: without it, an under-supplying accessor still
+ * "works" and simply resolves the attacker's value, which is indistinguishable from correct
+ * behaviour unless the two are asserted side by side.</p>
+ */
+@EnableTestLogger
+@DisplayName("ForwardedHeaderResolver accessor contract")
+class ForwardedAccessorContractTest {
+
+    /** A compliant accessor: returns every instance of the named header, in wire order. */
+    private static Function<String, List<String>> everyInstance(Map<String, List<String>> values) {
+        return new HashMap<>(values)::get;
+    }
+
+    /**
+     * An under-supplying accessor: exposes only the first instance, as a single-valued
+     * {@code request::getHeader} would. This is the shape the contract forbids.
+     */
+    private static Function<String, List<String>> firstInstanceOnly(Map<String, List<String>> values) {
+        Map<String, List<String>> copy = new HashMap<>(values);
+        return name -> {
+            List<String> instances = copy.get(name);
+            return instances == null || instances.isEmpty() ? null : List.of(instances.getFirst());
+        };
+    }
+
+    private static ForwardedHeaderResolver trustingResolver() {
+        ForwardedResolverConfig config = ForwardedResolverConfig.builder()
+                .trustAll(true)
+                .trustedProxies(Set.of("10.0.0.0/8"))
+                .build();
+        return new ForwardedHeaderResolver(config, new SecurityEventCounter());
+    }
+
+    @Nested
+    @DisplayName("Repeated X-Forwarded-For")
+    class RepeatedClientIpChain {
+
+        /**
+         * Append-style shape: the client forged the first instance before the request reached the
+         * proxy, and the proxy appended the second recording the real peer.
+         */
+        private static final Map<String, List<String>> APPEND_STYLE = Map.of(
+                "X-Forwarded-For", List.of("6.6.6.6", "203.0.113.7, 10.0.0.5"));
+
+        @Test
+        @DisplayName("returning every instance in wire order is the required caller contract: the proxy-attested client IP wins")
+        void everyInstanceResolvesProxyAttestedClient() {
+            var result = trustingResolver().resolve(everyInstance(APPEND_STYLE));
+
+            assertEquals("203.0.113.7", result.clientIp().orElseThrow(),
+                    "the nearest hop's appended instance must be visible to the resolver");
+        }
+
+        @Test
+        @DisplayName("negative control: an accessor returning only the first instance resolves the attacker's client IP")
+        void firstInstanceOnlyResolvesAttackerClient() {
+            var result = trustingResolver().resolve(firstInstanceOnly(APPEND_STYLE));
+
+            assertEquals("6.6.6.6", result.clientIp().orElseThrow(),
+                    "hiding the appended instance leaves only the forged one — the caller obligation is real");
+        }
+    }
+
+    @Nested
+    @DisplayName("Repeated X-Forwarded-Proto")
+    class RepeatedScheme {
+
+        private static final Map<String, List<String>> APPEND_STYLE = Map.of(
+                "X-Forwarded-Proto", List.of("https", "http"));
+
+        @Test
+        @DisplayName("returning every instance in wire order is the required caller contract: the nearest hop's scheme wins")
+        void everyInstanceResolvesNearestHopScheme() {
+            var result = trustingResolver().resolve(everyInstance(APPEND_STYLE));
+
+            assertEquals("http", result.scheme().orElseThrow(),
+                    "the appended instance is the nearest hop's scheme");
+        }
+
+        @Test
+        @DisplayName("negative control: an accessor returning only the first instance resolves the attacker's scheme")
+        void firstInstanceOnlyResolvesAttackerScheme() {
+            var result = trustingResolver().resolve(firstInstanceOnly(APPEND_STYLE));
+
+            assertEquals("https", result.scheme().orElseThrow(),
+                    "hiding the appended instance leaves only the forged one — the caller obligation is real");
+        }
+    }
+}

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
@@ -110,10 +110,11 @@ class ForwardedHeaderResolverTest {
         }
 
         @Test
-        @DisplayName("takes the first token of a comma-separated list")
-        void firstTokenOfList() {
-            assertEquals("https", trustAllResolver()
-                    .resolve(headers(Map.of("X-Forwarded-Proto", "https, http"))).scheme().orElseThrow());
+        @DisplayName("takes the last token of a comma-separated list")
+        void lastTokenOfList() {
+            assertEquals("http", trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Proto", "https, http"))).scheme().orElseThrow(),
+                    "the nearest hop appends last, so its scheme wins");
         }
 
         @Test
@@ -166,6 +167,23 @@ class ForwardedHeaderResolverTest {
                     "X-Forwarded-Host", "app.example.com:8443",
                     "X-Forwarded-Port", "9000")));
             assertEquals(9000, result.port().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("takes the last token of a comma-separated host list")
+        void lastHostTokenOfList() {
+            assertEquals("app.example.com", trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Host", "attacker.example, app.example.com")))
+                            .host().orElseThrow(),
+                    "the nearest hop appends last, so its host wins");
+        }
+
+        @Test
+        @DisplayName("takes the last token of a comma-separated port list")
+        void lastPortTokenOfList() {
+            assertEquals(9000, trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Port", "8443, 9000"))).port().orElseThrow(),
+                    "the nearest hop appends last, so its port wins");
         }
 
         @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
@@ -118,6 +118,27 @@ class ForwardedHeaderResolverTest {
         }
 
         @Test
+        @DisplayName("honors agreeing X-Forwarded-Proto and RFC 7239 proto")
+        void agreeingSourcesHonored() {
+            var result = trustAllResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Proto", "https",
+                    "Forwarded", "proto=https")));
+
+            assertEquals("https", result.scheme().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("drops the scheme and warns when the two sources disagree")
+        void disagreeingSourcesDropped() {
+            var result = trustAllResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Proto", "https",
+                    "Forwarded", "proto=http")));
+
+            assertTrue(result.scheme().isEmpty(), "a forged source must not win by precedence");
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "sources disagree");
+        }
+
+        @Test
         @DisplayName("drops a non-http(s) scheme")
         void dropsUnknownScheme() {
             assertTrue(trustAllResolver()
@@ -193,6 +214,27 @@ class ForwardedHeaderResolverTest {
                     .resolve(headers(Map.of("X-ProxyHost", "proxy.example.com"))).host().orElseThrow());
             assertEquals("rfc.example.com", trustAllResolver()
                     .resolve(headers(Map.of("Forwarded", "host=rfc.example.com"))).host().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("honors agreeing X-Forwarded-Host and RFC 7239 host")
+        void agreeingHostSourcesHonored() {
+            var result = trustAllResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Host", "app.example.com",
+                    "Forwarded", "host=app.example.com")));
+
+            assertEquals("app.example.com", result.host().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("drops the host and warns when the two sources disagree")
+        void disagreeingHostSourcesDropped() {
+            var result = trustAllResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Host", "app.example.com",
+                    "Forwarded", "host=attacker.example")));
+
+            assertTrue(result.host().isEmpty(), "a forged source must not win by precedence");
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "sources disagree");
         }
 
         @Test
@@ -352,6 +394,41 @@ class ForwardedHeaderResolverTest {
             var result = resolver(trustingProxies("10.0.0.0/8"))
                     .resolve(headers(Map.of("X-Forwarded-For", "203.0.113.7:51234, 10.0.0.5")));
             assertEquals("203.0.113.7", result.clientIp().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("honors agreeing X-Forwarded-For and RFC 7239 for chains")
+        void agreeingChainsHonored() {
+            var result = resolver(trustingProxies("10.0.0.0/8")).resolve(headers(Map.of(
+                    "X-Forwarded-For", "203.0.113.7, 10.0.0.5",
+                    "Forwarded", "for=203.0.113.7, for=\"10.0.0.5\"")));
+
+            assertEquals("203.0.113.7", result.clientIp().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("drops the client IP and warns when the two chains disagree")
+        void disagreeingChainsDropped() {
+            var result = resolver(trustingProxies("10.0.0.0/8")).resolve(headers(Map.of(
+                    "X-Forwarded-For", "203.0.113.7, 10.0.0.5",
+                    "Forwarded", "for=198.51.100.9, for=\"10.0.0.5\"")));
+
+            assertTrue(result.clientIp().isEmpty(),
+                    "disagreeing chains mean one is forged, so neither may be honored");
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "sources disagree");
+        }
+
+        @Test
+        @DisplayName("a single present chain is unaffected by the disagreement rule")
+        void singleSourceChainUnchanged() {
+            var fromXff = resolver(trustingProxies("10.0.0.0/8"))
+                    .resolve(headers(Map.of("X-Forwarded-For", "203.0.113.7, 10.0.0.5")));
+            var fromRfc = resolver(trustingProxies("10.0.0.0/8"))
+                    .resolve(headers(Map.of("Forwarded", "for=203.0.113.7, for=\"10.0.0.5\"")));
+
+            assertAll("single-source chains resolve independently",
+                    () -> assertEquals("203.0.113.7", fromXff.clientIp().orElseThrow()),
+                    () -> assertEquals("203.0.113.7", fromRfc.clientIp().orElseThrow()));
         }
 
         @Test

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
@@ -260,6 +260,29 @@ class ForwardedHeaderResolverTest {
         }
 
         @Test
+        @DisplayName("rejects a host carrying an embedded userinfo delimiter")
+        void rejectsHostWithUserinfoDelimiter() {
+            // "real-host@attacker.example" composed into "https://real-host@attacker.example/" is
+            // resolved by most URL parsers as userinfo "real-host" on host "attacker.example" —
+            // the same host-confusion class the path-separator guard already defends against.
+            assertTrue(trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Host", "real-host@attacker.example")))
+                    .host().isEmpty());
+        }
+
+        @Test
+        @DisplayName("rejects a host carrying an embedded fragment or query delimiter")
+        void rejectsHostWithFragmentOrQueryDelimiter() {
+            assertAll(
+                    () -> assertTrue(trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Host", "evil.com#attacker.example")))
+                            .host().isEmpty()),
+                    () -> assertTrue(trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Host", "evil.com?attacker.example")))
+                            .host().isEmpty()));
+        }
+
+        @Test
         @DisplayName("host and port are not honored without trustAll")
         void notHonoredWithoutTrustAll() {
             var result = resolver(ForwardedResolverConfig.secureDefault())

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
@@ -33,8 +33,12 @@ import static org.junit.jupiter.api.Assertions.*;
 @SuppressWarnings("java:S5778") // assertThrows lambdas intentionally wrap the whole failing call chain
 class ForwardedHeaderResolverTest {
 
-    private static Function<String, String> headers(Map<String, String> values) {
-        return new HashMap<>(values)::get;
+    private static Function<String, List<String>> headers(Map<String, String> values) {
+        Map<String, String> copy = new HashMap<>(values);
+        return name -> {
+            String value = copy.get(name);
+            return value == null ? null : List.of(value);
+        };
     }
 
     private static ForwardedHeaderResolver resolver(ForwardedResolverConfig config) {

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
@@ -483,6 +483,110 @@ class ForwardedHeaderResolverTest {
     }
 
     @Nested
+    @DisplayName("Forwarded header presence")
+    class ForwardedPresence {
+
+        /**
+         * A raw {@code Forwarded} value the header-value pipeline rejects outright (CRLF injection).
+         * The header WAS sent, so it must not be mistaken for an absent one.
+         */
+        private static final String REJECTED = "host=attacker.example\r\nInjected: 1";
+
+        private ForwardedHeaderResolver proxyAwareResolver() {
+            return resolver(ForwardedResolverConfig.builder()
+                    .trustAll(true)
+                    .trustedProxies(Set.of("10.0.0.0/8"))
+                    .build());
+        }
+
+        @Test
+        @DisplayName("an absent Forwarded header leaves the de-facto family honored")
+        void absentForwardedHonorsDeFacto() {
+            var result = proxyAwareResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Proto", "https",
+                    "X-Forwarded-Host", "app.example.com",
+                    "X-Forwarded-For", "203.0.113.7, 10.0.0.5")));
+
+            assertAll("no RFC source is present, so the de-facto family stands alone",
+                    () -> assertEquals("https", result.scheme().orElseThrow()),
+                    () -> assertEquals("app.example.com", result.host().orElseThrow()),
+                    () -> assertEquals("203.0.113.7", result.clientIp().orElseThrow()));
+        }
+
+        @Test
+        @DisplayName("an agreeing Forwarded header leaves the de-facto family honored")
+        void validForwardedHonorsAgreeingDeFacto() {
+            var result = proxyAwareResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Proto", "https",
+                    "X-Forwarded-Host", "app.example.com",
+                    "X-Forwarded-For", "203.0.113.7, 10.0.0.5",
+                    "Forwarded", "proto=https;host=app.example.com;for=203.0.113.7, for=\"10.0.0.5\"")));
+
+            assertAll("both sources resolve and agree",
+                    () -> assertEquals("https", result.scheme().orElseThrow()),
+                    () -> assertEquals("app.example.com", result.host().orElseThrow()),
+                    () -> assertEquals("203.0.113.7", result.clientIp().orElseThrow()));
+        }
+
+        @Test
+        @DisplayName("a sanitization-rejected Forwarded header drops every de-facto field it covers")
+        void rejectedForwardedDropsDeFactoFields() {
+            var result = proxyAwareResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Proto", "https",
+                    "X-Forwarded-Host", "app.example.com",
+                    "X-Forwarded-For", "203.0.113.7, 10.0.0.5",
+                    "Forwarded", REJECTED)));
+
+            assertAll("a present-but-unresolvable RFC source disagrees with every resolving sibling",
+                    () -> assertTrue(result.scheme().isEmpty(),
+                            "a rejected Forwarded header must not silently fall back to X-Forwarded-Proto"),
+                    () -> assertTrue(result.host().isEmpty(),
+                            "a rejected Forwarded header must not silently fall back to X-Forwarded-Host"),
+                    () -> assertTrue(result.clientIp().isEmpty(),
+                            "a rejected Forwarded header must not silently fall back to X-Forwarded-For"));
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "failed security sanitization");
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "sources disagree");
+        }
+
+        @Test
+        @DisplayName("a sanitization-rejected Forwarded header is not mistaken for an absent one")
+        void rejectedForwardedIsNotAbsent() {
+            var deFactoOnly = proxyAwareResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Host", "app.example.com")));
+            var withRejected = proxyAwareResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Host", "app.example.com",
+                    "Forwarded", REJECTED)));
+
+            assertAll("the two cases must not resolve identically",
+                    () -> assertEquals("app.example.com", deFactoOnly.host().orElseThrow()),
+                    () -> assertTrue(withRejected.host().isEmpty()),
+                    () -> assertNotEquals(deFactoOnly, withRejected));
+        }
+
+        @Test
+        @DisplayName("a well-formed Forwarded header lacking a directive keeps that field's de-facto value")
+        void absentDirectiveKeepsDeFactoFallback() {
+            var result = proxyAwareResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Proto", "https",
+                    "X-Forwarded-Host", "app.example.com",
+                    "Forwarded", "for=203.0.113.7")));
+
+            assertAll("a parsed header simply carrying no proto/host directive is not a disagreement",
+                    () -> assertEquals("https", result.scheme().orElseThrow()),
+                    () -> assertEquals("app.example.com", result.host().orElseThrow()));
+        }
+
+        @Test
+        @DisplayName("a sanitization-rejected Forwarded header alone yields nothing")
+        void rejectedForwardedAloneYieldsNothing() {
+            var result = proxyAwareResolver().resolve(headers(Map.of("Forwarded", REJECTED)));
+
+            assertEquals(ResolvedForwarding.empty(), result,
+                    "an unresolvable header contributes no value of its own");
+        }
+    }
+
+    @Nested
     @DisplayName("Round trip")
     class RoundTrip {
 

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedTrustBoundaryTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedTrustBoundaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedTrustBoundaryTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedTrustBoundaryTest.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.forwarded;
+
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.test.juli.LogAsserts;
+import de.cuioss.test.juli.TestLogLevel;
+import de.cuioss.test.juli.junit5.EnableTestLogger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression suite for the append-style proxy attack shapes against
+ * {@link ForwardedHeaderResolver}.
+ *
+ * <p>Every hop in a forwarded chain <em>appends</em>. An attacker who controls the original client
+ * therefore contributes the <em>leading</em> token (or the first repeated header line), and the
+ * trusted proxy contributes the trailing one. Each group below drives one attack shape and asserts
+ * that the proxy-attested value wins:</p>
+ * <ul>
+ *   <li><strong>FW-3</strong> — append-style scheme / host / port, in both the de-facto
+ *       {@code X-Forwarded-*} family and the RFC 7239 {@code Forwarded} header.</li>
+ *   <li><strong>FW-6</strong> — append-style {@code X-Forwarded-Prefix}, including the
+ *       protocol-relative and whitespace injection guards that must run against the selected
+ *       nearest-hop token rather than the whole raw value.</li>
+ *   <li><strong>FW-2</strong> — the fail-closed source-reconciliation guard: a disagreement between
+ *       the de-facto family and RFC 7239 drops the field, and agreeing / single-source inputs are
+ *       left untouched.</li>
+ *   <li><strong>FW-1</strong> — the same gaps re-run with the attacker's value on a <em>separate
+ *       header instance</em>, proving that the wire-order join and the nearest-hop token selection
+ *       compose end-to-end. This is the counterpart to {@link ForwardedAccessorContractTest}, which
+ *       pins the caller-side accessor obligation in isolation.</li>
+ *   <li><strong>Fail-closed chain walk</strong> — the all-hops-trusted and unparseable-hop
+ *       behaviours still yield no client IP, guarding against a regression that opens the chain walk
+ *       while the other gaps are closed.</li>
+ * </ul>
+ *
+ * <p>Every attack-shape test carries a matched negative control (a benign, agreeing or single-source
+ * input that must still resolve), so a blanket "always empty" regression cannot pass this suite. No
+ * test depends on DNS resolution, wall-clock time, or ordering between tests.</p>
+ */
+@EnableTestLogger
+@DisplayName("Forwarded trust boundary")
+class ForwardedTrustBoundaryTest {
+
+    private static final String PROXY_HOST = "app.example.com";
+    private static final String ATTACKER_HOST = "attacker.example";
+    private static final String TRUSTED_PROXY_RANGE = "10.0.0.0/8";
+    private static final String SOURCES_DISAGREE = "sources disagree";
+
+    /** Single-instance accessor: each header is present exactly once, as one comma-joined value. */
+    private static Function<String, List<String>> headers(Map<String, String> values) {
+        Map<String, String> copy = new HashMap<>(values);
+        return name -> {
+            String value = copy.get(name);
+            return value == null ? null : List.of(value);
+        };
+    }
+
+    /** Multi-instance accessor: exposes every repeated header line, in wire order. */
+    private static Function<String, List<String>> repeatedHeaders(Map<String, List<String>> values) {
+        return new HashMap<>(values)::get;
+    }
+
+    private static ForwardedHeaderResolver resolver(ForwardedResolverConfig config) {
+        return new ForwardedHeaderResolver(config, new SecurityEventCounter());
+    }
+
+    private static ForwardedHeaderResolver trustAllResolver() {
+        return resolver(ForwardedResolverConfig.builder().trustAll(true).build());
+    }
+
+    private static ForwardedHeaderResolver chainWalkingResolver() {
+        return resolver(ForwardedResolverConfig.builder()
+                .trustAll(true)
+                .trustedProxies(Set.of(TRUSTED_PROXY_RANGE))
+                .build());
+    }
+
+    @Nested
+    @DisplayName("FW-3 append-style scheme, host and port")
+    class AppendStyleSchemeHostPort {
+
+        @Test
+        @DisplayName("the X-Forwarded-* family resolves the proxy's appended token, not the attacker's leading one")
+        void xForwardedFamilyResolvesAppendedToken() {
+            var result = trustAllResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Proto", "https, http",
+                    "X-Forwarded-Host", ATTACKER_HOST + ", " + PROXY_HOST,
+                    "X-Forwarded-Port", "8443, 9000")));
+
+            assertAll("the nearest hop appends last, so its token wins for every field",
+                    () -> assertEquals("http", result.scheme().orElseThrow()),
+                    () -> assertEquals(PROXY_HOST, result.host().orElseThrow()),
+                    () -> assertEquals(9000, result.port().orElseThrow()));
+        }
+
+        @Test
+        @DisplayName("RFC 7239 resolves the proxy's appended element, not the attacker's leading one")
+        void rfc7239ResolvesAppendedElement() {
+            var result = trustAllResolver().resolve(headers(Map.of("Forwarded",
+                    "proto=https;host=" + ATTACKER_HOST + ":8443, proto=http;host=" + PROXY_HOST + ":9000")));
+
+            assertAll("the last proto/host directive is the nearest hop's, and its port carries through",
+                    () -> assertEquals("http", result.scheme().orElseThrow()),
+                    () -> assertEquals(PROXY_HOST, result.host().orElseThrow()),
+                    () -> assertEquals(9000, result.port().orElseThrow()));
+        }
+
+        @Test
+        @DisplayName("negative control: a benign single-token value is honored unchanged")
+        void benignSingleTokenHonored() {
+            var result = trustAllResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Proto", "http",
+                    "X-Forwarded-Host", PROXY_HOST,
+                    "X-Forwarded-Port", "9000")));
+
+            assertAll("without a prepended token there is nothing to strip",
+                    () -> assertEquals("http", result.scheme().orElseThrow()),
+                    () -> assertEquals(PROXY_HOST, result.host().orElseThrow()),
+                    () -> assertEquals(9000, result.port().orElseThrow()));
+        }
+    }
+
+    @Nested
+    @DisplayName("FW-6 append-style context-path prefix")
+    class AppendStylePrefix {
+
+        @Test
+        @DisplayName("resolves the proxy's appended prefix, not the attacker's leading one")
+        void appendedPrefixWins() {
+            var result = trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Prefix", "/app, /other")));
+
+            assertEquals("/other", result.contextPath(),
+                    "the nearest hop appends last, so its prefix wins");
+        }
+
+        @Test
+        @DisplayName("rejects an appended protocol-relative prefix and warns")
+        void appendedProtocolRelativePrefixRejected() {
+            var result = trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Prefix", "/app, //attacker.com")));
+
+            assertEquals("", result.contextPath(),
+                    "the guard must run against the selected token, not the whole raw value");
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN,
+                    "protocol-relative URL injection");
+        }
+
+        @Test
+        @DisplayName("rejects an appended prefix carrying whitespace")
+        void appendedWhitespacePrefixRejected() {
+            var result = trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Prefix", "/app, /oth er")));
+
+            assertEquals("", result.contextPath(),
+                    "a well-formed context path carries no whitespace");
+        }
+
+        @Test
+        @DisplayName("negative control: a benign single prefix is honored")
+        void benignSinglePrefixHonored() {
+            var result = trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Prefix", "/app")));
+
+            assertEquals("/app", result.contextPath());
+        }
+    }
+
+    @Nested
+    @DisplayName("FW-2 source disagreement")
+    class SourceDisagreement {
+
+        @Test
+        @DisplayName("drops the scheme and warns when RFC 7239 downgrades what X-Forwarded-Proto attests")
+        void downgradeAcrossSourcesDropsScheme() {
+            var result = trustAllResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Proto", "https",
+                    "Forwarded", "proto=http")));
+
+            assertTrue(result.scheme().isEmpty(),
+                    "a forged source must not win by precedence, in either direction");
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, SOURCES_DISAGREE);
+        }
+
+        @Test
+        @DisplayName("negative control: agreeing sources are honored")
+        void agreeingSourcesHonored() {
+            var result = trustAllResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Proto", "https",
+                    "Forwarded", "proto=https")));
+
+            assertEquals("https", result.scheme().orElseThrow(),
+                    "the guard must fire on disagreement only");
+        }
+
+        @Test
+        @DisplayName("negative control: a single present source is honored from either family")
+        void singleSourceHonored() {
+            var fromDeFacto = trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Proto", "https")));
+            var fromRfc = trustAllResolver()
+                    .resolve(headers(Map.of("Forwarded", "proto=http")));
+
+            assertAll("one present source cannot disagree with an absent one",
+                    () -> assertEquals("https", fromDeFacto.scheme().orElseThrow()),
+                    () -> assertEquals("http", fromRfc.scheme().orElseThrow()));
+        }
+    }
+
+    @Nested
+    @DisplayName("FW-1 repeated header lines")
+    class RepeatedHeaderLines {
+
+        @Test
+        @DisplayName("resolves the proxy's appended header instance for scheme, host and port")
+        void repeatedSchemeHostPortResolveAppendedInstance() {
+            var result = trustAllResolver().resolve(repeatedHeaders(Map.of(
+                    "X-Forwarded-Proto", List.of("https", "http"),
+                    "X-Forwarded-Host", List.of(ATTACKER_HOST, PROXY_HOST),
+                    "X-Forwarded-Port", List.of("8443", "9000"))));
+
+            assertAll("the wire-order join and the nearest-hop selection compose",
+                    () -> assertEquals("http", result.scheme().orElseThrow()),
+                    () -> assertEquals(PROXY_HOST, result.host().orElseThrow()),
+                    () -> assertEquals(9000, result.port().orElseThrow()));
+        }
+
+        @Test
+        @DisplayName("resolves the proxy's appended prefix instance")
+        void repeatedPrefixResolvesAppendedInstance() {
+            var result = trustAllResolver().resolve(repeatedHeaders(Map.of(
+                    "X-Forwarded-Prefix", List.of("/app", "/other"))));
+
+            assertEquals("/other", result.contextPath());
+        }
+
+        @Test
+        @DisplayName("rejects a protocol-relative prefix carried on an appended instance and warns")
+        void repeatedProtocolRelativePrefixRejected() {
+            var result = trustAllResolver().resolve(repeatedHeaders(Map.of(
+                    "X-Forwarded-Prefix", List.of("/app", "//attacker.com"))));
+
+            assertEquals("", result.contextPath());
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN,
+                    "protocol-relative URL injection");
+        }
+
+        @Test
+        @DisplayName("repeated Forwarded instances reconcile with an agreeing X-Forwarded-Proto")
+        void repeatedForwardedInstancesAgreeWithDeFactoFamily() {
+            var result = trustAllResolver().resolve(repeatedHeaders(Map.of(
+                    "X-Forwarded-Proto", List.of("http"),
+                    "Forwarded", List.of("proto=https", "proto=http"))));
+
+            assertEquals("http", result.scheme().orElseThrow(),
+                    "joining in wire order and taking the last directive is what makes the sources agree");
+        }
+
+        @Test
+        @DisplayName("drops the scheme when an appended Forwarded instance contradicts X-Forwarded-Proto")
+        void repeatedForwardedInstanceDisagreeingDropsScheme() {
+            var result = trustAllResolver().resolve(repeatedHeaders(Map.of(
+                    "X-Forwarded-Proto", List.of("http"),
+                    "Forwarded", List.of("proto=http", "proto=https"))));
+
+            assertTrue(result.scheme().isEmpty(),
+                    "the nearest-hop directive disagrees with the de-facto family, so the field is dropped");
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, SOURCES_DISAGREE);
+        }
+
+        @Test
+        @DisplayName("negative control: a single header instance is honored verbatim")
+        void singleInstanceHonored() {
+            var result = trustAllResolver().resolve(repeatedHeaders(Map.of(
+                    "X-Forwarded-Proto", List.of("https"),
+                    "X-Forwarded-Host", List.of(PROXY_HOST),
+                    "X-Forwarded-Prefix", List.of("/app"))));
+
+            assertAll("with no appended instance there is nothing to prefer",
+                    () -> assertEquals("https", result.scheme().orElseThrow()),
+                    () -> assertEquals(PROXY_HOST, result.host().orElseThrow()),
+                    () -> assertEquals("/app", result.contextPath()));
+        }
+    }
+
+    @Nested
+    @DisplayName("Fail-closed chain walk")
+    class FailClosedChainWalk {
+
+        @Test
+        @DisplayName("yields no client IP when every appended hop is a trusted proxy")
+        void everyHopTrustedYieldsNoClientIp() {
+            var result = chainWalkingResolver().resolve(repeatedHeaders(Map.of(
+                    "X-Forwarded-For", List.of("10.0.0.1", "10.0.0.5"))));
+
+            assertTrue(result.clientIp().isEmpty(),
+                    "a chain of only trusted proxies identifies no originating client");
+        }
+
+        @Test
+        @DisplayName("yields no client IP and warns when the nearest hop is unparseable")
+        void unparseableNearestHopYieldsNoClientIp() {
+            var result = chainWalkingResolver()
+                    .resolve(headers(Map.of("X-Forwarded-For", "203.0.113.7, garbage")));
+
+            assertTrue(result.clientIp().isEmpty(),
+                    "an unverifiable chain must not fall back to an earlier, attacker-supplied hop");
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "unparseable entry");
+        }
+
+        @Test
+        @DisplayName("positive control: the first untrusted hop from the right is resolved")
+        void untrustedHopResolves() {
+            var result = chainWalkingResolver()
+                    .resolve(headers(Map.of("X-Forwarded-For", "6.6.6.6, 203.0.113.7, 10.0.0.5")));
+
+            assertEquals("203.0.113.7", result.clientIp().orElseThrow(),
+                    "the chain walk is still open for a genuinely untrusted hop");
+        }
+    }
+}

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/RfcForwardedParserTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/RfcForwardedParserTest.java
@@ -57,11 +57,20 @@ class RfcForwardedParserTest {
     }
 
     @Test
-    @DisplayName("takes the first proto/host across elements")
-    void firstProtoWins() {
+    @DisplayName("takes the last proto across elements")
+    void lastProtoWins() {
         RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse("proto=https, proto=http");
 
-        assertEquals("https", parsed.proto().orElseThrow());
+        assertEquals("http", parsed.proto().orElseThrow(), "the nearest hop appends last, so its proto wins");
+    }
+
+    @Test
+    @DisplayName("takes the last host across elements")
+    void lastHostWins() {
+        RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse("host=attacker.example, host=app.example.com");
+
+        assertEquals("app.example.com", parsed.host().orElseThrow(),
+                "the nearest hop appends last, so its host wins");
     }
 
     @Test

--- a/doc/LogMessages.adoc
+++ b/doc/LogMessages.adoc
@@ -14,7 +14,7 @@ Module: `de.cuioss.http`
 LogMessages Classes:
 
 - `de.cuioss.http.client.HttpLogMessages` - HTTP client operations (HTTP-106–108, HTTP-110–115, HTTP-200–201)
-- `de.cuioss.http.forwarded.ForwardedLogMessages` - Forwarded / reverse-proxy header resolution (HTTP-120–123)
+- `de.cuioss.http.forwarded.ForwardedLogMessages` - Forwarded / reverse-proxy header resolution (HTTP-120–124)
 
 == HttpLogMessages
 
@@ -114,6 +114,11 @@ LogMessages Classes:
 |Forwarded
 |Ignoring client IP: forwarded chain carries an unparseable entry: %s
 |Logged when the forwarded chain contains an unparseable entry and client IP resolution is aborted. Parameters: sanitized chain entry.
+
+|HTTP-124
+|Forwarded
+|Dropping forwarded %s: sources disagree: %s resolves to %s but Forwarded resolves to %s
+|Logged when the de-facto X-Forwarded-* / X-Proxy* family and the RFC 7239 Forwarded header resolve a field to different values, so the field is dropped rather than letting either source win. Parameters: field name, de-facto header name, de-facto resolution, RFC 7239 resolution.
 |===
 
 == Notes

--- a/doc/adr/0001-Nearest-hop_token_selection_is_authoritative_for_forwarded_header_chains.adoc
+++ b/doc/adr/0001-Nearest-hop_token_selection_is_authoritative_for_forwarded_header_chains.adoc
@@ -1,0 +1,102 @@
+= ADR-0001: Nearest-hop token selection is authoritative for forwarded header chains
+:toc: left
+:toclevels: 2
+:sectnums:
+
+// adr-metadata
+// summary: The rightmost/nearest-hop token is authoritative for every field a comma-joined forwarding header contributes, uniformly across X-Forwarded-* and RFC 7239 Forwarded.
+// tags: security, trust-boundary, forwarded-headers, http
+// affects: cui-http
+// supersedes:
+// end-adr-metadata
+
+== Status
+
+Proposed
+
+== Context
+
+When a request passes through a chain of reverse proxies, several de-facto and
+standard headers — `X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Host`,
+`X-Forwarded-Port`, `X-Forwarded-Prefix`, and the RFC 7239 `Forwarded` header —
+carry a comma-separated list of values, one per hop, in append order.
+
+Only proxies inside a configured trusted range are vouched for. Any party in front
+of the first trusted proxy can freely prepend an arbitrary value before that proxy
+appends its own, so the leftmost entry in such a list is the attacker-controlled
+end under append-style proxies.
+
+A component resolving a request-origin fact from such a header must pick exactly
+one hop's value as authoritative. Which end of the list it reads from therefore
+decides whether it reads the attacker's value or the nearest trusted hop's. The
+choice is structural, and it must be made the same way for every field — a
+component that resolves the client IP from one end and the scheme from the other
+is exploitable in the direction it reads carelessly, however defensible each
+individual choice looks in isolation.
+
+== Decision
+
+**The nearest hop wins.** The rightmost — most recently appended — token in a
+comma-joined forwarding-header value is authoritative for every field the resolver
+derives: client IP, scheme, host, port, and context path. The rule applies
+uniformly across both header families, including the RFC 7239 `proto` and `host`
+directive accumulator, which keeps the last occurrence rather than the first.
+
+Token selection runs *before* the injection guards, not after. A guard that
+inspects the whole raw string rather than the selected token can be bypassed by a
+value whose dangerous part is not at the string's start — for example a prefix of
+`/app, //attacker.com`, which does not itself begin with `//` and so survives a
+protocol-relative check applied to the unselected string.
+
+== Consequences
+
+=== Positive
+
+* One uniform trust rule across every field and both header families; there is no
+  field for which a reader must remember a different direction.
+* Internal consistency with the client-IP chain walk, which already proceeds from
+  the nearest hop outward.
+* A value prepended by an attacker ahead of the first trusted proxy can never
+  become authoritative for any field.
+
+=== Negative
+
+* Any caller relying on the previous leftmost-token value is handed a different
+  value. This is a deliberate compatibility break.
+* Deployments using overwrite-style proxies see no change, so the break is
+  invisible to them — which makes it easy to under-estimate when advising others.
+
+=== Risks
+
+* The "rightmost equals nearest hop" invariant depends on list order actually
+  reflecting proxy-chain order. The resolver cannot verify this property; it is a
+  precondition on the deployment, not something the code can enforce.
+
+== Alternatives Considered
+
+**Keep leftmost-token selection and narrow the documented guarantee.** This would
+have left the code unchanged and instead stated in the Javadoc and the reference
+documentation that these fields require overwrite-style proxies. Rejected: it does
+not close the attack. Under an append-style proxy the resolver still silently
+resolves the attacker's value, and a documentation caveat does not stop code from
+doing that. The documented "must sit behind a trusted proxy" precondition is
+already satisfied by the attack — the request really did traverse the trusted
+proxy — so the precondition is necessary but not sufficient.
+
+**Make the selection direction configurable per deployment.** This would have
+added a knob letting each deployment declare its proxy style. Rejected: the
+correct direction is structural rather than a deployment preference, so the knob's
+only effect is to let an operator misconfigure trust onto the attacker-controlled
+end. It also doubles the surface to test and document for a decision that has
+exactly one secure answer.
+
+Both alternatives share a shape: they relocate a security decision from the code
+into either prose or configuration, leaving the insecure behaviour reachable.
+
+== References
+
+* xref:0002-Fail_closed_when_X-Forwarded-For_and_RFC_7239_Forwarded_disagree.adoc[ADR-0002: Fail closed when X-Forwarded-For and RFC 7239 Forwarded disagree]
+* xref:0003-Header_accessor_contract_must_expose_every_instance_of_a_repeated_header.adoc[ADR-0003: Header accessor contract must expose every instance of a repeated header]
+* `doc/forwarded-header-resolution.adoc` — header precedence and token selection
+* `de.cuioss.http.forwarded.ForwardedHeaderResolver` — class Javadoc
+* `de.cuioss.http.forwarded.RfcForwardedParser` — directive accumulator Javadoc

--- a/doc/adr/0002-Fail_closed_when_X-Forwarded-For_and_RFC_7239_Forwarded_disagree.adoc
+++ b/doc/adr/0002-Fail_closed_when_X-Forwarded-For_and_RFC_7239_Forwarded_disagree.adoc
@@ -1,0 +1,103 @@
+= ADR-0002: Fail closed when X-Forwarded-For and RFC 7239 Forwarded disagree
+:toc: left
+:toclevels: 2
+:sectnums:
+
+// adr-metadata
+// summary: A field resolves only when X-Forwarded-* and RFC 7239 Forwarded agree, or only one is present; disagreement — including a sanitization-rejected header — resolves empty rather than falling back to either source.
+// tags: security, trust-boundary, forwarded-headers, fail-closed
+// affects: cui-http
+// supersedes:
+// end-adr-metadata
+
+== Status
+
+Proposed
+
+== Context
+
+A resolver deriving request-origin facts from proxy-appended headers may see the
+same fact asserted by two independent header families: the de-facto
+`X-Forwarded-*` headers and the standardized RFC 7239 `Forwarded` header.
+
+Both families are equally writable by any party sitting between the client and the
+first trusted hop. An attacker who can reach the resolver at all can supply either
+or both. When both are present and disagree, the resolver must decide what to
+believe — and any *fixed* precedence answers that question in a way the attacker
+can predict and exploit.
+
+The failure is asymmetric in a way that makes it easy to miss. A deployment whose
+proxies manage only one family looks correct under either precedence rule, because
+the other family is simply absent. The vulnerability appears only when an attacker
+supplies the family the proxies do *not* manage — precisely the case the
+deployment's own configuration gives nobody a reason to test.
+
+== Decision
+
+**When the two families disagree, honour neither.**
+
+For each field independently — scheme, host, and client IP — the resolver derives
+a value from each family that is present. If both are present and the derived
+values differ, the field resolves as absent and the disagreement is logged. A
+request carrying only one family is unaffected, and so is a request whose two
+families agree.
+
+A header that is present but rejected by sanitization counts as *present and
+unresolvable*, not as absent. Collapsing "present but rejected" into "absent"
+would let the surviving family win by default, which is the same fail-open
+behaviour by another route: an attacker who can get one family rejected chooses
+which family is believed.
+
+The three states — absent, present-and-parsed, present-but-unresolvable — are
+therefore genuinely distinct in the implementation. A well-formed header that
+simply lacks a particular directive still falls back to the other family; only an
+unresolvable one forces the disagreement path.
+
+== Consequences
+
+=== Positive
+
+* No fixed precedence exists for an attacker to exploit. Reordering precedence
+  would merely relocate the same vulnerability rather than remove it.
+* Behaviour is unchanged for single-family deployments, which is the majority case.
+* No new configuration surface is introduced; there is nothing to misconfigure.
+
+=== Negative
+
+* A partially-upgraded proxy chain that legitimately emits disagreeing values now
+  resolves the field empty rather than picking one. The resolver cannot distinguish
+  this from an attack, and deliberately does not try.
+
+=== Risks
+
+* Because a sanitization-rejected header counts as disagreement, an operator who
+  leaves one family's value malformed loses the field entirely rather than falling
+  back to the other family — even though only one family was actually broken. This
+  is the intended direction of failure, but it can present as a puzzling empty
+  result rather than an obvious misconfiguration.
+
+== Alternatives Considered
+
+**Reorder precedence so `Forwarded` wins over `X-Forwarded-For`.** This would have
+preferred the standardized header over the de-facto one, which reads as the more
+principled ordering. Rejected: it inverts the exploit rather than removing it. An
+attacker past the trust boundary can supply `Forwarded` content exactly as easily
+as `X-Forwarded-For` content, so a fixed precedence in either direction hands the
+attacker a known-winning header to write.
+
+**Document the existing XFF-first precedence as intentional.** This would have
+declared the current behaviour a deliberate contract and described it in the
+Javadoc and reference documentation. Rejected: disclosing a fixed order does not
+stop its exploitation. A security-relevant precedence rule has to be structurally
+safe, not merely written down.
+
+The unifying reason both fail: they answer "which do we believe?" with a constant,
+and a constant is exactly what an attacker needs to know.
+
+== References
+
+* xref:0001-Nearest-hop_token_selection_is_authoritative_for_forwarded_header_chains.adoc[ADR-0001: Nearest-hop token selection is authoritative for forwarded header chains]
+* xref:0003-Header_accessor_contract_must_expose_every_instance_of_a_repeated_header.adoc[ADR-0003: Header accessor contract must expose every instance of a repeated header]
+* `doc/forwarded-header-resolution.adoc` — header precedence, sanitization
+* `de.cuioss.http.forwarded.ForwardedHeaderResolver` — precedence and present-but-invalid handling
+* `de.cuioss.http.forwarded.ForwardedLogMessages` — the sources-disagree WARN record

--- a/doc/adr/0003-Header_accessor_contract_must_expose_every_instance_of_a_repeated_header.adoc
+++ b/doc/adr/0003-Header_accessor_contract_must_expose_every_instance_of_a_repeated_header.adoc
@@ -1,0 +1,93 @@
+= ADR-0003: Header accessor contract must expose every instance of a repeated header
+:toc: left
+:toclevels: 2
+:sectnums:
+
+// adr-metadata
+// summary: The resolver's header-lookup accessor returns every instance of a repeated header in wire order, joined per RFC 7230, rather than a single first-seen value.
+// tags: security, trust-boundary, forwarded-headers, api-contract
+// affects: cui-http
+// supersedes:
+// end-adr-metadata
+
+== Status
+
+Proposed
+
+== Context
+
+HTTP permits a header field to appear as several separate header lines. RFC 7230
+§3.2.2 makes repeated instances of a list-valued field semantically identical to a
+single comma-joined value, so a receiver that reads only one instance is reading a
+truncated value, not an alternative rendering of the same one.
+
+An accessor typed to return a single string per header name can only ever surface
+one instance — typically the first, because that is what the common container APIs
+return. When a proxy chain appends by adding a *new* header line rather than
+extending the existing one, every hop after the first becomes invisible to such an
+accessor.
+
+The consequence is severe and easy to overlook: the resolver walks a chain it
+believes is complete while seeing only the attacker-controlled portion of it. No
+amount of care in the chain-walking algorithm helps, because the algorithm is
+correct — it is being handed the wrong input. The defect lives in the abstraction
+at the boundary, not in the logic behind it.
+
+== Decision
+
+**The accessor returns every instance.** The header-lookup function a caller
+supplies is typed to return a list of values for a header name — every instance,
+in wire order. The resolver joins them per RFC 7230 §3.2.2 exactly once, at the
+boundary, before any sanitization, injection guard, or token selection runs.
+
+Joining at the boundary is what keeps every downstream rule operating on the
+complete value. It also means the rest of the resolver needs no awareness of
+multi-instance headers at all: the private field resolvers continue to work on a
+single joined string.
+
+No single-value accessor contract is offered alongside it. Offering both would
+reintroduce exactly the ambiguity this decision removes.
+
+== Consequences
+
+=== Positive
+
+* The resolver sees the complete, wire-accurate value regardless of how a proxy
+  chain chose to write it.
+* Every other trust decision — nearest-hop selection, fail-closed reconciliation —
+  operates on the complete value rather than a silently truncated prefix.
+* The multi-instance concern is confined to one adapter at the boundary.
+
+=== Negative
+
+* Every caller must supply an accessor that surfaces all instances. This is a
+  breaking contract change with no deprecation path.
+* A caller migrating by wrapping a single-value lookup in a one-element list
+  compiles cleanly and silently reinstates the original gap.
+
+=== Risks
+
+* The contract is enforceable only by convention plus an executable contract test.
+  Nothing at the type level distinguishes a conforming accessor from one that
+  always returns a single-element list, so the test carries the whole weight: it
+  pins a compliant accessor and a deliberately under-supplying one as a matched
+  positive/negative control pair, and fails if the two produce the same result.
+
+== Alternatives Considered
+
+**Keep the single-value accessor and document that callers must join repeated
+instances themselves.** This would have avoided a breaking change and placed the
+obligation on the caller in prose. Rejected: the accessor's type signature cannot
+express "the caller has already joined this value", so a correctly-joining caller
+and one unknowingly passing only the first instance are indistinguishable — at the
+call site, and inside the resolver. Documentation cannot close a gap the
+abstraction is structurally unable to express, and the failure it leaves behind is
+silent rather than loud.
+
+== References
+
+* xref:0001-Nearest-hop_token_selection_is_authoritative_for_forwarded_header_chains.adoc[ADR-0001: Nearest-hop token selection is authoritative for forwarded header chains]
+* xref:0002-Fail_closed_when_X-Forwarded-For_and_RFC_7239_Forwarded_disagree.adoc[ADR-0002: Fail closed when X-Forwarded-For and RFC 7239 Forwarded disagree]
+* `doc/forwarded-header-resolution.adoc` — the header-accessor contract
+* `de.cuioss.http.forwarded.ForwardedHeaderResolver` — `resolve` parameter contract
+* `de.cuioss.http.forwarded.package-info` — secure-by-default guidance

--- a/doc/forwarded-header-resolution.adoc
+++ b/doc/forwarded-header-resolution.adoc
@@ -382,8 +382,8 @@ are quoted only when they are not a valid RFC 7239 token.
 [source,java]
 ----
 ForwardedResolverConfig config = ForwardedResolverConfig.builder()
-    .trustAll(true)                        // honor scheme/host/port + context-path
-    .trustedProxies(Set.of("10.0.0.0/8"))  // for X-Forwarded-For client-IP resolution
+    .trustAll(true)                                          // honor scheme/host/port + context-path
+    .trustedProxies(Set.of("10.0.7.10/32", "10.0.7.11/32"))  // the ingress proxies themselves
     .build();
 
 ForwardedHeaderResolver resolver =
@@ -399,6 +399,10 @@ int    port   = fwd.port().orElse(scheme.equals("https") ? 443 : 80);
 String prefix = fwd.contextPath();          // "" when none
 fwd.clientIp().ifPresent(ip -> log.info("client %s", ip));
 ----
+
+NOTE: `trustedProxies` lists the proxy machines themselves, never the enclosing network — see
+_Composing `trustedProxies`_ above. Widening this to the surrounding `10.0.0.0/8` would let any
+host inside that range spoof the client IP.
 
 === Context-path allowlist only (no trustAll)
 

--- a/doc/forwarded-header-resolution.adoc
+++ b/doc/forwarded-header-resolution.adoc
@@ -29,7 +29,7 @@ duplicated concerns of forwarded-header handling into one component:
   backslashes) — reusing the existing xref:security-readme.adoc[security validation pipelines]
   rather than hand-rolling guards.
 
-It is *transport-agnostic* (it consumes a `Function<String,String>` header accessor, so no
+It is *transport-agnostic* (it consumes a `Function<String, List<String>>` header accessor, so no
 servlet/Jetty type leaks in) and *secure-by-default* (nothing is honored unless a deployment opts
 in explicitly).
 
@@ -49,6 +49,13 @@ Enforce this with network controls — bind the listener to a private interface,
 firewall / security-group rules, or place it behind a service mesh — so that the socket peer is
 always a trusted proxy. The resolver cannot make this guarantee for you, and by design does not
 accept the peer address as a parameter.
+
+*The header accessor MUST expose every instance of a repeated header, in wire order.* A proxy
+appends by adding a repeated header line just as legitimately as by extending a comma-separated
+value, so a single-valued accessor built on `request.getHeader(name)` exposes only the *first*
+instance and hides the nearest hop's contribution — leaving the resolver looking at the attacker's
+forged value. Pass `name \-> Collections.list(request.getHeaders(name))`, or the equivalent
+all-instances accessor for your transport.
 ====
 
 === The header family
@@ -92,12 +99,29 @@ and a `SecurityEventCounter`; it internally builds a header-value sanitization p
 
 [source,java]
 ----
-ResolvedForwarding resolve(Function<String, String> headerLookup)
+ResolvedForwarding resolve(Function<String, List<String>> headerLookup)
 ----
 
-The `Function<String,String>` header accessor (typically `request::getHeader`) is the only input,
-so the resolver works with Jetty `Request`, `jakarta.servlet.HttpServletRequest`, or a plain
-`Map::get` in tests — without leaking any transport type.
+The `Function<String, List<String>>` header accessor is the only input, so the resolver works with
+Jetty `Request`, `jakarta.servlet.HttpServletRequest`, or a plain `Map<String, List<String>>` in
+tests — without leaking any transport type. The accessor maps a header name to *every* instance of
+that header present on the request, in wire order; `null` or an empty list means the header is
+absent.
+
+That multi-instance shape is a *security* requirement, not a convenience: the repeated instances are
+joined in wire order before nearest-hop token selection runs, so an accessor that returns only the
+first instance — anything built on `request.getHeader(name)` — hides the appended, proxy-attested
+value and resolves the attacker's forged one instead.
+
+[source,java]
+----
+// Servlet
+resolver.resolve(name -> Collections.list(request.getHeaders(name)));
+
+// Tests
+Map<String, List<String>> headers = Map.of("X-Forwarded-Proto", List.of("https", "http"));
+resolver.resolve(headers::get);
+----
 
 For each field the resolver:
 
@@ -133,9 +157,10 @@ Immutable trust-model configuration built through a validating builder. See xref
 
 === xref:../cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedLogMessages.java[ForwardedLogMessages]
 
-`HTTP-120`..`HTTP-123` WARN records for rejected/malformed values (context-path control
-characters, protocol-relative/backslash prefixes, values that failed sanitization, and
-unparseable client-IP chain entries).
+`HTTP-120`..`HTTP-124` WARN records for rejected/malformed values (context-path control
+characters, protocol-relative/backslash prefixes, values that failed sanitization, unparseable
+client-IP chain entries, and — `HTTP-124` — a field dropped because the de-facto `X-Forwarded-*`
+family and the RFC 7239 `Forwarded` header disagree).
 
 == Header precedence
 
@@ -152,7 +177,46 @@ Per field, the first present, non-blank value wins:
 | clientIp    | `X-Forwarded-For` chain → RFC 7239 `for` chain
 |===
 
-Comma-separated list headers (e.g. `X-Forwarded-Proto: https,http`) resolve to their first token.
+*Repeated header instances are joined in wire order before token selection.* A proxy appends by
+adding a repeated header line just as legitimately as by extending a comma-separated value, and
+RFC 7230 §3.2.2 makes the two forms equivalent. The resolver therefore joins every instance the
+accessor returns with `", "` in wire order, so a repeated header is indistinguishable from the
+equivalent single comma-separated header before any token selection runs.
+
+*Nearest hop wins within a header.* Each proxy in a chain *appends* its own value, so for a
+comma-separated header value the resolver selects the *rightmost* token — the one contributed by the
+closest, most trustworthy proxy. Leading tokens are attacker-supplied whenever the original client
+sent the header itself. The same rule applies across RFC 7239 elements: the *last* `proto` / `host`
+directive wins.
+
+[source,text]
+----
+X-Forwarded-Proto: https, http                    -> scheme = http            (nearest hop appended "http")
+X-Forwarded-Host:  attacker.example, app.internal -> host   = app.internal
+X-Forwarded-Prefix: /app, /other                  -> prefix = /other
+Forwarded: proto=https, proto=http                -> scheme = http            (last directive wins)
+----
+
+For the context-path the token selection must run *before* the injection guards, not after: a guard
+applied to the whole raw string inspects only its leading characters, so `X-Forwarded-Prefix: /app,
+//attacker.com` would pass the whole-string protocol-relative check and the nearest-hop token
+`//attacker.com` would then be honored unguarded. Selecting the last token first means every guard
+runs against the exact value that will be returned.
+
+*Conflicting sources = drop (fail closed).* For scheme, host, and client IP the de-facto
+`X-Forwarded-*` / `X-Proxy*` family and the RFC 7239 `Forwarded` header are resolved
+*independently*. When only one source is present its result is honored. When *both* are present they
+must agree: a proxy that populates both families does not contradict itself, so a disagreement means
+at least one side is forged. The field is then dropped and an `HTTP-124` warning logged, rather than
+letting the higher-precedence family silently win — preferring one source is precisely what an
+attacker exploits by supplying the family the resolver ranks higher.
+
+[source,text]
+----
+X-Forwarded-Proto: https + Forwarded: proto=https -> scheme = https  (sources agree)
+X-Forwarded-Proto: https + Forwarded: proto=http  -> scheme = empty  (sources disagree -> dropped)
+X-Forwarded-Proto: https                          -> scheme = https  (single source, unaffected)
+----
 
 *Present-but-invalid = drop (no fall-through).* Precedence selects the first present, non-blank
 source for a field; that value is then validated. If it fails its field guard it is *dropped* —
@@ -214,6 +278,41 @@ X-Forwarded-For: 10.0.0.1, 10.0.0.5                 -> clientIp = empty         
 (no trustedProxies configured)                       -> clientIp = empty         (nothing honored)
 ----
 
+==== Composing `trustedProxies` — a range must contain only proxies
+
+Membership of a `trustedProxies` range is a statement that the machine *is a proxy whose appended
+chain entry can be believed* — not merely that it is on a network you own. The walk *skips* every
+hop inside a configured range, so a range scoped to the enclosing VPC or office network rather than
+to the proxy tier itself fails in both directions:
+
+Too broad -> no client IP at all::
+A range wide enough to cover the whole network (or `0.0.0.0/0`) makes *every* hop trusted, so the
+walk skips the entire chain, falls off the left end, and returns empty. This fails closed — no
+forged address is ever honored — but it is counter-intuitive to operators debugging a missing
+client IP, who typically widen the range further and make the symptom worse.
+
+Too broad -> client-IP spoofing::
+A non-proxy machine that happens to fall inside a configured range is skipped by the walk exactly as
+a real proxy would be. Anything that machine *prepends* to the chain is then treated as an earlier,
+untrusted hop and returned as the client IP. One compromised or merely untrustworthy host inside the
+range is enough to spoof the client IP for every request it forwards.
+
+[source,text]
+----
+Deployment: ingress proxies at 10.0.7.10 and 10.0.7.11; application servers and a CI runner
+            share the 10.0.0.0/8 network.
+
+trustedProxies = [10.0.0.0/8]                       <1>
+X-Forwarded-For: 6.6.6.6, 10.0.3.99, 10.0.7.10      -> clientIp = 6.6.6.6   (spoofed by 10.0.3.99)
+
+trustedProxies = [10.0.7.10/32, 10.0.7.11/32]       <2>
+X-Forwarded-For: 6.6.6.6, 10.0.3.99, 10.0.7.10      -> clientIp = 10.0.3.99 (the real peer)
+----
+<1> Too broad: the CI runner at `10.0.3.99` is inside the range, so the walk skips it and honors the
+    entry it prepended.
+<2> Correctly scoped to the proxy tier: `10.0.3.99` is untrusted, so the walk stops there and
+    reports the address that actually connected to the proxy.
+
 == Sanitization and injection guards
 
 * Every honored value first passes through the header-value pipeline
@@ -249,8 +348,13 @@ ForwardedResolverConfig config = ForwardedResolverConfig.builder()
 
 The *field-specific* guards, by contrast, are fixed fail-secure invariants and are *not* affected
 by `securityConfig`: the context-path protocol-relative (`//`) and backslash rejection, the
-`http`/`https` scheme whitelist, the `1..65535` port range, and host-separator rejection always
-apply.
+context-path comma/whitespace rejection, the `http`/`https` scheme whitelist, the `1..65535` port
+range, and host-separator rejection always apply.
+
+The context-path comma/whitespace rejection is defence in depth: a well-formed context path
+contains neither, so their presence in a value that reached normalization means a comma-separated
+header value arrived without nearest-hop token selection having been applied — and normalizing such
+a value would honor an attacker-supplied token.
 
 == Serialization
 
@@ -285,7 +389,9 @@ ForwardedResolverConfig config = ForwardedResolverConfig.builder()
 ForwardedHeaderResolver resolver =
     new ForwardedHeaderResolver(config, new SecurityEventCounter());
 
-ResolvedForwarding fwd = resolver.resolve(request::getHeader);
+// The accessor MUST expose every instance of a repeated header, not just the first:
+ResolvedForwarding fwd =
+    resolver.resolve(name -> Collections.list(request.getHeaders(name)));
 
 String scheme = fwd.scheme().orElse("http");
 String host   = fwd.host().orElse(request.getServerName());
@@ -306,7 +412,9 @@ ForwardedResolverConfig config = ForwardedResolverConfig.builder()
 ForwardedHeaderResolver resolver =
     new ForwardedHeaderResolver(config, new SecurityEventCounter());
 
-String prefix = resolver.resolve(request::getHeader).contextPath();
+String prefix = resolver
+    .resolve(name -> Collections.list(request.getHeaders(name)))
+    .contextPath();
 ----
 
 The allowlist may also be parsed from an operator-supplied comma-separated string:
@@ -324,7 +432,8 @@ ForwardedHeaderResolver resolver = new ForwardedHeaderResolver(
     ForwardedResolverConfig.secureDefault(), new SecurityEventCounter());
 
 // Any forwarded header is ignored; result is ResolvedForwarding.empty()
-ResolvedForwarding fwd = resolver.resolve(request::getHeader);
+ResolvedForwarding fwd =
+    resolver.resolve(name -> Collections.list(request.getHeaders(name)));
 ----
 
 == Thread Safety


### PR DESCRIPTION
## Summary

Closes five trust-boundary gaps (FW-1, FW-2, FW-3, FW-6, FW-19) in
`de.cuioss.http.forwarded`'s header resolver, where header content reaching the
resolver could be attacker-influenced even behind a correctly-configured trusted
proxy. Also fixes a related host-confusion gap found during finalize security
audit.

> **Diff-size note for reviewers**: one commit,
> `chore(license): normalize copyright headers to "2025-present"`, touches 229
> files with exactly one changed line each. It is license-plugin churn produced
> by the mandated `verify -Ppre-commit` run and was deliberately isolated into
> its own commit so it can be skipped during review — the substantive changes
> below are all confined to `de.cuioss.http.forwarded`.

## Changes

- **FW-3 / FW-6** — Nearest-hop (rightmost) token selection for scheme, host,
  port, and context path in `ForwardedHeaderResolver.java`, and for the RFC 7239
  proto/host accumulator in `RfcForwardedParser.java`. Previously the leftmost
  (attacker-controlled, under append-style proxies) token won. In
  `resolveContextPath`, token selection now runs BEFORE the injection guards.
- **FW-2** — Scheme, host, and client-IP now resolve independently from the
  `X-Forwarded-*` and RFC 7239 `Forwarded` header families in
  `ForwardedHeaderResolver.java` and must agree; on disagreement the field is
  dropped and a new HTTP-124 WARN record is logged (`ForwardedLogMessages.java`).
- **FW-1 (BREAKING)** — The resolve accessor changed from
  `Function<String,String>` to `Function<String,List<String>>` so repeated
  header instances (append-style proxies emitting a second `X-Forwarded-For`
  line) are visible to the resolver. Instances are joined once per RFC 7230
  section 3.2.2.
- **FW-19** — Documented the trusted-range composition rule in
  `doc/forwarded-header-resolution.adoc`: `trustedProxies` ranges must contain
  only proxies, never end clients.
- **Security-audit finding (fixed during finalize)** — The host guard in
  `ForwardedHeaderResolver.java` now rejects the URL-authority delimiters `@`,
  `#`, and `?`, closing a userinfo host-confusion gap.

Regression tests for each resolved gap, including the append-style proxy shapes
that motivated this plan, live in `ForwardedHeaderResolverTest.java`,
`RfcForwardedParserTest.java`, `ForwardedTrustBoundaryTest.java`,
`ForwardedAccessorContractTest.java`, and `ForwardedResolverConfigTest.java`.

**Breaking change**: any caller invoking `resolve(request::getHeader)` (a
`Function<String,String>`) must switch to a `Function<String,List<String>>`
accessor.

## Test Plan

- [ ] Verification command passed (`verify -Ppre-commit`)
- [ ] Manual testing completed (if applicable)

## Related Issues

None.

---
Generated by plan-finalize skill

## Intent

**The problem.** `ForwardedHeaderResolver`'s chain-walk algorithm is correct and
fails closed, but the trust decision feeding it was inconsistent: every field
except the client IP picked the *leftmost* token out of a comma-joined header
value — the attacker-reachable end under an append-style proxy — the context
path picked no token at all, and the header-lookup abstraction could only ever
see the *first* instance of a repeated header line, so a proxy that appended
rather than overwrote was invisible. An attacker who can reach past the trusted
proxy (but not spoof it entirely) could therefore still control scheme, host,
port, and context path, and could hide a forged `X-Forwarded-For` line ahead of
the proxy's own.

**The chosen approach.** One coherent trust decision, applied uniformly: the
nearest hop wins. The token selection for scheme/host/port/context-path and the
RFC 7239 proto/host accumulator all switch from first-wins to last-wins, and
the header accessor now sees every instance of a repeated header (joined in
wire order per RFC 7230 §3.2.2) instead of only the first. Where the
`X-Forwarded-*` and RFC 7239 `Forwarded` families disagree on a field, the
resolver honors neither and logs a WARN rather than guessing. The accessor
signature change (`Function<String,String>` to
`Function<String,List<String>>`) is accepted as a breaking API change rather
than layered

_[Intent truncated — 1391 of 1987 characters shown; full outline in the plan workspace]_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forwarded headers now preserve and process repeated header values in wire order.
  * Resolution selects the nearest hop and reconciles standard and RFC 7239 sources.
* **Security & Reliability**
  * Conflicting or invalid forwarding data is discarded safely, with warnings recorded.
  * Added validation for unsafe host and context-path characters.
  * Improved trusted-proxy and client-IP spoofing protections.
* **Documentation**
  * Updated usage guidance, configuration requirements, and warning-message documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->