### PR TITLE
chore(marshal): declare the merge queue as org-managed

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -215,7 +215,7 @@
     ],
     "pr_strategy": "compact",
     "pr_compact_max_changed_files": 150,
-    "merge_queue_managed_externally": false
+    "merge_queue_managed_externally": true
   },
   "providers": [
     {


### PR DESCRIPTION
Aligns `marshal.json` with the org-managed merge queue that is now live on this repo.

## `merge_queue_managed_externally: true`

The field is documented as *"Declares that the org — not plan-marshall — owns the platform merge queue."* That is now literally true: the queue is provisioned from `cuioss-organization/branch-protection/config.json` (`merge_queue_repos`, `merge_method: SQUASH`, `grouping_strategy: ALLGREEN`) and applied by `setup-branch-protection.py --enable-merge-queue`.

Left `false`/absent, `marshall-steward` treats itself as the queue's owner — it runs a local probe as the authority and can prompt to provision a queue it does not own. With the flag set it defers: *"probe-only, no enable call, no operator prompt"*. That is the correct division now that the org config is the source of truth, and it also stops an `ineligible` local reading from blocking a legitimate `use_merge_queue` set.

## Verified

- live queue on `main` reports `SQUASH` (GraphQL `mergeQueue.configuration`)
- `pr_merge_strategy: squash` already agrees with the queue's merge method
- `marshal.json` is the only file touched; the JSON parses, and every other key is byte-identical when compared as parsed JSON with the changed keys stripped