### PR TITLE
test(generators): add semantic assertions to generator contract tests

### DIFF
--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/AllGeneratorsIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/AllGeneratorsIntegrationTest.java
@@ -61,21 +61,6 @@ class AllGeneratorsIntegrationTest {
     private final AttackCookieGenerator attackCookieGenerator = new AttackCookieGenerator();
 
     @Test
-    void shouldHaveAllGeneratorsImplemented() {
-        // Verify all generators are instantiated and functional (now using framework-compliant variants)
-        assertNotNull(pathTraversalGenerator);
-        assertNotNull(encodingGenerator);
-        assertNotNull(unicodeGenerator);
-        assertNotNull(boundaryGenerator);
-        assertNotNull(validUrlGenerator);
-        assertNotNull(invalidUrlGenerator);
-        assertNotNull(validParameterGenerator);
-        assertNotNull(attackParameterGenerator);
-        assertNotNull(validCookieGenerator);
-        assertNotNull(attackCookieGenerator);
-    }
-
-    @Test
     void shouldReturnCorrectTypes() {
         assertEquals(String.class, pathTraversalGenerator.getType());
         assertEquals(String.class, encodingGenerator.getType());

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/GeneratorContractAssertions.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/GeneratorContractAssertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/GeneratorContractAssertions.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/GeneratorContractAssertions.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.security.generators;
+
+import de.cuioss.http.security.core.HttpSecurityValidator;
+import de.cuioss.http.security.exceptions.UrlSecurityException;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Shared vocabularies and assertions for the generator contract tests.
+ *
+ * <p>Every generator contract test in {@code de.cuioss.http.security.generators} asserts a
+ * <em>defining property</em> of the values its generator emits — the property that makes the
+ * value an instance of the attack (or of the legitimate input) the generator advertises.
+ * Those properties are expressed against a small number of marker vocabularies, and this class
+ * is the single place they are declared, so that the vocabularies are not copy-pasted across
+ * the contract test population.</p>
+ *
+ * <h3>Traceability</h3>
+ *
+ * <p>Every marker declared here is emitted by a concrete branch of a generator in this tree;
+ * the vocabularies are closed sets, not speculative catalogues. In particular
+ * {@link #TRAVERSAL_MARKERS} carries the two <em>literal escape-text</em> forms
+ * &#92;u002e and &#92;ufe0e: {@code PathTraversalGenerator.generateUnicodeTraversal()} and
+ * {@code generateAdvancedTraversal()} case 4 append the six-character escape <em>text</em> to
+ * their output, not the decoded character, so a contract assertion must look for the text.</p>
+ *
+ * <h3>Pipeline round-trip</h3>
+ *
+ * <p>{@link #assertPipelineAccepts(HttpSecurityValidator, String)} and
+ * {@link #assertPipelineRejects(HttpSecurityValidator, String)} express the stronger contract
+ * available to generators whose every branch is unambiguously legitimate (accepts) or
+ * unambiguously an attack (rejects). Generators that mix the two — or that emit escape text
+ * rather than decoded characters — assert marker properties only.</p>
+ *
+ * @since 1.0
+ */
+public final class GeneratorContractAssertions {
+
+    /**
+     * Substrings that mark a value as a path-traversal payload, as actually emitted by the
+     * path-traversal generators in this tree.
+     */
+    public static final Set<String> TRAVERSAL_MARKERS = Set.of(
+            "../",
+            "..\\",
+            "%2e%2e",
+            "%2E%2E",
+            "%252e%252e",
+            "%252E%252E",
+            "..%2f",
+            "..%2F",
+            "..%5c",
+            "..%5C",
+            "....",
+            "%c0%ae",
+            "%C0%AE",
+            "\\u002e",
+            "\\ufe0e");
+
+    /**
+     * Substrings that mark a value as a null-byte injection payload: the raw null byte and its
+     * percent-encoded form.
+     */
+    public static final Set<String> NULL_BYTE_MARKERS = Set.of("\0", "%00");
+
+    /**
+     * Substrings that mark a value as a CRLF injection payload: the raw carriage return and line
+     * feed, plus their percent-encoded forms in both letter cases.
+     */
+    public static final Set<String> CRLF_MARKERS = Set.of("\r", "\n", "%0d", "%0a", "%0D", "%0A");
+
+    /**
+     * Shell metacharacters used by the boundary-fuzzing contract to recognise command-injection
+     * payloads.
+     */
+    public static final Set<String> SHELL_METACHARACTERS = Set.of("|", ";", "`", "$", ">");
+
+    private GeneratorContractAssertions() {
+        // utility class
+    }
+
+    /**
+     * Determines whether the value carries a control character, that is any character in the
+     * range U+0000 to U+001F.
+     *
+     * @param value the value to inspect, must not be null
+     * @return {@code true} when at least one character of {@code value} is a control character
+     */
+    public static boolean containsControlCharacter(String value) {
+        return value.chars().anyMatch(c -> c <= 0x1F);
+    }
+
+    /**
+     * Asserts that the value contains at least one of the given markers.
+     *
+     * @param value the generated value under test, must not be null
+     * @param markers the closed set of markers, at least one of which must occur in {@code value}
+     * @param description names the contract being asserted; it is prefixed to the failure message
+     */
+    public static void assertContainsAny(String value, Set<String> markers, String description) {
+        boolean found = markers.stream().anyMatch(value::contains);
+        assertTrue(found, () -> description + " — value contains none of the expected markers. Value: <"
+                + value + ">, expected any of: " + markers);
+    }
+
+    /**
+     * Asserts that the pipeline accepts the value, that is it neither throws nor discards it.
+     *
+     * @param pipeline the validation pipeline under test
+     * @param value the generated value that the pipeline must accept
+     */
+    public static void assertPipelineAccepts(HttpSecurityValidator pipeline, String value) {
+        Optional<String> result = assertDoesNotThrow(() -> pipeline.validate(value),
+                () -> "Pipeline must accept the generated value. Value: <" + value + ">");
+        assertTrue(result.isPresent(),
+                () -> "Pipeline must return a value for the accepted input. Value: <" + value + ">");
+    }
+
+    /**
+     * Asserts that the pipeline rejects the value with a {@link UrlSecurityException} that reports
+     * the value as its original input.
+     *
+     * @param pipeline the validation pipeline under test
+     * @param value the generated value that the pipeline must reject
+     */
+    public static void assertPipelineRejects(HttpSecurityValidator pipeline, String value) {
+        UrlSecurityException exception = assertThrows(UrlSecurityException.class,
+                () -> pipeline.validate(value),
+                () -> "Pipeline must reject the generated value. Value: <" + value + ">");
+        assertEquals(value, exception.getOriginalInput(),
+                "Rejection must report the generated value as its original input");
+    }
+}

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/GeneratorContractAssertions.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/GeneratorContractAssertions.java
@@ -73,6 +73,7 @@ public final class GeneratorContractAssertions {
             "%c0%ae",
             "%C0%AE",
             "..%c0%af",
+            "..%00",
             "\\u002e",
             "\\ufe0e");
 

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/GeneratorContractAssertions.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/GeneratorContractAssertions.java
@@ -111,6 +111,18 @@ public final class GeneratorContractAssertions {
     }
 
     /**
+     * Truncates a generated value for inclusion in a failure message, so an overlong attack
+     * payload does not flood the test report.
+     *
+     * @param value the value to preview, must not be null
+     * @return {@code value} unchanged when its length is at most 80, otherwise its first 80
+     *         characters followed by {@code "..."}
+     */
+    public static String preview(String value) {
+        return value.length() <= 80 ? value : value.substring(0, 80) + "...";
+    }
+
+    /**
      * Asserts that the value contains at least one of the given markers.
      *
      * @param value the generated value under test, must not be null

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/GeneratorContractAssertions.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/GeneratorContractAssertions.java
@@ -72,6 +72,7 @@ public final class GeneratorContractAssertions {
             "....",
             "%c0%ae",
             "%C0%AE",
+            "..%c0%af",
             "\\u002e",
             "\\ufe0e");
 

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGeneratorTest.java
@@ -233,8 +233,4 @@ class AttackCookieGeneratorTest {
                 || NEGATIVE_MAX_AGE_ATTRIBUTE.equals(attributes)
                 || MALFORMED_ATTRIBUTES.contains(attributes);
     }
-
-    private String preview(String value) {
-        return value.length() <= 80 ? value : value.substring(0, 80) + "...";
-    }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGeneratorTest.java
@@ -19,37 +19,222 @@ import de.cuioss.http.security.data.Cookie;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test for {@link AttackCookieGenerator}
- * Tests framework-compliant generator for malicious cookie attack patterns.
+ * Contract test for {@link AttackCookieGenerator}.
+ *
+ * <p>The defining property of this generator is that every emitted cookie is malicious in both
+ * its value and its attributes: the value carries a payload from one of the eleven documented
+ * attack families (or is a length attack in its own right), and the attributes carry a hostile
+ * domain, a traversal path, an injected header, a negative max-age or a malformed form.</p>
+ *
+ * <p>The aggregate tests assert that all four name-attack families and all eleven value-attack
+ * families are reachable, each identified by the literal payload its branch emits.</p>
  */
 @EnableGeneratorController
+@DisplayName("AttackCookieGenerator Contract Tests")
 class AttackCookieGeneratorTest {
+
+    private static final int AGGREGATE_DRAWS = 400;
+
+    /** Below this length a value must carry a content marker; at or above it, length is the attack. */
+    private static final int LENGTH_ATTACK_THRESHOLD = 5000;
+
+    private static final Set<String> MALICIOUS_NAMES = Set.of(
+            "", "   ", "cookie with spaces", "cookie=equals",
+            "cookie;semicolon", "cookie,comma", "cookie[bracket]");
+
+    private static final Set<String> SPECIAL_CHAR_NAMES = Set.of(
+            "cookie{brace}", "cookie|pipe", "cookie\\backslash", "cookie\"quote", "cookie'apostrophe");
+
+    private static final Set<String> CONTROL_CHAR_NAMES = Set.of(
+            "cookie\ttab", "cookie\nnewline", "cookie\rcarriage");
+
+    private static final String VERY_LONG_NAME_PREFIX = "very_long_cookie_name_";
+
+    private static final String NAME_FAMILY_MALICIOUS = "malicious";
+    private static final String NAME_FAMILY_SPECIAL_CHAR = "special-character";
+    private static final String NAME_FAMILY_CONTROL_CHAR = "control-character";
+    private static final String NAME_FAMILY_VERY_LONG = "very-long";
+
+    private static final Set<String> ALL_NAME_FAMILIES = Set.of(
+            NAME_FAMILY_MALICIOUS, NAME_FAMILY_SPECIAL_CHAR,
+            NAME_FAMILY_CONTROL_CHAR, NAME_FAMILY_VERY_LONG);
+
+    private static final String VALUE_FAMILY_XSS = "xss";
+    private static final String VALUE_FAMILY_SQL = "sql-injection";
+    private static final String VALUE_FAMILY_TRAVERSAL = "path-traversal";
+    private static final String VALUE_FAMILY_NULL_BYTE = "null-byte";
+    private static final String VALUE_FAMILY_JNDI = "jndi-lookup";
+    private static final String VALUE_FAMILY_HEADER_INJECTION = "header-injection";
+    private static final String VALUE_FAMILY_UNICODE = "bidi-override";
+    private static final String VALUE_FAMILY_CONTROL_CHAR = "control-character";
+    private static final String VALUE_FAMILY_VERY_LONG = "very-long";
+    private static final String VALUE_FAMILY_JAVASCRIPT = "javascript-protocol";
+    private static final String VALUE_FAMILY_DATA_URL = "data-url";
+
+    private static final Set<String> ALL_VALUE_FAMILIES = Set.of(
+            VALUE_FAMILY_XSS, VALUE_FAMILY_SQL, VALUE_FAMILY_TRAVERSAL, VALUE_FAMILY_NULL_BYTE,
+            VALUE_FAMILY_JNDI, VALUE_FAMILY_HEADER_INJECTION, VALUE_FAMILY_UNICODE,
+            VALUE_FAMILY_CONTROL_CHAR, VALUE_FAMILY_VERY_LONG, VALUE_FAMILY_JAVASCRIPT,
+            VALUE_FAMILY_DATA_URL);
+
+    private static final List<String> XSS_TAGS = List.of("<script>", "<img>", "<iframe>", "<object>");
+    private static final List<String> SQL_COMMANDS = List.of("DROP TABLE", "DELETE FROM", "INSERT INTO");
+    private static final String JNDI_PREFIX = "${jndi:ldap://";
+
+    /**
+     * U+202E RIGHT-TO-LEFT OVERRIDE, spelled as a code point rather than as a literal so the
+     * marker cannot silently reorder the surrounding source text in an editor.
+     */
+    private static final String BIDI_OVERRIDE = Character.toString(0x202E);
+    private static final String JAVASCRIPT_PREFIX = "javascript:";
+    private static final String DATA_URL_PREFIX = "data:text/html,";
+
+    /** The control-character value attack emits exactly these three forms. */
+    private static final Set<String> CONTROL_CHAR_VALUES = Set.of(
+            "\t injected", "\r injected", "\n injected");
+
+    private static final List<String> HOSTILE_DOMAINS = List.of(
+            ".evil.com", ".attacker.net", ".malicious.org");
+    private static final String TRAVERSAL_PATH_ATTRIBUTE = "Path=../../../";
+    private static final String NEGATIVE_MAX_AGE_ATTRIBUTE = "Max-Age=-1";
+
+    /** The malformed-attribute branch emits exactly these four forms. */
+    private static final Set<String> MALFORMED_ATTRIBUTES = Set.of(
+            "Domain=; Path=", "Invalid=Attribute; Bad=Value", "Domain=", "=; Path=/");
 
     @ParameterizedTest
     @TypeGeneratorSource(value = AttackCookieGenerator.class, count = 100)
-    @DisplayName("Generator should produce valid attack cookies")
-    void shouldGenerateValidOutput(Cookie generatedValue) {
+    @DisplayName("Every generated cookie carries a malicious value and malicious attributes")
+    void shouldGenerateMaliciousCookie(Cookie generatedValue) {
         assertNotNull(generatedValue, "Generator must not produce null values");
         assertNotNull(generatedValue.name(), "Cookie name should not be null");
-        assertNotNull(generatedValue.value(), "Cookie value should not be null");
-        assertNotNull(generatedValue.attributes(), "Cookie attributes should not be null");
 
-        // Attack cookies may have empty names for malicious testing
-        // Validate cookie structure
-        String toString = generatedValue.toString();
-        assertTrue(toString.contains("Cookie"), "toString should contain record name");
+        assertFalse(valueFamiliesOf(generatedValue.value()).isEmpty(),
+                () -> "Cookie value must carry an attack payload from one of the eleven documented "
+                        + "families, or be a length attack of at least " + LENGTH_ATTACK_THRESHOLD
+                        + " characters. Value: <" + preview(generatedValue.value()) + ">");
 
-        // Test equals and hashCode work (records auto-generate these)
-        Cookie duplicate = new Cookie(generatedValue.name(), generatedValue.value(), generatedValue.attributes());
-        assertEquals(generatedValue, duplicate, "Equal cookies should be equal");
-        assertEquals(generatedValue.hashCode(), duplicate.hashCode(), "Equal cookies should have same hash code");
+        assertTrue(isMaliciousAttributes(generatedValue.attributes()),
+                () -> "Cookie attributes must carry a malicious marker. Attributes: <"
+                        + generatedValue.attributes() + ">");
+    }
 
-        // Since this is for attack cookie testing, any non-null output serves
-        // the security testing purpose
+    @Test
+    @DisplayName("Should reach all four name-attack families")
+    void shouldReachAllNameAttackFamilies() {
+        assertEquals(ALL_NAME_FAMILIES, drawFamilies(cookie -> nameFamilyOf(cookie.name())),
+                "Every name-attack family must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should reach all eleven value-attack families")
+    void shouldReachAllValueAttackFamilies() {
+        AttackCookieGenerator generator = new AttackCookieGenerator();
+        Set<String> reached = new HashSet<>();
+        for (int draw = 0; draw < AGGREGATE_DRAWS; draw++) {
+            reached.addAll(valueFamiliesOf(generator.next().value()));
+        }
+
+        assertEquals(ALL_VALUE_FAMILIES, reached,
+                "Every value-attack family must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(Cookie.class, new AttackCookieGenerator().getType(),
+                "Generator should return Cookie.class");
+    }
+
+    private Set<String> drawFamilies(Function<Cookie, String> classifier) {
+        AttackCookieGenerator generator = new AttackCookieGenerator();
+        Set<String> reached = new HashSet<>();
+        for (int draw = 0; draw < AGGREGATE_DRAWS; draw++) {
+            reached.add(classifier.apply(generator.next()));
+        }
+        return reached;
+    }
+
+    private String nameFamilyOf(String name) {
+        if (name.startsWith(VERY_LONG_NAME_PREFIX)) {
+            return NAME_FAMILY_VERY_LONG;
+        }
+        if (CONTROL_CHAR_NAMES.contains(name)) {
+            return NAME_FAMILY_CONTROL_CHAR;
+        }
+        if (SPECIAL_CHAR_NAMES.contains(name)) {
+            return NAME_FAMILY_SPECIAL_CHAR;
+        }
+        assertTrue(MALICIOUS_NAMES.contains(name),
+                () -> "Cookie name belongs to no documented name-attack family: <" + name + ">");
+        return NAME_FAMILY_MALICIOUS;
+    }
+
+    /**
+     * Returns every documented value-attack family the value matches. A value can legitimately
+     * match more than one — the data-url branch embeds a script tag, and the header-injection
+     * branch emits a raw CRLF — so the result is a set rather than a single verdict.
+     */
+    private Set<String> valueFamiliesOf(String value) {
+        Set<String> families = new HashSet<>();
+        if (XSS_TAGS.stream().anyMatch(value::contains)) {
+            families.add(VALUE_FAMILY_XSS);
+        }
+        if (SQL_COMMANDS.stream().anyMatch(value::contains)) {
+            families.add(VALUE_FAMILY_SQL);
+        }
+        if (TRAVERSAL_MARKERS.stream().anyMatch(value::contains)) {
+            families.add(VALUE_FAMILY_TRAVERSAL);
+        }
+        if (NULL_BYTE_MARKERS.stream().anyMatch(value::contains)) {
+            families.add(VALUE_FAMILY_NULL_BYTE);
+        }
+        if (value.contains(JNDI_PREFIX)) {
+            families.add(VALUE_FAMILY_JNDI);
+        }
+        if (CRLF_MARKERS.stream().anyMatch(value::contains)) {
+            families.add(VALUE_FAMILY_HEADER_INJECTION);
+        }
+        if (value.contains(BIDI_OVERRIDE)) {
+            families.add(VALUE_FAMILY_UNICODE);
+        }
+        if (CONTROL_CHAR_VALUES.contains(value)) {
+            families.add(VALUE_FAMILY_CONTROL_CHAR);
+        }
+        if (value.length() >= LENGTH_ATTACK_THRESHOLD) {
+            families.add(VALUE_FAMILY_VERY_LONG);
+        }
+        if (value.startsWith(JAVASCRIPT_PREFIX)) {
+            families.add(VALUE_FAMILY_JAVASCRIPT);
+        }
+        if (value.startsWith(DATA_URL_PREFIX)) {
+            families.add(VALUE_FAMILY_DATA_URL);
+        }
+        return families;
+    }
+
+    private boolean isMaliciousAttributes(String attributes) {
+        return HOSTILE_DOMAINS.stream().anyMatch(attributes::contains)
+                || attributes.equals(TRAVERSAL_PATH_ATTRIBUTE)
+                || CRLF_MARKERS.stream().anyMatch(attributes::contains)
+                || NULL_BYTE_MARKERS.stream().anyMatch(attributes::contains)
+                || attributes.equals(NEGATIVE_MAX_AGE_ATTRIBUTE)
+                || MALFORMED_ATTRIBUTES.contains(attributes);
+    }
+
+    private String preview(String value) {
+        return value.length() <= 80 ? value : value.substring(0, 80) + "...";
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGeneratorTest.java
@@ -227,10 +227,10 @@ class AttackCookieGeneratorTest {
 
     private boolean isMaliciousAttributes(String attributes) {
         return HOSTILE_DOMAINS.stream().anyMatch(attributes::contains)
-                || attributes.equals(TRAVERSAL_PATH_ATTRIBUTE)
+                || TRAVERSAL_PATH_ATTRIBUTE.equals(attributes)
                 || CRLF_MARKERS.stream().anyMatch(attributes::contains)
                 || NULL_BYTE_MARKERS.stream().anyMatch(attributes::contains)
-                || attributes.equals(NEGATIVE_MAX_AGE_ATTRIBUTE)
+                || NEGATIVE_MAX_AGE_ATTRIBUTE.equals(attributes)
                 || MALFORMED_ATTRIBUTES.contains(attributes);
     }
 

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/ValidCookieGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/ValidCookieGeneratorTest.java
@@ -19,36 +19,143 @@ import de.cuioss.http.security.data.Cookie;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test for {@link ValidCookieGenerator}
- * Tests framework-compliant generator for legitimate cookie patterns.
+ * Contract test for {@link ValidCookieGenerator}.
+ *
+ * <p>The defining property of this generator is legitimacy: the name and value are cookie tokens
+ * carrying no attack marker of any kind, and the attributes are either absent or a well-formed
+ * semicolon-separated list drawn from the seven attributes RFC 6265 defines. Asserting the
+ * <em>absence</em> of traversal, null-byte, CRLF and control-character markers is what makes this
+ * the counterpart of {@link AttackCookieGeneratorTest} rather than a shape check.</p>
  */
 @EnableGeneratorController
+@DisplayName("ValidCookieGenerator Contract Tests")
 class ValidCookieGeneratorTest {
+
+    private static final int AGGREGATE_DRAWS = 400;
+
+    /** A legitimate cookie name and value stay inside the unreserved token alphabet. */
+    private static final Pattern COOKIE_TOKEN = Pattern.compile("[A-Za-z0-9_]+");
+
+    private static final String SECURE = "Secure";
+    private static final String HTTP_ONLY = "HttpOnly";
+
+    /** Attributes carrying no value; anything else must be a {@code Name=Value} pair. */
+    private static final Set<String> FLAG_ATTRIBUTES = Set.of(SECURE, HTTP_ONLY);
+
+    private static final List<String> VALUED_ATTRIBUTE_PREFIXES = List.of(
+            "Domain=", "Path=", "SameSite=", "Max-Age=", "Expires=");
+
+    /** The generator must emit at least this many distinct names to be worth calling a generator. */
+    private static final int MINIMUM_DISTINCT_NAMES = 10;
 
     @ParameterizedTest
     @TypeGeneratorSource(value = ValidCookieGenerator.class, count = 100)
-    @DisplayName("Generator should produce valid cookies")
-    void shouldGenerateValidOutput(Cookie generatedValue) {
+    @DisplayName("Every generated cookie is a legitimate token pair with well-formed attributes")
+    void shouldGenerateLegitimateCookie(Cookie generatedValue) {
         assertNotNull(generatedValue, "Generator must not produce null values");
-        assertNotNull(generatedValue.name(), "Cookie name should not be null");
-        assertNotNull(generatedValue.value(), "Cookie value should not be null");
-        assertNotNull(generatedValue.attributes(), "Cookie attributes should not be null");
 
-        // Validate name is not empty for valid cookies
-        assertFalse(generatedValue.name().isEmpty(), "Cookie name should not be empty");
+        String name = generatedValue.name();
+        String value = generatedValue.value();
 
-        // Validate cookie structure
-        String toString = generatedValue.toString();
-        assertTrue(toString.contains("Cookie"), "toString should contain record name");
+        assertFalse(name.isEmpty(), "Cookie name should not be empty");
+        assertTrue(COOKIE_TOKEN.matcher(name).matches(),
+                () -> "Cookie name must be a token of [A-Za-z0-9_]. Name: <" + name + ">");
+        assertTrue(COOKIE_TOKEN.matcher(value).matches(),
+                () -> "Cookie value must be a token of [A-Za-z0-9_]. Value: <" + value + ">");
 
-        // Test equals and hashCode work (records auto-generate these)
-        Cookie duplicate = new Cookie(generatedValue.name(), generatedValue.value(), generatedValue.attributes());
-        assertEquals(generatedValue, duplicate, "Equal cookies should be equal");
-        assertEquals(generatedValue.hashCode(), duplicate.hashCode(), "Equal cookies should have same hash code");
+        assertCarriesNoAttackMarker(name, "Cookie name");
+        assertCarriesNoAttackMarker(value, "Cookie value");
+
+        assertWellFormedAttributes(generatedValue.attributes());
+    }
+
+    @Test
+    @DisplayName("Should reach at least ten distinct names and both security flags")
+    void shouldReachDistinctNamesAndSecurityFlags() {
+        ValidCookieGenerator generator = new ValidCookieGenerator();
+        Set<String> names = new HashSet<>();
+        boolean secureSeen = false;
+        boolean httpOnlySeen = false;
+
+        for (int draw = 0; draw < AGGREGATE_DRAWS; draw++) {
+            Cookie cookie = generator.next();
+            names.add(cookie.name());
+            List<String> attributes = splitAttributes(cookie.attributes());
+            secureSeen |= attributes.contains(SECURE);
+            httpOnlySeen |= attributes.contains(HTTP_ONLY);
+        }
+
+        boolean secureReached = secureSeen;
+        boolean httpOnlyReached = httpOnlySeen;
+        assertAll("Generator variety across " + AGGREGATE_DRAWS + " draws",
+                () -> assertTrue(names.size() >= MINIMUM_DISTINCT_NAMES,
+                        () -> "Expected at least " + MINIMUM_DISTINCT_NAMES
+                                + " distinct cookie names but got " + names.size() + ": " + names),
+                () -> assertTrue(secureReached, "The Secure attribute must be reachable"),
+                () -> assertTrue(httpOnlyReached, "The HttpOnly attribute must be reachable"));
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(Cookie.class, new ValidCookieGenerator().getType(),
+                "Generator should return Cookie.class");
+    }
+
+    private void assertCarriesNoAttackMarker(String component, String description) {
+        assertAll(description + " must carry no attack marker: <" + component + ">",
+                () -> assertNoneContained(component, TRAVERSAL_MARKERS, description, "traversal"),
+                () -> assertNoneContained(component, NULL_BYTE_MARKERS, description, "null-byte"),
+                () -> assertNoneContained(component, CRLF_MARKERS, description, "CRLF"),
+                () -> assertFalse(containsControlCharacter(component),
+                        () -> description + " must carry no control character: <" + component + ">"));
+    }
+
+    private void assertNoneContained(String component, Set<String> markers, String description, String kind) {
+        markers.stream()
+                .filter(component::contains)
+                .findFirst()
+                .ifPresent(marker -> fail(description + " must carry no " + kind + " marker, but contains <"
+                        + marker + ">: <" + component + ">"));
+    }
+
+    private void assertWellFormedAttributes(String attributes) {
+        if (attributes.isEmpty()) {
+            return;
+        }
+        for (String attribute : splitAttributes(attributes)) {
+            assertTrue(isValidAttribute(attribute),
+                    () -> "Attribute <" + attribute + "> is not one of the documented cookie attributes "
+                            + FLAG_ATTRIBUTES + " / " + VALUED_ATTRIBUTE_PREFIXES
+                            + ". Attributes: <" + attributes + ">");
+        }
+    }
+
+    private boolean isValidAttribute(String attribute) {
+        if (FLAG_ATTRIBUTES.contains(attribute)) {
+            return true;
+        }
+        return VALUED_ATTRIBUTE_PREFIXES.stream()
+                .anyMatch(prefix -> attribute.startsWith(prefix) && attribute.length() > prefix.length());
+    }
+
+    private List<String> splitAttributes(String attributes) {
+        if (attributes.isEmpty()) {
+            return List.of();
+        }
+        return Arrays.stream(attributes.split(";")).map(String::trim).toList();
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/BoundaryFuzzingGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/BoundaryFuzzingGeneratorTest.java
@@ -18,29 +18,115 @@ package de.cuioss.http.security.generators.encoding;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test for {@link BoundaryFuzzingGenerator}
+ * Contract test for {@link BoundaryFuzzingGenerator}.
+ *
+ * <p>The defining property of this generator is that every emitted value pushes at least one of
+ * six documented boundaries: extreme length, extreme nesting depth, a null byte, a control
+ * character, a path traversal, or a shell metacharacter. The aggregate test asserts that all six
+ * branch families are reachable, each identified by the exact shape its branch emits.</p>
+ *
+ * <p>There is deliberately no per-value pipeline round-trip: the boundary families are not
+ * uniformly rejected — a merely long path is not by itself an attack — so a uniform "the
+ * pipeline rejects it" assertion would not hold.</p>
  */
 @EnableGeneratorController
+@DisplayName("BoundaryFuzzingGenerator Contract Tests")
 class BoundaryFuzzingGeneratorTest {
+
+    private static final int AGGREGATE_DRAWS = 400;
+    private static final int EXTREME_LENGTH = 1000;
+    private static final int EXTREME_NESTING_SLASHES = 50;
+
+    /** U+001F, built numerically so that this source file carries no raw control character. */
+    private static final String UNIT_SEPARATOR = Character.toString(0x001F);
+
+    private static final Pattern LONG_PATH = Pattern.compile("^/(verylongpathsegment/)+$");
+    private static final Pattern DEEP_NESTING = Pattern.compile("^(dir/)+$");
+    private static final Pattern MIXED_TRAVERSAL = Pattern.compile("^(\\.\\./)+etc/passwd$");
+    private static final Pattern MIXED_LONG_SEGMENTS = Pattern.compile("^/a(verylongpathsegment/)+$");
+    private static final Pattern MIXED_NULL_TRAVERSAL = Pattern.compile("^/%00(\\.\\./)+$");
+    private static final String MIXED_MULTIPLE_NULLS = "/\0/../\0/../file";
+
+    private static final Set<String> NULL_BYTE_PATTERNS = Set.of(
+            "/file\0.txt", "/admin%00.php", "../etc/passwd%00.jpg", "file.jsp%00.png", "%00../../etc/shadow");
+    private static final Set<String> CONTROL_CHARACTER_PATTERNS = Set.of(
+            "/file\r\n.txt", "/path\t\tfile", "/dir\b\bfile", "/test" + UNIT_SEPARATOR + "file");
+    private static final Set<String> SPECIAL_CHARACTER_PATTERNS = Set.of(
+            "/file|command", "/file;command", "/file`command`", "/file$variable", "/file>output");
 
     @ParameterizedTest
     @TypeGeneratorSource(value = BoundaryFuzzingGenerator.class, count = 200)
-    @DisplayName("Generator should produce valid boundary fuzzing patterns")
-    void shouldGenerateValidOutput(String generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
-        assertFalse(generatedValue.isEmpty(), "Generated value should not be empty");
+    @DisplayName("Every generated value pushes at least one documented boundary")
+    void shouldGenerateBoundaryCase(String generatedValue) {
+        assertFalse(generatedValue.isEmpty(), "Generator should produce non-empty boundary cases");
+        assertTrue(pushesADocumentedBoundary(generatedValue),
+                () -> "Value pushes no documented boundary. Value: <" + generatedValue + ">");
+    }
 
-        // Boundary fuzzing patterns should have various characteristics
-        // Could be very long, contain special characters, control characters, null bytes, etc.
-        assertFalse(generatedValue.isEmpty(), "Pattern should have content");
+    @Test
+    @DisplayName("Should reach all six documented branch families")
+    void shouldReachAllBranchFamilies() {
+        BoundaryFuzzingGenerator generator = new BoundaryFuzzingGenerator();
+        Set<String> families = new HashSet<>();
 
-        // Since this is for boundary fuzzing testing, any non-null, non-empty output serves
-        // the security testing purpose
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            String value = generator.next();
+            if (LONG_PATH.matcher(value).matches()) {
+                families.add("long-path");
+            }
+            if (DEEP_NESTING.matcher(value).matches()) {
+                families.add("deep-nesting");
+            }
+            if (NULL_BYTE_PATTERNS.contains(value)) {
+                families.add("null-bytes");
+            }
+            if (CONTROL_CHARACTER_PATTERNS.contains(value)) {
+                families.add("control-characters");
+            }
+            if (isMixedBoundaryAttack(value)) {
+                families.add("mixed");
+            }
+            if (SPECIAL_CHARACTER_PATTERNS.contains(value)) {
+                families.add("special-characters");
+            }
+        }
+
+        assertEquals(Set.of("long-path", "deep-nesting", "null-bytes", "control-characters",
+                        "mixed", "special-characters"), families,
+                "Every documented branch family must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(String.class, new BoundaryFuzzingGenerator().getType(),
+                "Generator should return String.class");
+    }
+
+    private static boolean pushesADocumentedBoundary(String value) {
+        return value.length() >= EXTREME_LENGTH
+                || value.chars().filter(character -> character == '/').count() >= EXTREME_NESTING_SLASHES
+                || NULL_BYTE_MARKERS.stream().anyMatch(value::contains)
+                || containsControlCharacter(value)
+                || TRAVERSAL_MARKERS.stream().anyMatch(value::contains)
+                || SHELL_METACHARACTERS.stream().anyMatch(value::contains);
+    }
+
+    private static boolean isMixedBoundaryAttack(String value) {
+        return MIXED_TRAVERSAL.matcher(value).matches()
+                || MIXED_LONG_SEGMENTS.matcher(value).matches()
+                || MIXED_NULL_TRAVERSAL.matcher(value).matches()
+                || MIXED_MULTIPLE_NULLS.equals(value);
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/EncodingCombinationGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/EncodingCombinationGenerator.java
@@ -111,10 +111,13 @@ public class EncodingCombinationGenerator implements TypedGenerator<String> {
     }
 
     private String urlEncode(String input) {
-        // URL encode with %25 for % in multi-level
-        return input.replace(".", "%2e")
-                .replace("/", "%2f")
-                .replace("%", "%25");
+        // The literal percent character must be escaped FIRST. Escaping it last would rewrite
+        // the percent characters that the dot and slash replacements just introduced, so a
+        // single application would already yield %252e%252e%252f and the advertised level-1
+        // output would be unreachable.
+        return input.replace("%", "%25")
+                .replace(".", "%2e")
+                .replace("/", "%2f");
     }
 
     private String applyMixedCase(String input) {

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/EncodingCombinationGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/EncodingCombinationGeneratorTest.java
@@ -15,28 +15,148 @@
  */
 package de.cuioss.http.security.generators.encoding;
 
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.pipeline.URLPathValidationPipeline;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.assertPipelineRejects;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test for {@link EncodingCombinationGenerator}
+ * Contract test for {@link EncodingCombinationGenerator}.
+ *
+ * <p>The defining property of this generator is that every emitted value is a percent-encoded
+ * traversal: it carries an encoded dot, and decoding it back to a fixed point yields one of the
+ * documented traversal shapes. Because every value is a genuine traversal payload, the per-value
+ * pipeline round-trip applies.</p>
+ *
+ * <p>The aggregate test asserts that all three encoding levels are reachable, that the mixed-case
+ * variant is observable, and that all five decoded base-pattern shapes are reachable. The shapes
+ * rather than the branches are asserted because the branches are not distinguishable from the
+ * output: the Windows branch and the backslash arm of the simple branch emit the same value, as
+ * do the deep and custom-depth branches.</p>
  */
 @EnableGeneratorController
+@DisplayName("EncodingCombinationGenerator Contract Tests")
 class EncodingCombinationGeneratorTest {
+
+    private static final int AGGREGATE_DRAWS = 400;
+    private static final int MAX_DECODE_ROUNDS = 8;
+
+    /** The encoded dot as it appears at each of the three advertised encoding levels. */
+    private static final List<String> ENCODED_DOT_FORMS =
+            List.of("%2e", "%2E", "%252e", "%252E", "%25252e");
+    private static final Pattern TRAVERSAL_SHAPE = Pattern.compile("^(\\.\\.[/\\\\])+$");
+
+    private static final Pattern SINGLE_FORWARD = Pattern.compile("^\\.\\./$");
+    private static final Pattern SINGLE_BACKSLASH = Pattern.compile("^\\.\\.\\\\$");
+    private static final Pattern MIXED_SEPARATOR = Pattern.compile("^\\.\\./\\.\\.\\\\\\.\\./$");
+    private static final Pattern DEEP_FORWARD = Pattern.compile("^(\\.\\./){2,}$");
+    private static final Pattern DEEP_BACKSLASH = Pattern.compile("^(\\.\\.\\\\){2,}$");
 
     @ParameterizedTest
     @TypeGeneratorSource(value = EncodingCombinationGenerator.class, count = 100)
-    @DisplayName("Generator should produce valid encoding combination patterns")
-    void shouldGenerateValidOutput(String generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
-        assertFalse(generatedValue.isEmpty(), "Generated value should not be empty");
+    @DisplayName("Every generated value is a percent-encoded traversal the pipeline rejects")
+    void shouldGenerateEncodedTraversal(String generatedValue) {
+        assertTrue(ENCODED_DOT_FORMS.stream().anyMatch(generatedValue::contains),
+                () -> "Value must carry an encoded dot from " + ENCODED_DOT_FORMS
+                        + ". Value: <" + generatedValue + ">");
 
-        // Since this is for encoding combination testing, any non-null, non-empty output serves
-        // the security testing purpose
+        String decoded = decodeToFixedPoint(generatedValue);
+        assertTrue(TRAVERSAL_SHAPE.matcher(decoded).matches(),
+                () -> "Fully decoded value must be a traversal. Value: <" + generatedValue
+                        + ">, decoded: <" + decoded + ">");
+
+        assertPipelineRejects(
+                new URLPathValidationPipeline(SecurityConfiguration.defaults(), new SecurityEventCounter()),
+                generatedValue);
+    }
+
+    @Test
+    @DisplayName("Should reach all three encoding levels and the mixed-case variant")
+    void shouldReachAllEncodingLevels() {
+        EncodingCombinationGenerator generator = new EncodingCombinationGenerator();
+        Set<String> levels = new HashSet<>();
+        boolean mixedCaseObserved = false;
+
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            String value = generator.next();
+            if (value.contains("%25252e")) {
+                levels.add("level-3");
+            } else if (value.contains("%252e") || value.contains("%252E")) {
+                levels.add("level-2");
+            } else if (value.contains("%2e") || value.contains("%2E")) {
+                levels.add("level-1");
+            }
+            mixedCaseObserved |= value.contains("%2E");
+        }
+
+        boolean mixedCaseSeen = mixedCaseObserved;
+        assertAll("Encoding levels",
+                () -> assertEquals(Set.of("level-1", "level-2", "level-3"), levels,
+                        "Every advertised encoding level must be reachable"),
+                () -> assertTrue(mixedCaseSeen,
+                        "The mixed-case encoding variant must be observable"));
+    }
+
+    @Test
+    @DisplayName("Should reach all five decoded base-pattern shapes")
+    void shouldReachAllBasePatternShapes() {
+        EncodingCombinationGenerator generator = new EncodingCombinationGenerator();
+        Set<String> shapes = new HashSet<>();
+
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            String decoded = decodeToFixedPoint(generator.next());
+            if (SINGLE_FORWARD.matcher(decoded).matches()) {
+                shapes.add("single-forward");
+            }
+            if (SINGLE_BACKSLASH.matcher(decoded).matches()) {
+                shapes.add("single-backslash");
+            }
+            if (MIXED_SEPARATOR.matcher(decoded).matches()) {
+                shapes.add("mixed-separator");
+            }
+            if (DEEP_FORWARD.matcher(decoded).matches()) {
+                shapes.add("deep-forward");
+            }
+            if (DEEP_BACKSLASH.matcher(decoded).matches()) {
+                shapes.add("deep-backslash");
+            }
+        }
+
+        assertEquals(Set.of("single-forward", "single-backslash", "mixed-separator",
+                        "deep-forward", "deep-backslash"), shapes,
+                "Every decoded base-pattern shape must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(String.class, new EncodingCombinationGenerator().getType(),
+                "Generator should return String.class");
+    }
+
+    private static String decodeToFixedPoint(String value) {
+        String current = value;
+        for (int round = 0; round < MAX_DECODE_ROUNDS; round++) {
+            String decoded = URLDecoder.decode(current, StandardCharsets.UTF_8);
+            if (decoded.equals(current)) {
+                return decoded;
+            }
+            current = decoded;
+        }
+        return current;
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/PathTraversalGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/PathTraversalGeneratorTest.java
@@ -25,8 +25,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.TRAVERSAL_MARKERS;
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.assertContainsAny;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Contract test for {@link PathTraversalGenerator}.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/PathTraversalGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/PathTraversalGeneratorTest.java
@@ -18,25 +18,92 @@ package de.cuioss.http.security.generators.encoding;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test for {@link PathTraversalGenerator}
+ * Contract test for {@link PathTraversalGenerator}.
+ *
+ * <p>The defining property of this generator is that every emitted value carries a traversal
+ * marker. The Unicode arms contribute the <em>literal escape text</em> forms of the marker
+ * vocabulary rather than decoded characters, because
+ * {@link PathTraversalGenerator} builds them from doubled backslashes.</p>
+ *
+ * <p>There is deliberately no per-value pipeline round-trip: those literal escape-text values
+ * are ordinary printable text to a validator, so a uniform "the pipeline rejects it" assertion
+ * would not hold.</p>
+ *
+ * <p>The generator's seven attack types deliberately share encodings — the mixed arm re-emits
+ * the basic, encoded and Unicode forms — so the aggregate test asserts reachability of one
+ * literal signature per attack type rather than attempting to attribute each value back to the
+ * branch that produced it.</p>
  */
 @EnableGeneratorController
+@DisplayName("PathTraversalGenerator Contract Tests")
 class PathTraversalGeneratorTest {
+
+    private static final int AGGREGATE_DRAWS = 400;
+
+    private static final List<String> BASIC_SIGNATURES = List.of("../", "..\\");
+    private static final List<String> ENCODED_SIGNATURES = List.of("%2e%2e%2f", "%2e%2e%5c");
+    private static final List<String> DOUBLE_ENCODED_SIGNATURES = List.of("%252e%252e");
+    /** Escape text with an escaped separator, emitted only by {@code generateUnicodeTraversal}. */
+    private static final List<String> UNICODE_LITERAL_SIGNATURES =
+            List.of("\\u002e\\u002e\\u002f", "\\u002e\\u002e\\u005c");
+    /** Escape text with a raw separator, emitted only by the mixed arm. */
+    private static final List<String> MIXED_SIGNATURES =
+            List.of("\\u002e\\u002e/", "\\u002e\\u002e\\");
+    private static final List<String> NULL_BYTE_SIGNATURES = List.of("%00");
+    private static final List<String> ADVANCED_SIGNATURES =
+            List.of("....", "%c0%ae%c0%ae%c0%af", "\\ufe0e\\ufe0e\\u2044", "/var/www/", "C:\\inetpub\\wwwroot\\");
 
     @ParameterizedTest
     @TypeGeneratorSource(value = PathTraversalGenerator.class, count = 100)
-    @DisplayName("Generator should produce valid path traversal patterns")
-    void shouldGenerateValidOutput(String generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
-        assertFalse(generatedValue.isEmpty(), "Generated value should not be empty");
+    @DisplayName("Every generated value carries a traversal marker")
+    void shouldGeneratePathTraversal(String generatedValue) {
+        assertContainsAny(generatedValue, TRAVERSAL_MARKERS, "Path traversal value");
+    }
 
-        // Since this is for path traversal testing, any non-null, non-empty output serves
-        // the security testing purpose
+    @Test
+    @DisplayName("Should reach a signature of all seven documented attack types")
+    void shouldReachAllAttackTypes() {
+        PathTraversalGenerator generator = new PathTraversalGenerator();
+        Set<String> attackTypes = new HashSet<>();
+
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            String value = generator.next();
+            recordIfMatched(attackTypes, "basic", value, BASIC_SIGNATURES);
+            recordIfMatched(attackTypes, "encoded", value, ENCODED_SIGNATURES);
+            recordIfMatched(attackTypes, "double-encoded", value, DOUBLE_ENCODED_SIGNATURES);
+            recordIfMatched(attackTypes, "unicode-literal", value, UNICODE_LITERAL_SIGNATURES);
+            recordIfMatched(attackTypes, "mixed", value, MIXED_SIGNATURES);
+            recordIfMatched(attackTypes, "null-byte", value, NULL_BYTE_SIGNATURES);
+            recordIfMatched(attackTypes, "advanced", value, ADVANCED_SIGNATURES);
+        }
+
+        assertEquals(Set.of("basic", "encoded", "double-encoded", "unicode-literal",
+                        "mixed", "null-byte", "advanced"), attackTypes,
+                "Every documented attack type must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(String.class, new PathTraversalGenerator().getType(),
+                "Generator should return String.class");
+    }
+
+    private static void recordIfMatched(Set<String> attackTypes, String attackType,
+            String value, List<String> signatures) {
+        if (signatures.stream().anyMatch(value::contains)) {
+            attackTypes.add(attackType);
+        }
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeAttackGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeAttackGeneratorTest.java
@@ -18,25 +18,99 @@ package de.cuioss.http.security.generators.encoding;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.util.HashSet;
+import java.util.Set;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.assertContainsAny;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test for {@link UnicodeAttackGenerator}
+ * Contract test for {@link UnicodeAttackGenerator}.
+ *
+ * <p>The defining property of this generator is that every emitted value carries one of the six
+ * attack code points it documents, optionally suffixed with a traversal to a sensitive path.
+ * The aggregate test asserts that all six code points and both output forms — the bare code
+ * point and the traversal-suffixed composite — are reachable.</p>
+ *
+ * <p>There is deliberately no per-value pipeline round-trip: a bare zero-width or bidi-override
+ * code point is not per se a pipeline rejection, so a uniform "the pipeline rejects it"
+ * assertion would not hold.</p>
+ *
+ * <p>The attack code points are built from numeric code points rather than written as literals,
+ * so that this source file stays plain ASCII and carries no invisible or direction-overriding
+ * character of its own.</p>
  */
 @EnableGeneratorController
+@DisplayName("UnicodeAttackGenerator Contract Tests")
 class UnicodeAttackGeneratorTest {
 
-    @ParameterizedTest
-    @TypeGeneratorSource(value = UnicodeAttackGenerator.class, count = 200)
-    @DisplayName("Generator should produce valid Unicode attack patterns")
-    void shouldGenerateValidOutput(String generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
-        assertFalse(generatedValue.isEmpty(), "Generated value should not be empty");
+    private static final int AGGREGATE_DRAWS = 400;
 
-        // Since this is for Unicode attack testing, any non-null, non-empty output serves
-        // the security testing purpose
+    /** Unicode dots and slash, which the generator's escapes decode to. */
+    private static final String DECODED_DOTS_AND_SLASH = fromCodePoints(0x002E, 0x002E, 0x002F);
+    /** One-dot leaders and division slash, the homoglyph lookalike family. */
+    private static final String LOOKALIKE_DOTS_AND_SLASH = fromCodePoints(0x2024, 0x2024, 0x2215);
+    private static final String RIGHT_TO_LEFT_OVERRIDE = fromCodePoints(0x202E);
+    private static final String ZERO_WIDTH_SPACE = fromCodePoints(0x200B);
+    private static final String ZERO_WIDTH_NO_BREAK_SPACE = fromCodePoints(0xFEFF);
+    private static final String NULL_CHARACTER = fromCodePoints(0x0000);
+
+    /** The six attack code points the generator documents. */
+    private static final Set<String> ATTACK_CODE_POINTS = Set.of(
+            DECODED_DOTS_AND_SLASH,
+            LOOKALIKE_DOTS_AND_SLASH,
+            RIGHT_TO_LEFT_OVERRIDE,
+            ZERO_WIDTH_SPACE,
+            ZERO_WIDTH_NO_BREAK_SPACE,
+            NULL_CHARACTER);
+
+    private static final Set<String> PATH_TARGETS =
+            Set.of("etc/passwd", "etc/shadow", "windows/win.ini", "boot.ini");
+
+    @ParameterizedTest
+    @TypeGeneratorSource(value = UnicodeAttackGenerator.class, count = 100)
+    @DisplayName("Every generated value carries one of the six attack code points")
+    void shouldGenerateUnicodeAttack(String generatedValue) {
+        assertContainsAny(generatedValue, ATTACK_CODE_POINTS, "Unicode attack value");
+    }
+
+    @Test
+    @DisplayName("Should reach all six code points bare and at least one composite form")
+    void shouldReachBareAndCompositeForms() {
+        UnicodeAttackGenerator generator = new UnicodeAttackGenerator();
+        Set<String> bareForms = new HashSet<>();
+        Set<String> compositeTargets = new HashSet<>();
+
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            String value = generator.next();
+            if (ATTACK_CODE_POINTS.contains(value)) {
+                bareForms.add(value);
+            }
+            PATH_TARGETS.stream().filter(value::endsWith).forEach(compositeTargets::add);
+        }
+
+        assertAll("Output forms",
+                () -> assertEquals(ATTACK_CODE_POINTS, bareForms,
+                        "Every attack code point must be reachable in its bare form"),
+                () -> assertFalse(compositeTargets.isEmpty(),
+                        "The traversal-suffixed composite form must be reachable"));
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(String.class, new UnicodeAttackGenerator().getType(),
+                "Generator should return String.class");
+    }
+
+    private static String fromCodePoints(int... codePoints) {
+        StringBuilder builder = new StringBuilder(codePoints.length);
+        for (int codePoint : codePoints) {
+            builder.appendCodePoint(codePoint);
+        }
+        return builder.toString();
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/HTTPHeaderInjectionGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/HTTPHeaderInjectionGeneratorTest.java
@@ -18,29 +18,99 @@ package de.cuioss.http.security.generators.header;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * QI-5: Basic generator test for HTTPHeaderInjectionGenerator.
+ * Contract test for {@link HTTPHeaderInjectionGenerator}.
  *
- * <p>
- * Simple validation to ensure the generator works without exceptions and produces
- * non-null, non-empty output. Following cui-test-generator lightweight testing pattern.
- * </p>
+ * <p>The defining property of this generator is that every emitted header-value fragment
+ * smuggles a second directive past the header boundary — either by carrying a CRLF marker or,
+ * in the null-byte family, by truncating the value with a null byte. The aggregate test asserts
+ * that all eight documented injection families are reachable.</p>
  *
- * @author QI-5 Generator Coverage Initiative
+ * <p>No per-value pipeline round-trip is asserted here: this generator emits raw header-value
+ * fragments rather than URLs, so it has no single pipeline that consumes every emitted value.</p>
  */
 @EnableGeneratorController
+@DisplayName("HTTPHeaderInjectionGenerator Contract Tests")
 class HTTPHeaderInjectionGeneratorTest {
 
+    private static final int AGGREGATE_DRAWS = 400;
+
+    private static final Pattern CRLF_INJECTION =
+            Pattern.compile("[\\r\\n](X-Injected|X-Forwarded-For|X-Real-IP|X-Admin|Authorization): ");
+    private static final Pattern SMUGGLING =
+            Pattern.compile("\\n\\n(GET|POST|PUT|DELETE) /(admin|api|config|users) HTTP/1\\.1");
+    private static final Pattern SECURITY_HEADER_OVERRIDE =
+            Pattern.compile("\\r\\n(X-Frame-Options|Content-Security-Policy|Access-Control-Allow-Origin|X-XSS-Protection): ");
+    private static final Pattern CONTENT_TYPE_OVERRIDE =
+            Pattern.compile("\\r\\n(Content-Type|Content-Length|Transfer-Encoding): ");
+    private static final Pattern HOST_HEADER_INJECTION =
+            Pattern.compile("\\r\\n(Host|Location): ");
+    private static final String RESPONSE_SPLITTING = "\r\n\r\nHTTP/1.1 200 OK";
+    private static final String NULL_BYTE_INJECTION = "\0admin";
+    private static final String COOKIE_INJECTION = "\r\nSet-Cookie: ";
+
     @ParameterizedTest
-    @TypeGeneratorSource(value = HTTPHeaderInjectionGenerator.class, count = 10)
-    @DisplayName("Generator should produce valid non-null HTTP header injection attacks")
-    void shouldGenerateValidOutput(String generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
-        assertFalse(generatedValue.isEmpty(), "Generator should produce non-empty header injection attacks");
-        assertTrue(generatedValue.length() > 5, "Header injection attacks should be meaningful (more than 5 characters)");
+    @TypeGeneratorSource(value = HTTPHeaderInjectionGenerator.class, count = 100)
+    @DisplayName("Every generated value carries a CRLF or a null-byte marker")
+    void shouldGenerateHeaderInjection(String generatedValue) {
+        Set<String> injectionMarkers = new HashSet<>(CRLF_MARKERS);
+        injectionMarkers.addAll(NULL_BYTE_MARKERS);
+        assertContainsAny(generatedValue, injectionMarkers, "HTTP header injection value");
+    }
+
+    @Test
+    @DisplayName("Should reach all eight documented injection families")
+    void shouldReachAllInjectionFamilies() {
+        HTTPHeaderInjectionGenerator generator = new HTTPHeaderInjectionGenerator();
+        Set<String> families = new HashSet<>();
+
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            String value = generator.next();
+            if (CRLF_INJECTION.matcher(value).find()) {
+                families.add("crlf");
+            }
+            if (value.contains(RESPONSE_SPLITTING)) {
+                families.add("response-splitting");
+            }
+            if (value.contains(NULL_BYTE_INJECTION)) {
+                families.add("null-byte");
+            }
+            if (value.contains(COOKIE_INJECTION)) {
+                families.add("cookie");
+            }
+            if (SECURITY_HEADER_OVERRIDE.matcher(value).find()) {
+                families.add("security-header");
+            }
+            if (CONTENT_TYPE_OVERRIDE.matcher(value).find()) {
+                families.add("content-type");
+            }
+            if (SMUGGLING.matcher(value).find()) {
+                families.add("smuggling");
+            }
+            if (HOST_HEADER_INJECTION.matcher(value).find()) {
+                families.add("host-header");
+            }
+        }
+
+        assertEquals(Set.of("crlf", "response-splitting", "null-byte", "cookie",
+                        "security-header", "content-type", "smuggling", "host-header"), families,
+                "Every documented injection family must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(String.class, new HTTPHeaderInjectionGenerator().getType(),
+                "Generator should return String.class");
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/HTTPHeaderInjectionGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/HTTPHeaderInjectionGeneratorTest.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Contract test for {@link HTTPHeaderInjectionGenerator}.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/InvalidHTTPHeaderNameGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/InvalidHTTPHeaderNameGeneratorTest.java
@@ -18,29 +18,95 @@ package de.cuioss.http.security.generators.header;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * QI-5: Basic generator test for InvalidHTTPHeaderNameGenerator.
+ * Contract test for {@link InvalidHTTPHeaderNameGenerator}.
  *
- * <p>
- * Simple validation to ensure the generator works without exceptions and produces
- * non-null, non-empty output. Following cui-test-generator lightweight testing pattern.
- * </p>
- *
- * @author QI-5 Generator Coverage Initiative
+ * <p>The defining property of this generator is that every emitted name is a well-formed
+ * RFC 7230 field-name token spliced with exactly one injection separator, followed by the
+ * literal payload {@code Injected}. That shape is what makes the value an injection attempt
+ * rather than merely an odd string. The aggregate test asserts that all four documented
+ * injection variants are reachable.</p>
  */
 @EnableGeneratorController
+@DisplayName("InvalidHTTPHeaderNameGenerator Contract Tests")
 class InvalidHTTPHeaderNameGeneratorTest {
 
+    private static final int AGGREGATE_DRAWS = 400;
+    private static final String INJECTED_PAYLOAD = "Injected";
+    private static final Pattern RFC7230_TOKEN = Pattern.compile("[!#$%&'*+\\-.^_`|~0-9A-Za-z]+");
+    private static final Set<String> INJECTION_SEPARATORS = Set.of("\r", "\n", "\r\n", "\0");
+
     @ParameterizedTest
-    @TypeGeneratorSource(value = InvalidHTTPHeaderNameGenerator.class, count = 10)
-    @DisplayName("Generator should produce valid non-null invalid HTTP header names")
-    void shouldGenerateValidOutput(String generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
-        assertFalse(generatedValue.isEmpty(), "Generator should produce non-empty invalid header names");
-        assertTrue(generatedValue.length() > 1, "Invalid header names should be meaningful (more than 1 character)");
+    @TypeGeneratorSource(value = InvalidHTTPHeaderNameGenerator.class, count = 100)
+    @DisplayName("Every generated name splices exactly one injection separator into a valid token")
+    void shouldGenerateSplicedHeaderName(String generatedValue) {
+        int injectionPoint = indexOfInjectionPoint(generatedValue);
+        assertTrue(injectionPoint >= 0,
+                () -> "Invalid header name must carry an injection separator. Value: <"
+                        + generatedValue + ">");
+
+        String separator = separatorAt(generatedValue, injectionPoint);
+        String baseName = generatedValue.substring(0, injectionPoint);
+        String payload = generatedValue.substring(injectionPoint + separator.length());
+
+        assertAll("Spliced header name",
+                () -> assertTrue(INJECTION_SEPARATORS.contains(separator),
+                        () -> "Separator must be one of " + INJECTION_SEPARATORS + ". Value: <"
+                                + generatedValue + ">"),
+                () -> assertTrue(RFC7230_TOKEN.matcher(baseName).matches(),
+                        () -> "Base name must match the RFC 7230 token production. Value: <"
+                                + baseName + ">"),
+                () -> assertEquals(INJECTED_PAYLOAD, payload,
+                        "Everything after the separator must be the injected payload"));
+    }
+
+    @Test
+    @DisplayName("Should reach all four documented injection variants")
+    void shouldReachAllInjectionVariants() {
+        InvalidHTTPHeaderNameGenerator generator = new InvalidHTTPHeaderNameGenerator();
+        Set<String> separators = new HashSet<>();
+
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            String value = generator.next();
+            separators.add(separatorAt(value, indexOfInjectionPoint(value)));
+        }
+
+        assertEquals(INJECTION_SEPARATORS, separators,
+                "Every documented injection variant must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(String.class, new InvalidHTTPHeaderNameGenerator().getType(),
+                "Generator should return String.class");
+    }
+
+    private static int indexOfInjectionPoint(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (current == '\r' || current == '\n' || current == '\0') {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static String separatorAt(String value, int injectionPoint) {
+        assertTrue(injectionPoint >= 0,
+                () -> "Value carries no injection separator. Value: <" + value + ">");
+        if (value.startsWith("\r\n", injectionPoint)) {
+            return "\r\n";
+        }
+        return value.substring(injectionPoint, injectionPoint + 1);
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/ValidHTTPHeaderNameGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/header/ValidHTTPHeaderNameGeneratorTest.java
@@ -18,29 +18,93 @@ package de.cuioss.http.security.generators.header;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.containsControlCharacter;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * QI-5: Basic generator test for ValidHTTPHeaderNameGenerator.
+ * Contract test for {@link ValidHTTPHeaderNameGenerator}.
  *
- * <p>
- * Simple validation to ensure the generator works without exceptions and produces
- * non-null, non-empty output. Following cui-test-generator lightweight testing pattern.
- * </p>
- *
- * @author QI-5 Generator Coverage Initiative
+ * <p>The defining property of this generator is that every emitted name is a well-formed
+ * RFC 7230 field-name token and carries no control character. The aggregate test asserts that
+ * all seven documented header families are reachable.</p>
  */
 @EnableGeneratorController
+@DisplayName("ValidHTTPHeaderNameGenerator Contract Tests")
 class ValidHTTPHeaderNameGeneratorTest {
 
+    private static final int AGGREGATE_DRAWS = 400;
+
+    /** The RFC 7230 {@code token} production, which a field-name must match. */
+    private static final Pattern RFC7230_TOKEN = Pattern.compile("[!#$%&'*+\\-.^_`|~0-9A-Za-z]+");
+
+    private static final Set<String> STANDARD_HEADERS =
+            Set.of("Authorization", "Content-Type", "User-Agent", "Host");
+    private static final Set<String> ACCEPT_HEADERS =
+            Set.of("Accept", "Accept-Language", "Accept-Encoding");
+    private static final Set<String> CONTENT_HEADERS =
+            Set.of("Content-Length", "Content-Encoding", "Cache-Control");
+    private static final Set<String> COOKIE_HEADERS = Set.of("Cookie", "Set-Cookie");
+    private static final Set<String> NAVIGATION_HEADERS = Set.of("Origin", "Referer", "Location");
+    private static final Set<String> CONNECTION_HEADERS = Set.of("Connection", "Keep-Alive", "Upgrade");
+
     @ParameterizedTest
-    @TypeGeneratorSource(value = ValidHTTPHeaderNameGenerator.class, count = 10)
-    @DisplayName("Generator should produce valid non-null HTTP header names")
-    void shouldGenerateValidOutput(String generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
-        assertFalse(generatedValue.isEmpty(), "Generator should produce non-empty header names");
-        assertTrue(generatedValue.length() > 2, "Header names should be meaningful (more than 2 characters)");
+    @TypeGeneratorSource(value = ValidHTTPHeaderNameGenerator.class, count = 100)
+    @DisplayName("Every generated name is an RFC 7230 token free of control characters")
+    void shouldGenerateWellFormedHeaderName(String generatedValue) {
+        assertTrue(RFC7230_TOKEN.matcher(generatedValue).matches(),
+                () -> "Header name must match the RFC 7230 token production. Value: <"
+                        + generatedValue + ">");
+        assertFalse(containsControlCharacter(generatedValue),
+                () -> "Header name must carry no control character. Value: <" + generatedValue + ">");
+    }
+
+    @Test
+    @DisplayName("Should reach all seven documented header families")
+    void shouldReachAllHeaderFamilies() {
+        ValidHTTPHeaderNameGenerator generator = new ValidHTTPHeaderNameGenerator();
+        Set<String> families = new HashSet<>();
+
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            String value = generator.next();
+            if (STANDARD_HEADERS.contains(value)) {
+                families.add("standard");
+            }
+            if (ACCEPT_HEADERS.contains(value)) {
+                families.add("accept");
+            }
+            if (CONTENT_HEADERS.contains(value)) {
+                families.add("content");
+            }
+            if (COOKIE_HEADERS.contains(value)) {
+                families.add("cookie");
+            }
+            if (NAVIGATION_HEADERS.contains(value)) {
+                families.add("navigation");
+            }
+            if (CONNECTION_HEADERS.contains(value)) {
+                families.add("connection");
+            }
+            if (value.startsWith("X-")) {
+                families.add("custom");
+            }
+        }
+
+        assertEquals(Set.of("standard", "accept", "content", "cookie", "navigation", "connection", "custom"),
+                families,
+                "Every documented header family must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(String.class, new ValidHTTPHeaderNameGenerator().getType(),
+                "Generator should return String.class");
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/HttpRequestSmugglingAttackGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/HttpRequestSmugglingAttackGeneratorTest.java
@@ -15,32 +15,163 @@
  */
 package de.cuioss.http.security.generators.injection;
 
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.pipeline.URLPathValidationPipeline;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.assertPipelineRejects;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * QI-5: Basic generator test for HttpRequestSmugglingAttackGenerator.
+ * Contract test for {@link HttpRequestSmugglingAttackGenerator}.
  *
- * <p>
- * Simple validation to ensure the generator works without exceptions and produces
- * non-null, non-empty output. Following cui-test-generator lightweight testing pattern.
- * </p>
+ * <p>The defining property of this generator is that every emitted value is an absolute HTTP URL
+ * whose query smuggles a second request across an encoded CRLF, and is therefore rejected by the
+ * URL path validation pipeline. The aggregate test asserts that all fifteen documented smuggling
+ * families are reachable.</p>
  *
- * @author QI-5 Generator Coverage Initiative
+ * <p>Family attribution is first-match-wins over the ordered classifier below, because several
+ * families legitimately share a header: the header-manipulation family, for instance, emits one
+ * pattern carrying {@code X-HTTP-Method-Override}, which the method-override classifier claims
+ * first. Every family still fills from the patterns that are unambiguously its own.</p>
  */
 @EnableGeneratorController
+@DisplayName("HttpRequestSmugglingAttackGenerator Contract Tests")
 class HttpRequestSmugglingAttackGeneratorTest {
 
+    private static final int AGGREGATE_DRAWS = 600;
+    private static final String ENCODED_CRLF = "%0d%0a";
+
+    private static final Pattern RESPONSE_STATUS_LINE = Pattern.compile("HTTP/1\\.1 \\d{3}");
+    private static final Pattern DUPLICATE_TRANSFER_ENCODING =
+            Pattern.compile("Transfer-[Ee]ncoding:.*?%0d%0aTransfer-[Ee]ncoding:");
+    private static final Pattern DUPLICATE_CONTENT_LENGTH =
+            Pattern.compile("Content-Length: \\d+%0d%0aContent-Length: \\d+");
+    private static final Pattern CONTENT_LENGTH_THEN_TRANSFER_ENCODING =
+            Pattern.compile("Content-Length: \\d+%0d%0aTransfer-Encoding: chunked");
+    private static final Pattern TRANSFER_ENCODING_THEN_CONTENT_LENGTH =
+            Pattern.compile("Transfer-Encoding: chunked%0d%0aContent-Length: \\d+");
+
+    private static final List<String> HTTP2_MARKERS = List.of("HTTP2-Settings", "PRI * HTTP/2.0");
+    private static final List<String> WEBSOCKET_MARKERS = List.of("Upgrade: websocket", "Sec-WebSocket");
+    private static final List<String> CACHE_MARKERS = List.of("Cache-Control:", "Vary:", "Expires:");
+    private static final List<String> HIJACKING_MARKERS = List.of(
+            "/victim-request", "X=1POST /capture", "SMUGGLED_REQUEST", "HIJACK_PAYLOAD_REQUEST",
+            "INTERCEPTED_USER_REQUEST", "POISONED_REQUEST_QUEUE", "QUEUE_POISONING_ATTACK");
+    private static final List<String> URL_REWRITING_MARKERS = List.of(
+            "X-Rewrite-URL", "X-Original-URI", "X-Forwarded-URI", "X-Forwarded-Path", "X-Proxy-URL",
+            "X-Original-URL: /admin/users", "X-Original-URL: /admin/elevate");
+    private static final List<String> METHOD_OVERRIDE_MARKERS = List.of(
+            "X-HTTP-Method-Override", "X-HTTP-Method:", "X-Method-Override", "X-Method:", "_method:");
+    private static final List<String> AUTH_BYPASS_MARKERS = List.of(
+            "Authorization: Bearer hijacked", "X-Forwarded-User", "X-Remote-User",
+            "Cookie: session=admin-session", "X-Forwarded-For: 127.0.0.1", "X-User-Role",
+            "X-Original-URL: /admin%0d%0a");
+    private static final List<String> HEADER_MANIPULATION_MARKERS = List.of(
+            "X-Forwarded-Proto", "Host: evil.com", "X-Forwarded-Host", "X-Original-IP",
+            "Referer: http://admin.internal", "User-Agent: AdminBot");
+
+    private static final Set<String> DOCUMENTED_FAMILIES = Set.of(
+            "cl.te", "te.cl", "te.te", "cl.cl", "http2-downgrade", "pipeline-poisoning",
+            "cache-deception", "auth-bypass", "header-manipulation", "method-override",
+            "url-rewriting", "request-hijacking", "response-queue-poisoning",
+            "websocket-upgrade", "chunked-bypass");
+
     @ParameterizedTest
-    @TypeGeneratorSource(value = HttpRequestSmugglingAttackGenerator.class, count = 10)
-    @DisplayName("Should generate valid request smuggling patterns")
-    void shouldGenerateValidOutput(String generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
-        assertFalse(generatedValue.isEmpty(), "Generator should produce non-empty attack patterns");
-        assertTrue(generatedValue.length() > 10, "HTTP smuggling patterns should be substantial (more than 10 characters)");
+    @TypeGeneratorSource(value = HttpRequestSmugglingAttackGenerator.class, count = 100)
+    @DisplayName("Every generated value is an absolute URL smuggling a request across an encoded CRLF")
+    void shouldGenerateSmugglingUrl(String generatedValue) {
+        assertTrue(generatedValue.startsWith("http://") || generatedValue.startsWith("https://"),
+                () -> "Smuggling payloads are absolute HTTP URLs. Value: <" + generatedValue + ">");
+        assertTrue(generatedValue.contains(ENCODED_CRLF),
+                () -> "Smuggling payloads carry an encoded CRLF. Value: <" + generatedValue + ">");
+
+        assertPipelineRejects(
+                new URLPathValidationPipeline(SecurityConfiguration.defaults(), new SecurityEventCounter()),
+                generatedValue);
+    }
+
+    @Test
+    @DisplayName("Should reach all fifteen documented smuggling families")
+    void shouldReachAllSmugglingFamilies() {
+        HttpRequestSmugglingAttackGenerator generator = new HttpRequestSmugglingAttackGenerator();
+        Set<String> families = new HashSet<>();
+
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            families.add(classify(generator.next()));
+        }
+
+        assertEquals(DOCUMENTED_FAMILIES, families,
+                "Every documented smuggling family must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(String.class, new HttpRequestSmugglingAttackGenerator().getType(),
+                "Generator should return String.class");
+    }
+
+    private static String classify(String value) {
+        if (containsAny(value, HTTP2_MARKERS)) {
+            return "http2-downgrade";
+        }
+        if (containsAny(value, WEBSOCKET_MARKERS)) {
+            return "websocket-upgrade";
+        }
+        if (containsAny(value, CACHE_MARKERS)) {
+            return "cache-deception";
+        }
+        if (RESPONSE_STATUS_LINE.matcher(value).find()) {
+            return "response-queue-poisoning";
+        }
+        if (containsAny(value, HIJACKING_MARKERS)) {
+            return "request-hijacking";
+        }
+        if (containsAny(value, URL_REWRITING_MARKERS)) {
+            return "url-rewriting";
+        }
+        if (containsAny(value, METHOD_OVERRIDE_MARKERS)) {
+            return "method-override";
+        }
+        if (containsAny(value, AUTH_BYPASS_MARKERS)) {
+            return "auth-bypass";
+        }
+        if (containsAny(value, HEADER_MANIPULATION_MARKERS)) {
+            return "header-manipulation";
+        }
+        if (value.contains("Connection: keep-alive")) {
+            return "pipeline-poisoning";
+        }
+        if (DUPLICATE_TRANSFER_ENCODING.matcher(value).find()) {
+            return "te.te";
+        }
+        if (DUPLICATE_CONTENT_LENGTH.matcher(value).find()) {
+            return "cl.cl";
+        }
+        if (CONTENT_LENGTH_THEN_TRANSFER_ENCODING.matcher(value).find()) {
+            return "cl.te";
+        }
+        if (TRANSFER_ENCODING_THEN_CONTENT_LENGTH.matcher(value).find()) {
+            return "te.cl";
+        }
+        if (value.contains("Transfer-Encoding: chunked")) {
+            return "chunked-bypass";
+        }
+        return fail("Value belongs to no documented smuggling family. Value: <" + value + ">");
+    }
+
+    private static boolean containsAny(String value, List<String> markers) {
+        return markers.stream().anyMatch(value::contains);
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/URLLengthLimitAttackGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/URLLengthLimitAttackGeneratorTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 
 import static de.cuioss.http.security.generators.GeneratorContractAssertions.assertPipelineRejects;
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.preview;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -185,9 +186,5 @@ class URLLengthLimitAttackGeneratorTest {
                 .maxPathLength(SecurityDefaults.MAX_PATH_LENGTH_STRICT)
                 .build();
         return new URLPathValidationPipeline(config, new SecurityEventCounter());
-    }
-
-    private String preview(String value) {
-        return value.length() <= 80 ? value : value.substring(0, 80) + "...";
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/URLLengthLimitAttackGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/URLLengthLimitAttackGeneratorTest.java
@@ -15,33 +15,179 @@
  */
 package de.cuioss.http.security.generators.injection;
 
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.config.SecurityDefaults;
 import de.cuioss.http.security.generators.url.URLLengthLimitAttackGenerator;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.pipeline.URLPathValidationPipeline;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.assertPipelineRejects;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * QI-5: Basic generator test for URLLengthLimitAttackGenerator.
+ * Contract test for {@link URLLengthLimitAttackGenerator}.
  *
- * <p>
- * Simple validation to ensure the generator works without exceptions and produces
- * non-null, non-empty output. Following cui-test-generator lightweight testing pattern.
- * </p>
+ * <p>The defining property of this generator is length: every emitted value exceeds
+ * {@link SecurityDefaults#MAX_PATH_LENGTH_STRICT}, which is the limit the generator advertises
+ * itself as attacking. A value that stays under that limit is not a length-limit attack, so the
+ * per-value test asserts the length directly rather than a token minimum.</p>
  *
- * @author QI-5 Generator Coverage Initiative
+ * <p>The pipeline round-trip is asserted only for the values {@link URLPathValidationPipeline}
+ * actually governs — relative path and query values. Hostname-family values (which carry their
+ * length in the authority component) and fragment-family values lie outside that pipeline's
+ * remit, so they carry the length property alone.</p>
  */
 @EnableGeneratorController
+@DisplayName("URLLengthLimitAttackGenerator Contract Tests")
 class URLLengthLimitAttackGeneratorTest {
 
+    /**
+     * Sized so that the rarest branch — the single traversal arm of the algorithmic-complexity
+     * family, reached on one of eight sub-cases of one of thirteen families — is missed with
+     * negligible probability.
+     */
+    private static final int AGGREGATE_DRAWS = 2000;
+
+    /** The number of attack families {@code AttackTypeSelector} cycles through. */
+    private static final int ATTACK_FAMILY_COUNT = 13;
+
+    /**
+     * Observable shapes that are each reachable only through a distinct branch family, so that
+     * reaching all of them is evidence the generator spans its documented taxonomy rather than
+     * collapsing onto one shape.
+     */
+    private static final String HOSTNAME_SHAPE = "authority-rooted (https://)";
+    private static final String FRAGMENT_SHAPE = "carries a fragment (#)";
+    private static final String QUERY_SHAPE = "carries a query (?)";
+    private static final String PURE_PATH_SHAPE = "pure path (no query, no fragment)";
+    private static final String TRAVERSAL_SHAPE = "carries traversal segments (../)";
+    private static final String BEYOND_LENIENT_SHAPE = "exceeds the lenient limit";
+
+    private static final Set<String> ALL_SHAPES = Set.of(
+            HOSTNAME_SHAPE, FRAGMENT_SHAPE, QUERY_SHAPE,
+            PURE_PATH_SHAPE, TRAVERSAL_SHAPE, BEYOND_LENIENT_SHAPE);
+
     @ParameterizedTest
-    @TypeGeneratorSource(value = URLLengthLimitAttackGenerator.class, count = 10)
-    @DisplayName("Generator should produce valid non-null URL length limit attack patterns")
-    void shouldGenerateValidOutput(String generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
-        assertFalse(generatedValue.isEmpty(), "Generator should produce non-empty attack patterns");
-        assertTrue(generatedValue.length() > 10, "URL length attacks should be substantial (more than 10 characters)");
+    @TypeGeneratorSource(value = URLLengthLimitAttackGenerator.class, count = 100)
+    @DisplayName("Every generated value exceeds the strict path limit and is a rooted URL")
+    void shouldGenerateOverlongRootedUrl(String generatedValue) {
+        assertOverlongRootedUrl(generatedValue);
+
+        if (isGovernedByPathPipeline(generatedValue)) {
+            assertPipelineRejects(strictPathPipeline(), generatedValue);
+        }
+    }
+
+    @Test
+    @DisplayName("Should cycle through all thirteen attack families, each emitting overlong URLs")
+    void shouldReachAllAttackFamilies() {
+        URLLengthLimitAttackGenerator generator = new URLLengthLimitAttackGenerator();
+        List<List<String>> valuesByFamily = new ArrayList<>();
+        for (int family = 0; family < ATTACK_FAMILY_COUNT; family++) {
+            valuesByFamily.add(new ArrayList<>());
+        }
+
+        for (int draw = 0; draw < AGGREGATE_DRAWS; draw++) {
+            valuesByFamily.get(draw % ATTACK_FAMILY_COUNT).add(generator.next());
+        }
+
+        for (int family = 0; family < ATTACK_FAMILY_COUNT; family++) {
+            List<String> values = valuesByFamily.get(family);
+            assertFalse(values.isEmpty(), "Attack family " + family + " must be reached");
+            values.forEach(this::assertOverlongRootedUrl);
+        }
+    }
+
+    @Test
+    @DisplayName("Should span every documented URL shape, including one beyond the lenient limit")
+    void shouldSpanAllDocumentedShapes() {
+        URLLengthLimitAttackGenerator generator = new URLLengthLimitAttackGenerator();
+        Set<String> reached = new HashSet<>();
+
+        for (int draw = 0; draw < AGGREGATE_DRAWS; draw++) {
+            reached.addAll(shapesOf(generator.next()));
+        }
+
+        assertEquals(ALL_SHAPES, reached,
+                "Every documented URL shape must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(String.class, new URLLengthLimitAttackGenerator().getType(),
+                "Generator should return String.class");
+    }
+
+    private void assertOverlongRootedUrl(String value) {
+        assertNotNull(value, "Generator must not produce null values");
+        assertTrue(value.length() > SecurityDefaults.MAX_PATH_LENGTH_STRICT,
+                () -> "A length-limit attack must exceed the strict limit of "
+                        + SecurityDefaults.MAX_PATH_LENGTH_STRICT + " characters, but was "
+                        + value.length() + ". Value starts: <" + preview(value) + ">");
+        assertTrue(isRooted(value),
+                () -> "A URL length attack must be rooted at '/' or carry an http(s) scheme. Value starts: <"
+                        + preview(value) + ">");
+    }
+
+    private Set<String> shapesOf(String value) {
+        Set<String> shapes = new HashSet<>();
+        if (value.startsWith("https://") || value.startsWith("http://")) { // NOSONAR - test URL patterns
+            shapes.add(HOSTNAME_SHAPE);
+        }
+        if (value.indexOf('#') >= 0) {
+            shapes.add(FRAGMENT_SHAPE);
+        }
+        if (value.indexOf('?') >= 0) {
+            shapes.add(QUERY_SHAPE);
+        }
+        if (value.indexOf('?') < 0 && value.indexOf('#') < 0) {
+            shapes.add(PURE_PATH_SHAPE);
+        }
+        if (value.contains("../")) {
+            shapes.add(TRAVERSAL_SHAPE);
+        }
+        if (value.length() > SecurityDefaults.MAX_PATH_LENGTH_LENIENT) {
+            shapes.add(BEYOND_LENIENT_SHAPE);
+        }
+        return shapes;
+    }
+
+    /**
+     * Determines whether the URL path pipeline governs the value. Authority-rooted values carry
+     * their length in the hostname and fragment-bearing values carry it after the {@code #}, so
+     * neither is this pipeline's concern; everything else is a path or query the pipeline owns.
+     */
+    private boolean isGovernedByPathPipeline(String value) {
+        return isRelative(value) && value.indexOf('#') < 0;
+    }
+
+    private boolean isRooted(String value) {
+        return isRelative(value) || value.startsWith("http://") || value.startsWith("https://"); // NOSONAR - test URL patterns
+    }
+
+    private boolean isRelative(String value) {
+        return value.startsWith("/");
+    }
+
+    private URLPathValidationPipeline strictPathPipeline() {
+        SecurityConfiguration config = SecurityConfiguration.builder()
+                .maxPathLength(SecurityDefaults.MAX_PATH_LENGTH_STRICT)
+                .build();
+        return new URLPathValidationPipeline(config, new SecurityEventCounter());
+    }
+
+    private String preview(String value) {
+        return value.length() <= 80 ? value : value.substring(0, 80) + "...";
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/InvalidURLGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/InvalidURLGeneratorTest.java
@@ -26,7 +26,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Contract test for {@link InvalidURLGenerator}.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/InvalidURLGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/InvalidURLGeneratorTest.java
@@ -18,26 +18,122 @@ package de.cuioss.http.security.generators.url;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test for {@link InvalidURLGenerator}
+ * Contract test for {@link InvalidURLGenerator}.
+ *
+ * <p>The defining property of this generator is that every emitted value is either blank or
+ * carries one of the ten documented malformation families. There is deliberately no per-value
+ * pipeline round-trip: the generator emits values such as the well-formed
+ * {@code http://example.com/path/} whose only declared defect is a trailing slash, so a uniform
+ * "the pipeline rejects it" assertion would not hold.</p>
+ *
+ * <p>{@code createPathIssue} case 3 emits a merely trailing-slash URL, which is well-formed
+ * rather than malformed. "Trailing slash" is enumerated below as a declared malformation family
+ * so that this test states honestly what the generator emits today.</p>
  */
 @EnableGeneratorController
+@DisplayName("InvalidURLGenerator Contract Tests")
 class InvalidURLGeneratorTest {
+
+    /**
+     * The literal-coverage assertion below needs the two rarest literals, each drawn with
+     * probability 1/60. 2000 draws puts the chance of a spurious miss below one in a trillion,
+     * where 400 draws would leave this test flaking roughly once in four hundred runs.
+     */
+    private static final int AGGREGATE_DRAWS = 2000;
+
+    private static final String EMPTY_URL = "";
+    private static final String WHITESPACE_URL = "   ";
+    private static final String NOT_A_URL = "not-a-url-at-all";
+
+    private static final Pattern SINGLE_SLASH_SCHEME = Pattern.compile("^[a-z]+:/[^/]");
+    private static final Pattern TRAILING_DOT_HOST = Pattern.compile("://[^/]+\\./");
+    private static final Pattern PORT_ISSUE = Pattern.compile("://[^/]*:(/|abc|-80|\\d{5,})");
+    private static final List<String> INVALID_ESCAPES = List.of(
+            "%encoding", "%2encoding", "%ZZencoding", "%GGencoding", "%invalidencoding", "%invalid%encoding");
+    private static final List<String> UNENCODED_SPECIALS = List.of(" ", "[", "]", "{", "}", "|", "\\");
+    private static final int MAX_REASONABLE_URL_LENGTH = 2048;
 
     @ParameterizedTest
     @TypeGeneratorSource(value = InvalidURLGenerator.class, count = 200)
-    @DisplayName("Generator should produce invalid URLs")
-    void shouldGenerateValidOutput(String generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
+    @DisplayName("Every generated URL is blank or carries a documented malformation")
+    void shouldGenerateBlankOrMalformedUrl(String generatedValue) {
+        assertTrue(generatedValue.isBlank() || carriesDocumentedMalformation(generatedValue),
+                () -> "Value belongs to no documented malformation family. Value: <" + generatedValue + ">");
+    }
 
-        // Invalid URLs can be empty strings, whitespace, or have various malformations
+    @Test
+    @DisplayName("Should reach the empty, whitespace-only and non-URL literals")
+    void shouldReachDegenerateLiterals() {
+        InvalidURLGenerator generator = new InvalidURLGenerator();
+        Set<String> literals = new HashSet<>();
 
-        // Since this is for testing invalid URLs, we simply verify it's not null
-        // The generator's purpose is to create invalid URLs, so any non-null output is acceptable
-        // as it serves the security testing purpose
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            String value = generator.next();
+            if (EMPTY_URL.equals(value) || WHITESPACE_URL.equals(value) || NOT_A_URL.equals(value)) {
+                literals.add(value);
+            }
+        }
+
+        assertEquals(Set.of(EMPTY_URL, WHITESPACE_URL, NOT_A_URL), literals,
+                "Every degenerate literal must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(String.class, new InvalidURLGenerator().getType(),
+                "Generator should return String.class");
+    }
+
+    private static boolean carriesDocumentedMalformation(String value) {
+        return hasSchemeIssue(value)
+                || hasHostIssue(value)
+                || hasPathSlashIssue(value)
+                || value.contains("?")
+                || value.contains("#")
+                || PORT_ISSUE.matcher(value).find()
+                || UNENCODED_SPECIALS.stream().anyMatch(value::contains)
+                || INVALID_ESCAPES.stream().anyMatch(value::contains)
+                || value.length() > MAX_REASONABLE_URL_LENGTH
+                || NOT_A_URL.equals(value);
+    }
+
+    private static boolean hasSchemeIssue(String value) {
+        return value.startsWith("htp://")
+                || value.startsWith("://")
+                || value.startsWith("http:///")
+                || value.startsWith("javascript:")
+                || value.startsWith("data:")
+                || value.startsWith("ftp://")
+                || value.startsWith("file://")
+                || SINGLE_SLASH_SCHEME.matcher(value).find();
+    }
+
+    private static boolean hasHostIssue(String value) {
+        return value.endsWith("://")
+                || value.contains(":///")
+                || value.contains("..")
+                || value.contains("://.")
+                || TRAILING_DOT_HOST.matcher(value).find();
+    }
+
+    private static boolean hasPathSlashIssue(String value) {
+        if (value.endsWith("/")) {
+            return true;
+        }
+        int schemeEnd = value.indexOf("://");
+        String rest = schemeEnd < 0 ? value : value.substring(schemeEnd + 3);
+        return rest.contains("//");
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/NullByteURLGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/NullByteURLGeneratorTest.java
@@ -28,7 +28,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Contract test for {@link NullByteURLGenerator}.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/NullByteURLGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/NullByteURLGeneratorTest.java
@@ -15,32 +15,74 @@
  */
 package de.cuioss.http.security.generators.url;
 
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.pipeline.URLPathValidationPipeline;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * QI-5: Basic generator test for NullByteURLGenerator.
+ * Contract test for {@link NullByteURLGenerator}.
  *
- * <p>
- * Simple validation to ensure the generator works without exceptions and produces
- * non-null, non-empty output. Following cui-test-generator lightweight testing pattern.
- * </p>
- *
- * @author QI-5 Generator Coverage Initiative
+ * <p>The defining property of this generator is that every emitted value is an API path
+ * carrying a null byte — raw or percent-encoded — and is therefore rejected by the URL path
+ * validation pipeline. The aggregate test asserts that both null-byte encodings are
+ * reachable.</p>
  */
 @EnableGeneratorController
+@DisplayName("NullByteURLGenerator Contract Tests")
 class NullByteURLGeneratorTest {
 
+    private static final int AGGREGATE_DRAWS = 400;
+    private static final String RAW_NULL_BYTE = "\0";
+    private static final String ENCODED_NULL_BYTE = "%00";
+
     @ParameterizedTest
-    @TypeGeneratorSource(value = NullByteURLGenerator.class, count = 10)
-    @DisplayName("Generator should produce valid non-null null byte injection URLs")
-    void shouldGenerateValidOutput(String generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
-        assertFalse(generatedValue.isEmpty(), "Generator should produce non-empty null byte URLs");
-        assertTrue(generatedValue.length() > 5, "Null byte URLs should be substantial (more than 5 characters)");
+    @TypeGeneratorSource(value = NullByteURLGenerator.class, count = 100)
+    @DisplayName("Every generated URL carries a null byte and is rejected by the pipeline")
+    void shouldGenerateNullByteInjection(String generatedValue) {
+        assertTrue(generatedValue.startsWith("/api"),
+                () -> "Null byte URLs are rooted at '/api'. Value: <" + generatedValue + ">");
+        assertContainsAny(generatedValue, NULL_BYTE_MARKERS, "Null byte injection URL");
+
+        assertPipelineRejects(
+                new URLPathValidationPipeline(SecurityConfiguration.defaults(), new SecurityEventCounter()),
+                generatedValue);
+    }
+
+    @Test
+    @DisplayName("Should reach both the raw and the percent-encoded null-byte form")
+    void shouldReachBothNullByteEncodings() {
+        NullByteURLGenerator generator = new NullByteURLGenerator();
+        Set<String> forms = new HashSet<>();
+
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            String value = generator.next();
+            if (value.contains(RAW_NULL_BYTE)) {
+                forms.add("raw");
+            }
+            if (value.contains(ENCODED_NULL_BYTE)) {
+                forms.add("encoded");
+            }
+        }
+
+        assertEquals(Set.of("raw", "encoded"), forms,
+                "Both null-byte encodings must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(String.class, new NullByteURLGenerator().getType(),
+                "Generator should return String.class");
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalParameterGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalParameterGeneratorTest.java
@@ -15,32 +15,79 @@
  */
 package de.cuioss.http.security.generators.url;
 
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.pipeline.URLParameterValidationPipeline;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * QI-5: Basic generator test for PathTraversalParameterGenerator.
+ * Contract test for {@link PathTraversalParameterGenerator}.
  *
- * <p>
- * Simple validation to ensure the generator works without exceptions and produces
- * non-null, non-empty output. Following cui-test-generator lightweight testing pattern.
- * </p>
- *
- * @author QI-5 Generator Coverage Initiative
+ * <p>The defining property of this generator is that every emitted parameter value carries a
+ * traversal marker and is therefore rejected by the URL parameter validation pipeline. The
+ * aggregate test asserts that the literal traversal sequences of all eight documented attack
+ * families are reachable; the Windows and UTF-8-overlong families each contribute two
+ * sequences, because each of those branches alternates between two forms.</p>
  */
 @EnableGeneratorController
+@DisplayName("PathTraversalParameterGenerator Contract Tests")
 class PathTraversalParameterGeneratorTest {
 
+    private static final int AGGREGATE_DRAWS = 400;
+
+    /** Every literal traversal sequence the eight documented attack families emit. */
+    private static final List<String> FAMILY_SEQUENCES = List.of(
+            "..%2F",                // basic encoded traversal
+            "%2E%2E%2F",            // double encoded traversal (also the mixed uppercase arm)
+            "%2e%2e%2f",            // mixed lowercase arm and deep traversal
+            "..%5c",                // Windows style, partially encoded arm
+            "%2e%2e%5c",            // Windows style, fully encoded arm
+            "....%2f",              // quad-dot bypass
+            "..%c0%af",             // UTF-8 overlong slash arm
+            "%c0%ae%c0%ae%c0%af",   // UTF-8 overlong dots-and-slash arm
+            "%252e%252e%252f");     // triple encoded traversal
+
     @ParameterizedTest
-    @TypeGeneratorSource(value = PathTraversalParameterGenerator.class, count = 10)
-    @DisplayName("Generator should produce valid non-null path traversal parameters")
-    void shouldGenerateValidOutput(String generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
-        assertFalse(generatedValue.isEmpty(), "Generator should produce non-empty path traversal parameters");
-        assertTrue(generatedValue.length() > 3, "Path traversal parameters should be meaningful (more than 3 characters)");
+    @TypeGeneratorSource(value = PathTraversalParameterGenerator.class, count = 100)
+    @DisplayName("Every generated parameter value carries a traversal marker and is rejected")
+    void shouldGeneratePathTraversalParameterValue(String generatedValue) {
+        assertContainsAny(generatedValue, TRAVERSAL_MARKERS, "Path traversal parameter value");
+
+        assertPipelineRejects(
+                new URLParameterValidationPipeline(SecurityConfiguration.defaults(), new SecurityEventCounter()),
+                generatedValue);
+    }
+
+    @Test
+    @DisplayName("Should reach the traversal sequences of all eight documented attack families")
+    void shouldReachAllAttackFamilySequences() {
+        PathTraversalParameterGenerator generator = new PathTraversalParameterGenerator();
+        Set<String> reached = new HashSet<>();
+
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            String value = generator.next();
+            FAMILY_SEQUENCES.stream().filter(value::contains).forEach(reached::add);
+        }
+
+        assertEquals(Set.copyOf(FAMILY_SEQUENCES), reached,
+                "Every documented traversal sequence must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(String.class, new PathTraversalParameterGenerator().getType(),
+                "Generator should return String.class");
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalParameterGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalParameterGeneratorTest.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Set;
 
 import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Contract test for {@link PathTraversalParameterGenerator}.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalURLGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalURLGeneratorTest.java
@@ -15,32 +15,77 @@
  */
 package de.cuioss.http.security.generators.url;
 
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.pipeline.URLPathValidationPipeline;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * QI-5: Basic generator test for PathTraversalURLGenerator.
+ * Contract test for {@link PathTraversalURLGenerator}.
  *
- * <p>
- * Simple validation to ensure the generator works without exceptions and produces
- * non-null, non-empty output. Following cui-test-generator lightweight testing pattern.
- * </p>
- *
- * @author QI-5 Generator Coverage Initiative
+ * <p>The defining property of this generator is that every emitted value is a rooted URL path
+ * carrying a traversal marker, and is therefore rejected by the URL path validation pipeline.
+ * The aggregate test asserts that all six documented encoding families are reachable, each
+ * identified by the literal separator sequence its branch emits.</p>
  */
 @EnableGeneratorController
+@DisplayName("PathTraversalURLGenerator Contract Tests")
 class PathTraversalURLGeneratorTest {
 
+    private static final int AGGREGATE_DRAWS = 400;
+
+    /** One literal per documented encoding family, in the branch order of the generator. */
+    private static final List<String> FAMILY_MARKERS = List.of(
+            "%2E%2E/",          // basic uppercase-encoded traversal
+            "%2E%2E%5C",        // Windows-style traversal
+            "%252e%252e%252f",  // double-encoded traversal
+            "../",              // mixed encoding, unencoded arm
+            "%2e%2e/",          // lowercase-encoded traversal
+            "%2E%2E%2F");       // multiple-depth traversal
+
     @ParameterizedTest
-    @TypeGeneratorSource(value = PathTraversalURLGenerator.class, count = 10)
-    @DisplayName("Generator should produce valid non-null path traversal URLs")
-    void shouldGenerateValidOutput(String generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
-        assertFalse(generatedValue.isEmpty(), "Generator should produce non-empty path traversal URLs");
-        assertTrue(generatedValue.length() > 5, "Path traversal URLs should be substantial (more than 5 characters)");
+    @TypeGeneratorSource(value = PathTraversalURLGenerator.class, count = 100)
+    @DisplayName("Every generated URL carries a traversal marker and is rejected by the pipeline")
+    void shouldGeneratePathTraversalUrl(String generatedValue) {
+        assertTrue(generatedValue.startsWith("/"),
+                () -> "Path traversal URLs are rooted at '/'. Value: <" + generatedValue + ">");
+        assertContainsAny(generatedValue, TRAVERSAL_MARKERS, "Path traversal URL");
+
+        assertPipelineRejects(
+                new URLPathValidationPipeline(SecurityConfiguration.defaults(), new SecurityEventCounter()),
+                generatedValue);
+    }
+
+    @Test
+    @DisplayName("Should reach all six documented encoding families")
+    void shouldReachAllEncodingFamilies() {
+        PathTraversalURLGenerator generator = new PathTraversalURLGenerator();
+        Set<String> reached = new HashSet<>();
+
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            String value = generator.next();
+            FAMILY_MARKERS.stream().filter(value::contains).forEach(reached::add);
+        }
+
+        assertEquals(Set.copyOf(FAMILY_MARKERS), reached,
+                "Every documented encoding family must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(String.class, new PathTraversalURLGenerator().getType(),
+                "Generator should return String.class");
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalURLGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalURLGeneratorTest.java
@@ -29,7 +29,8 @@ import java.util.List;
 import java.util.Set;
 
 import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Contract test for {@link PathTraversalURLGenerator}.

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/URLLengthLimitAttackGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/URLLengthLimitAttackGenerator.java
@@ -51,6 +51,18 @@ import java.util.List;
  *   <li><strong>Algorithmic Complexity</strong> - URLs causing processing slowdown</li>
  * </ul>
  *
+ * <h3>Length Invariant</h3>
+ *
+ * <p>Every value this generator emits is longer than
+ * {@link de.cuioss.http.security.config.SecurityDefaults#MAX_PATH_LENGTH_STRICT} characters and
+ * begins either with {@code /} or with an {@code http://} / {@code https://} scheme. That is the
+ * defining property of the generator: a value that does not exceed the limit it targets is not a
+ * length-limit attack at all. Branches that need a repeated token build it through
+ * {@code repeat(token, minCount, maxCount)} rather than
+ * {@code Generators.strings(token, min, max)} — the latter treats its first argument as an
+ * <em>alphabet</em> and would emit a short scramble of the token's characters, leaving the value
+ * far under the limit.</p>
+ *
  * <h3>Security Standards</h3>
  * <ul>
  *   <li>RFC 3986 - Uniform Resource Identifier (URI): Generic Syntax</li>
@@ -142,13 +154,13 @@ public class URLLengthLimitAttackGenerator implements TypedGenerator<String> {
     private String createPathComponentOverflow(String pattern) {
         int attackType = hashBasedSelection(8);
         return switch (attackType) {
-            case 0 -> pattern + "/" + Generators.strings("segment/", 150, 180).next() + "file"; // Repeated segments to reach limits
+            case 0 -> pattern + "/" + repeat("segment/", 150, 180) + "file"; // Repeated segments to reach limits
             case 1 -> pattern + "/" + Generators.letterStrings(1030, 1050).next() + "/normal"; // Single long segment over STRICT
-            case 2 -> pattern + "/" + "path_" + Generators.letterStrings(1000, 1020).next() + "/data"; // Long segment with prefix
-            case 3 -> "/" + Generators.letterStrings(800, 850).next() + pattern + "/file"; // Long prefix path
-            case 4 -> pattern + "/" + "dir_" + Generators.letterStrings(500, 520).next() + "/file_" + Generators.letterStrings(500, 520).next(); // Multiple segments
-            case 5 -> pattern + "/" + "very_long_directory_name_" + Generators.letterStrings(950, 980).next(); // Descriptive long segment
-            case 6 -> pattern + "/" + "component" + Generators.letterStrings(400, 420).next() + "/subdir" + Generators.letterStrings(400, 420).next() + "/file"; // Nested paths
+            case 2 -> pattern + "/" + "path_" + Generators.letterStrings(1030, 1050).next() + "/data"; // Long segment with prefix
+            case 3 -> "/" + Generators.letterStrings(1030, 1080).next() + pattern + "/file"; // Long prefix path
+            case 4 -> pattern + "/" + "dir_" + Generators.letterStrings(520, 560).next() + "/file_" + Generators.letterStrings(520, 560).next(); // Multiple segments
+            case 5 -> pattern + "/" + "very_long_directory_name_" + Generators.letterStrings(1000, 1030).next(); // Descriptive long segment
+            case 6 -> pattern + "/" + "component" + Generators.letterStrings(505, 530).next() + "/subdir" + Generators.letterStrings(505, 530).next() + "/file"; // Nested paths
             case 7 -> pattern + "/" + Generators.letterStrings(4100, 4150).next() + "/end"; // Just over DEFAULT limit
             default -> pattern + "/" + Generators.letterStrings(1030, 1050).next(); // Default just over STRICT
         };
@@ -160,12 +172,12 @@ public class URLLengthLimitAttackGenerator implements TypedGenerator<String> {
     private String createQueryParameterOverflow(String pattern) {
         int attackType = hashBasedSelection(8);
         return switch (attackType) {
-            case 0 -> pattern + "?" + "param=" + Generators.letterStrings(900, 950).next(); // Parameter value near STRICT limit
-            case 1 -> pattern + "?" + "data=" + Generators.letterStrings(500, 520).next() + "&info=" + Generators.letterStrings(500, 520).next(); // Multiple parameters
+            case 0 -> pattern + "?" + "param=" + Generators.letterStrings(1020, 1060).next(); // Parameter value over STRICT limit
+            case 1 -> pattern + "?" + "data=" + Generators.letterStrings(520, 560).next() + "&info=" + Generators.letterStrings(520, 560).next(); // Multiple parameters
             case 2 -> pattern + "?" + "query=" + Generators.letterStrings(3800, 3900).next(); // Parameter near DEFAULT limit
-            case 3 -> pattern + "?" + "search=" + Generators.strings("term ", 200, 250).next(); // Repeated terms to reach limit
-            case 4 -> pattern + "?" + "content=" + Generators.letterStrings(900, 950).next() + "&type=json"; // Long parameter with normal
-            case 5 -> pattern + "?" + Generators.strings("input=value123&", 50, 80).next(); // Many small parameters
+            case 3 -> pattern + "?" + "search=" + repeat("term ", 210, 260); // Repeated terms to reach limit
+            case 4 -> pattern + "?" + "content=" + Generators.letterStrings(1010, 1060).next() + "&type=json"; // Long parameter with normal
+            case 5 -> pattern + "?" + repeat("input=value123&", 70, 100); // Many small parameters
             case 6 -> pattern + "?" + "buffer=" + Generators.letterStrings(7800, 7900).next(); // Near LENIENT limit
             case 7 -> pattern + "?" + "payload=" + Generators.letterStrings(1030, 1080).next() + "&extra=data"; // Just over STRICT with extra
             default -> pattern + "?" + "param=" + Generators.letterStrings(1030, 1050).next(); // Default just over STRICT
@@ -178,15 +190,15 @@ public class URLLengthLimitAttackGenerator implements TypedGenerator<String> {
     private String createFragmentOverflow(String pattern) {
         int attackType = hashBasedSelection(8);
         return switch (attackType) {
-            case 0 -> pattern + "#" + Generators.letterStrings(500, 550).next(); // Fragment within reasonable limits
-            case 1 -> pattern + "?param=value#" + Generators.letterStrings(800, 850).next(); // Long fragment with query
-            case 2 -> pattern + "/path#" + "section" + Generators.letterStrings(400, 450).next(); // Named fragment
-            case 3 -> pattern + "#" + "anchor_" + Generators.letterStrings(600, 650).next(); // Fragment with prefix
-            case 4 -> pattern + "?data=test#" + Generators.letterStrings(900, 950).next(); // Long fragment near STRICT
-            case 5 -> pattern + "#" + Generators.strings("part_", 60, 80).next(); // Repeated fragment parts
+            case 0 -> pattern + "#" + Generators.letterStrings(1030, 1080).next(); // Fragment just over STRICT
+            case 1 -> pattern + "?param=value#" + Generators.letterStrings(1030, 1080).next(); // Long fragment with query
+            case 2 -> pattern + "/path#" + "section" + Generators.letterStrings(1030, 1080).next(); // Named fragment
+            case 3 -> pattern + "#" + "anchor_" + Generators.letterStrings(1030, 1080).next(); // Fragment with prefix
+            case 4 -> pattern + "?data=test#" + Generators.letterStrings(1030, 1080).next(); // Long fragment over STRICT
+            case 5 -> pattern + "#" + repeat("part_", 210, 260); // Repeated fragment parts
             case 6 -> pattern + "#" + Generators.letterStrings(3800, 3900).next(); // Fragment near DEFAULT limit
-            case 7 -> pattern + "/resource?id=123#" + "content_" + Generators.letterStrings(700, 750).next(); // Mixed with fragment
-            default -> pattern + "#" + Generators.letterStrings(500, 550).next(); // Default fragment
+            case 7 -> pattern + "/resource?id=123#" + "content_" + Generators.letterStrings(1030, 1080).next(); // Mixed with fragment
+            default -> pattern + "#" + Generators.letterStrings(1030, 1080).next(); // Default fragment
         };
     }
 
@@ -196,15 +208,15 @@ public class URLLengthLimitAttackGenerator implements TypedGenerator<String> {
     private String createHostnameOverflow(String pattern) {
         int attackType = hashBasedSelection(8);
         return switch (attackType) {
-            case 0 -> "https://" + Generators.letterStrings(250, 253).next() + ".com" + pattern; // Near DNS max hostname (253)
-            case 1 -> "https://" + Generators.letterStrings(60, 63).next() + "." + Generators.letterStrings(60, 63).next() + ".com" + pattern; // Near DNS max label (63)
-            case 2 -> "https://" + Generators.strings("subdomain.", 15, 25).next() + "example.com" + pattern; // Many subdomains within reason
-            case 3 -> "https://" + Generators.letterStrings(100, 120).next() + ".evil.com" + pattern; // Long but reasonable subdomain
-            case 4 -> "https://" + Generators.strings("sub", 50, 80).next() + ".domain.com" + pattern; // Repeated subdomain parts
-            case 5 -> "https://" + Generators.letterStrings(80, 100).next() + ".attacker.org" + pattern; // Long subdomain
-            case 6 -> "https://" + Generators.letterStrings(150, 200).next() + ".malicious.net" + pattern; // Very long hostname part
-            case 7 -> "https://" + Generators.strings("long", 30, 50).next() + ".test.com" + pattern; // Multiple long parts
-            default -> "https://" + Generators.letterStrings(100, 120).next() + ".com" + pattern; // Default long hostname
+            case 0 -> "https://" + Generators.letterStrings(1030, 1080).next() + ".com" + pattern; // Single label far past DNS max (253)
+            case 1 -> "https://" + Generators.letterStrings(520, 560).next() + "." + Generators.letterStrings(520, 560).next() + ".com" + pattern; // Two labels each far past DNS max (63)
+            case 2 -> "https://" + repeat("subdomain.", 105, 130) + "example.com" + pattern; // Many subdomains
+            case 3 -> "https://" + Generators.letterStrings(1030, 1080).next() + ".evil.com" + pattern; // Long subdomain
+            case 4 -> "https://" + repeat("sub", 350, 420) + ".domain.com" + pattern; // Repeated subdomain parts
+            case 5 -> "https://" + Generators.letterStrings(1030, 1080).next() + ".attacker.org" + pattern; // Long subdomain
+            case 6 -> "https://" + Generators.letterStrings(1050, 1200).next() + ".malicious.net" + pattern; // Very long hostname part
+            case 7 -> "https://" + repeat("long", 265, 320) + ".test.com" + pattern; // Multiple long parts
+            default -> "https://" + Generators.letterStrings(1030, 1080).next() + ".com" + pattern; // Default long hostname
         };
     }
 
@@ -214,15 +226,15 @@ public class URLLengthLimitAttackGenerator implements TypedGenerator<String> {
     private String createRepeatedParameterAttack(String pattern) {
         int attackType = hashBasedSelection(8);
         return switch (attackType) {
-            case 0 -> pattern + "?" + Generators.strings("param=value&", 30, 50).next(); // Many small parameters to reach limit
-            case 1 -> pattern + "?" + Generators.strings("data=test&", 40, 60).next(); // Repeated parameters
-            case 2 -> pattern + "?" + Generators.strings("field=info&", 25, 35).next(); // Parameter repetition
-            case 3 -> pattern + "?" + Generators.strings("item=" + Generators.letterStrings(20, 30).next() + "&", 15, 25).next(); // Parameters with medium values
-            case 4 -> pattern + "?" + Generators.strings("query=search&", 35, 55).next(); // Many search parameters
-            case 5 -> pattern + "?" + Generators.strings("param" + Generators.letterStrings(10, 15).next() + "=value&", 20, 30).next(); // Varied parameter names
-            case 6 -> pattern + "?" + Generators.strings("test=data&", 60, 90).next(); // Many test parameters
-            case 7 -> pattern + "?" + Generators.strings("key=value" + Generators.letterStrings(5, 10).next() + "&", 25, 40).next(); // Mixed parameters
-            default -> pattern + "?" + Generators.strings("param=value&", 30, 50).next(); // Default repeated parameters
+            case 0 -> pattern + "?" + repeat("param=value&", 90, 130); // Many small parameters to reach limit
+            case 1 -> pattern + "?" + repeat("data=test&", 105, 150); // Repeated parameters
+            case 2 -> pattern + "?" + repeat("field=info&", 95, 140); // Parameter repetition
+            case 3 -> pattern + "?" + repeat("item=" + Generators.letterStrings(20, 30).next() + "&", 40, 60); // Parameters with medium values
+            case 4 -> pattern + "?" + repeat("query=search&", 80, 120); // Many search parameters
+            case 5 -> pattern + "?" + repeat("param" + Generators.letterStrings(10, 15).next() + "=value&", 47, 70); // Varied parameter names
+            case 6 -> pattern + "?" + repeat("test=data&", 105, 150); // Many test parameters
+            case 7 -> pattern + "?" + repeat("key=value" + Generators.letterStrings(5, 10).next() + "&", 70, 100); // Mixed parameters
+            default -> pattern + "?" + repeat("param=value&", 90, 130); // Default repeated parameters
         };
     }
 
@@ -232,15 +244,15 @@ public class URLLengthLimitAttackGenerator implements TypedGenerator<String> {
     private String createDeepPathNesting(String pattern) {
         int attackType = hashBasedSelection(8);
         return switch (attackType) {
-            case 0 -> "/" + Generators.strings("dir/", 40, 60).next() + pattern.substring(1); // Many directory levels to reach limits
-            case 1 -> "/" + Generators.strings("level/", 50, 70).next() + "file"; // Deep levels
-            case 2 -> pattern + "/" + Generators.strings("sub/", 30, 50).next() + "resource"; // Nested levels
-            case 3 -> "/" + Generators.strings("path/", 45, 65).next() + "endpoint"; // Many path segments
-            case 4 -> "/" + Generators.strings("deep/", 20, 30).next() + Generators.strings("very/", 20, 30).next() + "nested/" + pattern.substring(1); // Mixed depths
-            case 5 -> "/" + Generators.strings("dir" + hashBasedSelection(100) + "/", 35, 55).next() + "target"; // Varied directory names
-            case 6 -> "/" + Generators.strings("A/", 80, 120).next() + "final"; // Single-char directories
-            case 7 -> "/" + Generators.strings("folder/subfolder/", 25, 35).next() + "destination"; // Alternating paths
-            default -> "/" + Generators.strings("dir/", 40, 60).next() + pattern.substring(1); // Default deep nesting
+            case 0 -> "/" + repeat("dir/", 260, 320) + pattern.substring(1); // Many directory levels to reach limits
+            case 1 -> "/" + repeat("level/", 175, 220) + "file"; // Deep levels
+            case 2 -> pattern + "/" + repeat("sub/", 260, 320) + "resource"; // Nested levels
+            case 3 -> "/" + repeat("path/", 210, 260) + "endpoint"; // Many path segments
+            case 4 -> "/" + repeat("deep/", 110, 140) + repeat("very/", 110, 140) + "nested/" + pattern.substring(1); // Mixed depths
+            case 5 -> "/" + repeat("dir" + hashBasedSelection(100) + "/", 210, 280) + "target"; // Varied directory names
+            case 6 -> "/" + repeat("A/", 520, 640) + "final"; // Single-char directories
+            case 7 -> "/" + repeat("folder/subfolder/", 62, 90) + "destination"; // Alternating paths
+            default -> "/" + repeat("dir/", 260, 320) + pattern.substring(1); // Default deep nesting
         };
     }
 
@@ -250,15 +262,15 @@ public class URLLengthLimitAttackGenerator implements TypedGenerator<String> {
     private String createLongParameterNames(String pattern) {
         int attackType = hashBasedSelection(8);
         return switch (attackType) {
-            case 0 -> pattern + "?" + Generators.letterStrings(900, 950).next() + "=value"; // Long parameter name near STRICT
-            case 1 -> pattern + "?" + "param_" + Generators.letterStrings(800, 850).next() + "=data"; // Long name with prefix
-            case 2 -> pattern + "?" + Generators.letterStrings(700, 750).next() + "=test&normal=ok"; // Long name with normal parameter
-            case 3 -> pattern + "?" + "field_name_" + Generators.letterStrings(600, 650).next() + "=content"; // Descriptive long name
+            case 0 -> pattern + "?" + Generators.letterStrings(1020, 1060).next() + "=value"; // Long parameter name over STRICT
+            case 1 -> pattern + "?" + "param_" + Generators.letterStrings(1015, 1060).next() + "=data"; // Long name with prefix
+            case 2 -> pattern + "?" + Generators.letterStrings(1010, 1060).next() + "=test&normal=ok"; // Long name with normal parameter
+            case 3 -> pattern + "?" + "field_name_" + Generators.letterStrings(1005, 1050).next() + "=content"; // Descriptive long name
             case 4 -> pattern + "?" + Generators.letterStrings(3800, 3900).next() + "=info"; // Parameter name near DEFAULT limit
-            case 5 -> pattern + "?" + Generators.strings("parameter_" + Generators.letterStrings(20, 30).next() + "=value&", 10, 15).next(); // Multiple medium names
+            case 5 -> pattern + "?" + repeat("parameter_" + Generators.letterStrings(20, 30).next() + "=value&", 30, 45); // Multiple medium names
             case 6 -> pattern + "?" + Generators.letterStrings(1030, 1080).next() + "=result"; // Just over STRICT limit
-            case 7 -> pattern + "?" + "query_string_parameter_name_" + Generators.letterStrings(500, 550).next() + "=search"; // Very descriptive name
-            default -> pattern + "?" + Generators.letterStrings(900, 950).next() + "=value"; // Default long name
+            case 7 -> pattern + "?" + "query_string_parameter_name_" + Generators.letterStrings(990, 1040).next() + "=search"; // Very descriptive name
+            default -> pattern + "?" + Generators.letterStrings(1020, 1060).next() + "=value"; // Default long name
         };
     }
 
@@ -272,9 +284,9 @@ public class URLLengthLimitAttackGenerator implements TypedGenerator<String> {
             case 1 -> pattern + "?content=" + Generators.letterStrings(4100, 4150).next(); // Just over DEFAULT limit
             case 2 -> pattern + "?payload=" + Generators.letterStrings(8200, 8250).next(); // Just over LENIENT limit
             case 3 -> pattern + "?info=" + Generators.letterStrings(2000, 2100).next(); // Medium length value
-            case 4 -> pattern + "?search=" + Generators.strings("query ", 150, 200).next(); // Repeated search terms
+            case 4 -> pattern + "?search=" + repeat("query ", 175, 220); // Repeated search terms
             case 5 -> pattern + "?input=" + Generators.letterStrings(3000, 3200).next(); // Large but reasonable value
-            case 6 -> pattern + "?field=" + "value_" + Generators.letterStrings(900, 950).next(); // Long value with prefix
+            case 6 -> pattern + "?field=" + "value_" + Generators.letterStrings(1015, 1060).next(); // Long value with prefix
             case 7 -> pattern + "?buffer=" + Generators.letterStrings(7800, 7900).next(); // Near LENIENT limit
             default -> pattern + "?data=" + Generators.letterStrings(1030, 1080).next(); // Default just over STRICT
         };
@@ -286,15 +298,15 @@ public class URLLengthLimitAttackGenerator implements TypedGenerator<String> {
     private String createMixedLengthAttacks(String pattern) {
         int attackType = hashBasedSelection(8);
         return switch (attackType) {
-            case 0 -> "/" + Generators.letterStrings(300, 350).next() + pattern + "?" + "param=" + Generators.letterStrings(300, 350).next() + "#" + Generators.letterStrings(300, 350).next(); // Distributed length components
-            case 1 -> pattern + "/" + Generators.letterStrings(500, 550).next() + "?" + Generators.letterStrings(400, 450).next() + "=value"; // Long path segment and parameter name
-            case 2 -> "/" + Generators.strings("path/", 15, 25).next() + pattern.substring(1) + "?" + "data=" + Generators.letterStrings(800, 850).next(); // Deep path with long parameter
+            case 0 -> "/" + Generators.letterStrings(350, 400).next() + pattern + "?" + "param=" + Generators.letterStrings(350, 400).next() + "#" + Generators.letterStrings(350, 400).next(); // Distributed length components
+            case 1 -> pattern + "/" + Generators.letterStrings(560, 610).next() + "?" + Generators.letterStrings(460, 510).next() + "=value"; // Long path segment and parameter name
+            case 2 -> "/" + repeat("path/", 15, 25) + pattern.substring(1) + "?" + "data=" + Generators.letterStrings(960, 1010).next(); // Deep path with long parameter
             case 3 -> pattern + "/" + Generators.letterStrings(400, 450).next() + "/" + Generators.letterStrings(400, 450).next() + "?" + "query=" + Generators.letterStrings(600, 650).next(); // Multiple medium components
-            case 4 -> "/" + Generators.letterStrings(800, 850).next() + "?" + Generators.strings("param" + Generators.letterStrings(15, 20).next() + "=" + Generators.letterStrings(15, 20).next() + "&", 8, 12).next(); // Long path with parameters
+            case 4 -> "/" + Generators.letterStrings(800, 850).next() + "?" + repeat("param" + Generators.letterStrings(15, 20).next() + "=" + Generators.letterStrings(15, 20).next() + "&", 8, 12); // Long path with parameters
             case 5 -> pattern + "/" + "segment_" + Generators.letterStrings(400, 450).next() + "?" + "field_" + Generators.letterStrings(200, 250).next() + "=" + Generators.letterStrings(400, 450).next() + "#anchor_" + Generators.letterStrings(200, 250).next(); // All components reasonable
-            case 6 -> "/" + Generators.strings("dir/", 30, 50).next() + "resource" + "?" + "buffer=" + Generators.letterStrings(600, 650).next(); // Deep nesting with parameter
-            case 7 -> "https://" + Generators.letterStrings(80, 100).next() + ".example.com" + pattern + "/" + Generators.letterStrings(300, 350).next() + "?" + "data=" + Generators.letterStrings(400, 450).next(); // Long hostname, path, and parameter
-            default -> pattern + "/" + Generators.letterStrings(400, 450).next() + "?" + "param=" + Generators.letterStrings(400, 450).next(); // Default mixed length
+            case 6 -> "/" + repeat("dir/", 30, 50) + "resource" + "?" + "buffer=" + Generators.letterStrings(910, 960).next(); // Deep nesting with parameter
+            case 7 -> "https://" + Generators.letterStrings(80, 100).next() + ".example.com" + pattern + "/" + Generators.letterStrings(450, 500).next() + "?" + "data=" + Generators.letterStrings(560, 610).next(); // Long hostname, path, and parameter
+            default -> pattern + "/" + Generators.letterStrings(510, 560).next() + "?" + "param=" + Generators.letterStrings(510, 560).next(); // Default mixed length
         };
     }
 
@@ -308,7 +320,7 @@ public class URLLengthLimitAttackGenerator implements TypedGenerator<String> {
             case 1 -> pattern + "/" + Generators.letterStrings(4100, 4200).next() + "?" + "data=" + Generators.letterStrings(4100, 4200).next(); // DEFAULT limit overflow in both components
             case 2 -> pattern + "?" + "buffer=" + Generators.letterStrings(9000, 9500).next(); // Moderate buffer test
             case 3 -> "/" + Generators.letterStrings(2000, 2100).next() + pattern + "?" + "payload=" + Generators.letterStrings(6000, 6500).next(); // Distributed length test
-            case 4 -> pattern + "?" + Generators.strings("overflow" + Generators.letterStrings(20, 30).next() + "=data&", 30, 50).next(); // Many parameters with patterns
+            case 4 -> pattern + "?" + repeat("overflow" + Generators.letterStrings(20, 30).next() + "=data&", 35, 55); // Many parameters with patterns
             case 5 -> pattern + "/" + Generators.letterStrings(8300, 8400).next(); // Path component just over LENIENT
             case 6 -> pattern + "?" + "input=" + Generators.letterStrings(10000, 12000).next(); // Large but not extreme parameter
             case 7 -> pattern + "#" + Generators.letterStrings(7000, 7500).next(); // Large fragment
@@ -324,10 +336,10 @@ public class URLLengthLimitAttackGenerator implements TypedGenerator<String> {
         return switch (attackType) {
             case 0 -> pattern + "?" + "memory=" + Generators.letterStrings(12000, 15000).next(); // Large but reasonable parameter
             case 1 -> pattern + "/" + Generators.letterStrings(4000, 4500).next() + "?" + "data=" + Generators.letterStrings(4000, 4500).next(); // Distributed large components
-            case 2 -> pattern + "?" + Generators.strings("param" + hashBasedSelection(100) + "=" + Generators.letterStrings(20, 30).next() + "&", 100, 200).next(); // Many parameters with varied data
+            case 2 -> pattern + "?" + repeat("param" + hashBasedSelection(100) + "=" + Generators.letterStrings(20, 30).next() + "&", 100, 200); // Many parameters with varied data
             case 3 -> pattern + "?" + "exhaustion=" + Generators.letterStrings(20000, 25000).next(); // Large parameter test
             case 4 -> "/" + Generators.letterStrings(6000, 8000).next() + pattern; // Large path prefix
-            case 5 -> pattern + "?" + "large_data=" + Generators.strings("chunk" + Generators.letterStrings(50, 100).next(), 50, 100).next(); // Structured data within limits
+            case 5 -> pattern + "?" + "large_data=" + repeat("chunk" + Generators.letterStrings(50, 100).next(), 50, 100); // Structured data within limits
             case 6 -> pattern + "#" + Generators.letterStrings(10000, 15000).next(); // Large fragment
             case 7 -> pattern + "?" + "payload=" + Generators.letterStrings(30000, 35000).next(); // Large payload test
             default -> pattern + "?" + "memory=" + Generators.letterStrings(12000, 15000).next(); // Default memory test
@@ -340,15 +352,15 @@ public class URLLengthLimitAttackGenerator implements TypedGenerator<String> {
     private String createAlgorithmicComplexity(String pattern) {
         int attackType = hashBasedSelection(8);
         return switch (attackType) {
-            case 0 -> pattern + "?" + Generators.strings("a=b&", 200, 400).next(); // Many small parameters within reason
-            case 1 -> pattern + "/" + Generators.strings("x/", 150, 300).next() + "target"; // Many small path segments
-            case 2 -> "/" + Generators.strings("../", 100, 200).next() + pattern; // Path traversal attempts within limits
-            case 3 -> pattern + "?" + Generators.strings("param" + hashBasedSelection(100) + "=value" + hashBasedSelection(100) + "&", 50, 100).next(); // Varied parameter names
-            case 4 -> pattern + "/" + Generators.strings("segment" + hashBasedSelection(50), 80, 150).next(); // Varied path segments
-            case 5 -> pattern + "?" + "regex=" + Generators.strings("(a+)+", 30, 60).next(); // Regex complexity pattern
-            case 6 -> pattern + "/" + Generators.strings("a" + Generators.strings("/b", 20, 40).next(), 15, 30).next(); // Nested pattern complexity
-            case 7 -> pattern + "?" + Generators.strings("key=value&", 150, 300).next(); // Numerous but reasonable parameters
-            default -> pattern + "?" + Generators.strings("a=b&", 200, 400).next(); // Default complexity attack
+            case 0 -> pattern + "?" + repeat("a=b&", 260, 400); // Many small parameters within reason
+            case 1 -> pattern + "/" + repeat("x/", 520, 700) + "target"; // Many small path segments
+            case 2 -> "/" + repeat("../", 350, 450) + pattern; // Path traversal attempts within limits
+            case 3 -> pattern + "?" + repeat("param" + hashBasedSelection(100) + "=value" + hashBasedSelection(100) + "&", 90, 150); // Varied parameter names
+            case 4 -> pattern + "/" + repeat("segment" + hashBasedSelection(50), 130, 200); // Varied path segments
+            case 5 -> pattern + "?" + "regex=" + repeat("(a+)+", 210, 260); // Regex complexity pattern
+            case 6 -> pattern + "/" + repeat("a" + repeat("/b", 20, 40), 26, 45); // Nested pattern complexity
+            case 7 -> pattern + "?" + repeat("key=value&", 105, 300); // Numerous but reasonable parameters
+            default -> pattern + "?" + repeat("a=b&", 260, 400); // Default complexity attack
         };
     }
 
@@ -367,6 +379,26 @@ public class URLLengthLimitAttackGenerator implements TypedGenerator<String> {
      */
     private int hashBasedSelection(int bound) {
         return Generators.integers(0, bound - 1).next();
+    }
+
+    /**
+     * Repeats a multi-character token a seed-reproducible number of times.
+     *
+     * <p>This is deliberately <em>not</em> {@code Generators.strings(token, min, max)}: that
+     * factory treats its first argument as an alphabet and draws {@code min..max}
+     * <em>characters</em> from it, so a multi-character token yields a short scramble of the
+     * token's characters rather than the intended repetition. Every attack branch below that
+     * needs a repeated token uses this helper, so the produced component length is
+     * {@code token.length() * count} and can be reasoned about against the length limits the
+     * generator targets.</p>
+     *
+     * @param token the token to repeat, must not be empty
+     * @param minCount minimum number of repetitions, inclusive
+     * @param maxCount maximum number of repetitions, inclusive
+     * @return the token repeated between {@code minCount} and {@code maxCount} times
+     */
+    private String repeat(String token, int minCount, int maxCount) {
+        return token.repeat(Generators.integers(minCount, maxCount).next());
     }
 
     /**

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLParameterGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLParameterGeneratorTest.java
@@ -15,34 +15,129 @@
  */
 package de.cuioss.http.security.generators.url;
 
+import de.cuioss.http.security.config.SecurityConfiguration;
 import de.cuioss.http.security.data.URLParameter;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.pipeline.URLParameterValidationPipeline;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * QI-5: Basic generator test for ValidURLParameterGenerator.
+ * Contract test for {@link ValidURLParameterGenerator}.
  *
- * <p>
- * Simple validation to ensure the generator works without exceptions and produces
- * non-null, non-empty output. Following cui-test-generator lightweight testing pattern.
- * </p>
- *
- * @author QI-5 Generator Coverage Initiative
+ * <p>The defining property of this generator is that every emitted parameter is a legitimate
+ * name/value pair: the name is a lower-case identifier, the value is alphanumeric, neither
+ * carries an attack marker, and the value is accepted by the URL parameter validation pipeline.
+ * The aggregate test asserts that the generator's name and value vocabularies are broad.</p>
  */
 @EnableGeneratorController
+@DisplayName("ValidURLParameterGenerator Contract Tests")
 class ValidURLParameterGeneratorTest {
 
+    private static final int AGGREGATE_DRAWS = 400;
+    private static final int MIN_DISTINCT_NAMES = 12;
+    private static final int MIN_DISTINCT_VALUE_SHAPES = 6;
+
+    private static final Pattern NAME_PATTERN = Pattern.compile("[a-z][a-z0-9_]*");
+    private static final Pattern VALUE_PATTERN = Pattern.compile("[A-Za-z0-9_]+");
+    private static final Pattern NUMERIC_VALUE = Pattern.compile("\\d+");
+
+    private static final Set<String> BOOLEAN_VALUES = Set.of("true", "false");
+    private static final Set<String> SORT_VALUES = Set.of("asc", "desc");
+    private static final Set<String> FORMAT_VALUES = Set.of("json", "xml", "csv", "html");
+    private static final Set<String> LANGUAGE_VALUES = Set.of("en", "de", "fr", "es", "ja");
+    private static final Set<String> STATUS_VALUES = Set.of("active", "inactive", "pending", "deleted");
+    private static final Set<String> TEST_VALUES = Set.of("test", "example", "demo", "sample");
+
     @ParameterizedTest
-    @TypeGeneratorSource(value = ValidURLParameterGenerator.class, count = 10)
-    @DisplayName("Generator should produce valid non-null URL parameters")
-    void shouldGenerateValidOutput(URLParameter generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
-        assertNotNull(generatedValue.name(), "URL parameter name should not be null");
-        assertFalse(generatedValue.name().isEmpty(), "URL parameter name should not be empty");
-        assertTrue(generatedValue.name().length() > 1, "URL parameter names should be meaningful (more than 1 character)");
+    @TypeGeneratorSource(value = ValidURLParameterGenerator.class, count = 100)
+    @DisplayName("Every generated parameter is legitimate and its value is accepted by the pipeline")
+    void shouldGenerateLegitimateParameter(URLParameter generatedValue) {
+        String name = generatedValue.name();
+        String value = generatedValue.value();
+
+        assertTrue(NAME_PATTERN.matcher(name).matches(),
+                () -> "Parameter name must be a lower-case identifier. Value: <" + name + ">");
+        assertTrue(VALUE_PATTERN.matcher(value).matches(),
+                () -> "Parameter value must be alphanumeric. Value: <" + value + ">");
+        assertCarriesNoMarker(name, "name");
+        assertCarriesNoMarker(value, "value");
+
+        assertPipelineAccepts(
+                new URLParameterValidationPipeline(SecurityConfiguration.defaults(), new SecurityEventCounter()),
+                value);
+    }
+
+    @Test
+    @DisplayName("Should reach a broad name and value vocabulary")
+    void shouldReachBroadVocabulary() {
+        ValidURLParameterGenerator generator = new ValidURLParameterGenerator();
+        Set<String> names = new HashSet<>();
+        Set<String> valueShapes = new HashSet<>();
+
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            URLParameter parameter = generator.next();
+            names.add(parameter.name());
+            valueShapes.add(classifyValueShape(parameter.value()));
+        }
+
+        assertAll("Vocabulary breadth",
+                () -> assertTrue(names.size() >= MIN_DISTINCT_NAMES,
+                        () -> "Expected at least " + MIN_DISTINCT_NAMES + " distinct names, got "
+                                + names.size() + ": " + names),
+                () -> assertTrue(valueShapes.size() >= MIN_DISTINCT_VALUE_SHAPES,
+                        () -> "Expected at least " + MIN_DISTINCT_VALUE_SHAPES
+                                + " distinct value shapes, got " + valueShapes.size() + ": " + valueShapes));
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(URLParameter.class, new ValidURLParameterGenerator().getType(),
+                "Generator should return URLParameter.class");
+    }
+
+    private static String classifyValueShape(String value) {
+        if (NUMERIC_VALUE.matcher(value).matches()) {
+            return "number";
+        }
+        if (BOOLEAN_VALUES.contains(value)) {
+            return "boolean";
+        }
+        if (SORT_VALUES.contains(value)) {
+            return "sort";
+        }
+        if (FORMAT_VALUES.contains(value)) {
+            return "format";
+        }
+        if (LANGUAGE_VALUES.contains(value)) {
+            return "language";
+        }
+        if (STATUS_VALUES.contains(value)) {
+            return "status";
+        }
+        if (TEST_VALUES.contains(value)) {
+            return "test";
+        }
+        return fail("Value <" + value + "> belongs to no documented value shape");
+    }
+
+    private static void assertCarriesNoMarker(String component, String description) {
+        TRAVERSAL_MARKERS.forEach(marker -> assertFalse(component.contains(marker),
+                () -> "Valid parameter " + description + " carries no traversal marker <" + marker
+                        + ">. Value: <" + component + ">"));
+        NULL_BYTE_MARKERS.forEach(marker -> assertFalse(component.contains(marker),
+                () -> "Valid parameter " + description + " carries no null-byte marker <" + marker
+                        + ">. Value: <" + component + ">"));
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLPathGeneratorTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLPathGeneratorTest.java
@@ -15,32 +15,114 @@
  */
 package de.cuioss.http.security.generators.url;
 
+import de.cuioss.http.security.config.SecurityConfiguration;
+import de.cuioss.http.security.monitoring.SecurityEventCounter;
+import de.cuioss.http.security.pipeline.URLPathValidationPipeline;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static de.cuioss.http.security.generators.GeneratorContractAssertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * QI-5: Basic generator test for ValidURLPathGenerator.
+ * Contract test for {@link ValidURLPathGenerator}.
  *
- * <p>
- * Simple validation to ensure the generator works without exceptions and produces
- * non-null, non-empty output. Following cui-test-generator lightweight testing pattern.
- * </p>
- *
- * @author QI-5 Generator Coverage Initiative
+ * <p>The defining property of this generator is that every emitted value is a legitimate API
+ * path: it is rooted at {@code /}, carries no attack marker, and is accepted by the URL path
+ * validation pipeline. The aggregate test asserts that all seven documented path families are
+ * reachable.</p>
  */
 @EnableGeneratorController
+@DisplayName("ValidURLPathGenerator Contract Tests")
 class ValidURLPathGeneratorTest {
 
+    private static final int AGGREGATE_DRAWS = 400;
+
+    private static final Set<String> SYSTEM_PATHS = Set.of("/health", "/metrics", "/status", "/info");
+    private static final String RESOURCES = "(users|orders|products|customers|documents)";
+    private static final Pattern PLAIN_API =
+            Pattern.compile("^/api/" + RESOURCES + "(/\\d+/(search|profile|login|logout))?$");
+    private static final Pattern VERSIONED_API =
+            Pattern.compile("^/api/v[123]/" + RESOURCES + "(/\\d+)?$");
+    private static final Pattern NESTED_RESOURCE =
+            Pattern.compile("^/api/" + RESOURCES + "/\\d+/(items|orders|profile|notifications)$");
+    private static final Pattern AUTH_PATH =
+            Pattern.compile("^/api/auth/(search|profile|login|logout)$");
+    private static final Pattern ADMIN_PATH =
+            Pattern.compile("^/api/admin/(dashboard|settings|config)$");
+    private static final Pattern REPORTING_PATH =
+            Pattern.compile("^/api/(reports|stats|backup)/(daily|summary|status)$");
+
     @ParameterizedTest
-    @TypeGeneratorSource(value = ValidURLPathGenerator.class, count = 10)
-    @DisplayName("Generator should produce valid non-null URL paths")
-    void shouldGenerateValidOutput(String generatedValue) {
-        assertNotNull(generatedValue, "Generator must not produce null values");
-        assertFalse(generatedValue.isEmpty(), "Generator should produce non-empty URL paths");
-        assertTrue(generatedValue.length() > 1, "URL paths should be meaningful (more than 1 character)");
+    @TypeGeneratorSource(value = ValidURLPathGenerator.class, count = 100)
+    @DisplayName("Every generated path is a legitimate API path the pipeline accepts")
+    void shouldGenerateLegitimateApiPath(String generatedValue) {
+        assertTrue(generatedValue.startsWith("/"),
+                () -> "Valid URL paths are rooted at '/'. Value: <" + generatedValue + ">");
+        assertCarriesNoMarker(generatedValue, TRAVERSAL_MARKERS, "path traversal");
+        assertCarriesNoMarker(generatedValue, NULL_BYTE_MARKERS, "null byte");
+        assertFalse(generatedValue.contains("<script"),
+                () -> "Valid URL paths carry no script tag. Value: <" + generatedValue + ">");
+        assertFalse(generatedValue.contains("javascript:"),
+                () -> "Valid URL paths carry no javascript protocol. Value: <" + generatedValue + ">");
+
+        assertPipelineAccepts(
+                new URLPathValidationPipeline(SecurityConfiguration.defaults(), new SecurityEventCounter()),
+                generatedValue);
+    }
+
+    @Test
+    @DisplayName("Should reach all seven documented path families")
+    void shouldReachAllPathFamilies() {
+        ValidURLPathGenerator generator = new ValidURLPathGenerator();
+        Set<String> families = new HashSet<>();
+
+        for (int i = 0; i < AGGREGATE_DRAWS; i++) {
+            String value = generator.next();
+            if (SYSTEM_PATHS.contains(value)) {
+                families.add("system");
+            }
+            if (VERSIONED_API.matcher(value).matches()) {
+                families.add("versioned");
+            }
+            if (NESTED_RESOURCE.matcher(value).matches()) {
+                families.add("nested");
+            }
+            if (AUTH_PATH.matcher(value).matches()) {
+                families.add("auth");
+            }
+            if (ADMIN_PATH.matcher(value).matches()) {
+                families.add("admin");
+            }
+            if (REPORTING_PATH.matcher(value).matches()) {
+                families.add("reporting");
+            }
+            if (PLAIN_API.matcher(value).matches()) {
+                families.add("api");
+            }
+        }
+
+        assertEquals(Set.of("api", "versioned", "nested", "system", "auth", "admin", "reporting"), families,
+                "Every documented path family must be reachable within " + AGGREGATE_DRAWS + " draws");
+    }
+
+    @Test
+    @DisplayName("Should return correct type")
+    void shouldReturnCorrectType() {
+        assertEquals(String.class, new ValidURLPathGenerator().getType(),
+                "Generator should return String.class");
+    }
+
+    private static void assertCarriesNoMarker(String value, Set<String> markers, String description) {
+        markers.forEach(marker -> assertFalse(value.contains(marker),
+                () -> "Valid URL paths carry no " + description + " marker <" + marker
+                        + ">. Value: <" + value + ">"));
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/security/tests/URLLengthLimitAttackTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/security/tests/URLLengthLimitAttackTest.java
@@ -24,10 +24,13 @@ import de.cuioss.http.security.pipeline.URLPathValidationPipeline;
 import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
 import de.cuioss.test.generator.junit.parameterized.TypeGeneratorSource;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -80,8 +83,45 @@ import static org.junit.jupiter.api.Assertions.*;
 @DisplayName("T19: URL Length Limit Attack Tests")
 class URLLengthLimitAttackTest {
 
+    /**
+     * Sample counters for the two guarded parameterized tests. Both tests skip samples whose path
+     * component stays within the configured limit, because {@link URLPathValidationPipeline}
+     * genuinely does not govern hostname- and fragment-family attacks. That guard is only sound
+     * while it still admits samples: if the generator ever stops producing over-limit path
+     * components, the guard would swallow every sample and both tests would pass while asserting
+     * nothing. The {@link #shouldHaveAdmittedPathBasedSamples()} check turns that silent
+     * degradation into a failure.
+     */
+    private static final AtomicInteger REJECT_TEST_SAMPLES = new AtomicInteger();
+    private static final AtomicInteger REJECT_TEST_ADMITTED = new AtomicInteger();
+    private static final AtomicInteger BLOCK_TEST_SAMPLES = new AtomicInteger();
+    private static final AtomicInteger BLOCK_TEST_ADMITTED = new AtomicInteger();
+
     private URLPathValidationPipeline pipeline;
     private SecurityEventCounter eventCounter;
+
+    @AfterAll
+    static void shouldHaveAdmittedPathBasedSamples() {
+        assertAll("Guarded parameterized tests must not degrade into silent no-ops",
+                () -> assertGuardAdmittedSamples("shouldRejectPathBasedURLLengthLimitAttacks",
+                        REJECT_TEST_SAMPLES, REJECT_TEST_ADMITTED),
+                () -> assertGuardAdmittedSamples("shouldBlockBasicPathBasedLengthOverflowAttacks",
+                        BLOCK_TEST_SAMPLES, BLOCK_TEST_ADMITTED));
+    }
+
+    /**
+     * Asserts that a guarded test admitted at least one sample, but only when that test actually
+     * ran. Skipping the assertion for a test with zero samples keeps a single-method IDE run from
+     * failing on the sibling method it never executed.
+     */
+    private static void assertGuardAdmittedSamples(String testName, AtomicInteger samples, AtomicInteger admitted) {
+        if (samples.get() == 0) {
+            return;
+        }
+        assertTrue(admitted.get() > 0,
+                () -> testName + " saw " + samples.get() + " generated samples but its path-based guard "
+                        + "admitted none — the test asserted nothing this run");
+    }
 
     @BeforeEach
     void setUp() {
@@ -114,9 +154,11 @@ class URLLengthLimitAttackTest {
     void shouldRejectPathBasedURLLengthLimitAttacks(String lengthAttackPattern) {
         // Given: A URL length limit attack pattern from the generator
         //  Only test path-based attacks (skip hostname-based attacks for this pipeline)
+        REJECT_TEST_SAMPLES.incrementAndGet();
         if (!isPathBasedLengthAttack(lengthAttackPattern)) {
             return; // Skip hostname-based attacks
         }
+        REJECT_TEST_ADMITTED.incrementAndGet();
 
         long initialEventCount = eventCounter.getTotalCount();
 
@@ -153,9 +195,11 @@ class URLLengthLimitAttackTest {
     @DisplayName("Basic path-based length overflow attacks must be blocked")
     void shouldBlockBasicPathBasedLengthOverflowAttacks(String basicLengthAttack) {
         // Only test path-based attacks (skip hostname-based attacks for this pipeline)
+        BLOCK_TEST_SAMPLES.incrementAndGet();
         if (!isPathBasedLengthAttack(basicLengthAttack)) {
             return; // Skip hostname-based attacks
         }
+        BLOCK_TEST_ADMITTED.incrementAndGet();
 
         long initialEventCount = eventCounter.getTotalCount();
 


### PR DESCRIPTION
## Summary

Adds semantic, failure-capable assertions to the generator-contract test suite (17 weak contract
tests across URL, header, encoding, injection, and cookie generators), replaces the two cookie
generator tests' record-equality exercise with real generator-semantics assertions, applies the
`SupportedValidationTypeGeneratorContractTest`-style defining-property pattern uniformly, and fixes
`AllGeneratorsIntegrationTest.shouldHaveAllGeneratorsImplemented` to assert real generator-output
properties instead of `assertNotNull` on already-initialized fields.

## Intent

<!--
Rendered by `pr_intent_section render`, NOT hand-written — do not author this
section in the body Write. The renderer owns the character budget and its
truncation deterministically (see workflow/create-pr.md § Step 3.4).

ABSENT ENTIRELY, heading included, when the plan has no solution_outline.md (or
its summary and overview sections are both empty). An empty `## Intent` would
imply the intent was considered and found vacuous, which tells a reviewer less
than no section at all.
-->

## Changes

1. Introduce the shared generator-contract assertion helper (`GeneratorContractAssertions`).
2. Add defining-property assertions to the 9 URL and header generator contract tests.
3. Add defining-property assertions to the 4 unblocked encoding and injection contract tests.
4. Fix `EncodingCombinationGenerator` and land its defining-property assertions together.
5. Fix `URLLengthLimitAttackGenerator` and land its defining-property assertions together.
6. Replace the two cookie generator tests' record-equality exercise with generator semantics.
7. Delete the vacuous `AllGeneratorsIntegrationTest.shouldHaveAllGeneratorsImplemented` assertion
   and replace it with a real generator-output property check.

## Absorbed from PLAN-12

This plan absorbed two of PLAN-12's deliverables by operator decision, landing each generator's
production fix in the same coordinated change as its new semantic test assertions so that no
assertion is ever merged in a known-failing state:

- `EncodingCombinationGenerator` production fix (findings TQ-15, TQ-16)
- `URLLengthLimitAttackGenerator` production fix (finding TQ-17)

PLAN-12's scope is otherwise unaffected — production fixes to any other generator remain there.

## Test Plan

- [ ] Verification command passed (`python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Ppre-commit"`)
- [ ] Manual testing completed (if applicable)

## Related Issues

N/A

---
Generated by plan-finalize skill

## Intent

The generator-contract test suite exercised 17 generator contract tests with assertions that could
never fail — mostly `assertNotNull` on fields the generator constructor already initializes — so a
broken generator could ship undetected. Two cookie generator tests additionally exercised
`Cookie::equals` record equality rather than the generator's actual output semantics, and the
integration test claiming to verify "all generators implemented" asserted nothing about generator
behavior at all.

The fix applies one defining-property pattern uniformly across every affected generator family
(URL, header, encoding, injection, cookie): each attack generator's output must exhibit the
property that makes it an attack (e.g. contains `../`, contains a null byte, exceeds a length
limit) and must be rejected by the real validation pipeline, while each valid generator's output
must pass that same pipeline. This is the same pattern already used by
`SupportedValidationTypeGeneratorContractTest`, extended to every remaining weak contract test
via a shared assertion helper so the property check is expressed once and reused.

Two generators — `EncodingCombinationGenerator` and `URLLengthLimitAttackGenerator` — failed their
new defining-property assertions because of real generator bugs. Per operator decision these two
production fixes were pulled forward from PLAN-12 and land in this same

_[Intent truncated — 1392 of 1825 characters shown; full outline in the plan workspace]_
