### PR TITLE
docs(http-security): refresh stale inventories and close navigation gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,10 @@ The authoritative Git workflow is defined in the "Git Workflow" section below.
 
 1. **Security Validation Pipelines** (`de.cuioss.http.security.pipeline`)
    - `URLPathValidationPipeline`: All URL validation (paths, full URLs, directory traversal, CVE exploits)
-   - `HTTPHeaderValidationPipeline`: Header injection attacks
-   - `URLParameterValidationPipeline`: Query parameter validation
+   - `URLParameterValidationPipeline`: Query parameter *value* validation
+   - `URLParameterNameValidationPipeline`: Query parameter *name* validation (rejects delimiters that appear only after decoding)
+   - `HTTPHeaderValidationPipeline`: Header injection attacks (header names and values)
+   - `ContentTypeValidationPipeline`: Content-Type allow/block-list enforcement
 
 2. **Validation Stages** (`de.cuioss.http.security.validation`)
    - `DecodingStage`: URL percent-decoding, UTF-8 overlong detection, and Unicode normalization (NFKC for URL paths, NFC for parameter values)
@@ -48,21 +50,26 @@ The authoritative Git workflow is defined in the "Git Workflow" section below.
    - `CharacterValidationStage`: Invalid character detection
    - `LengthValidationStage`: Length limits enforcement
    - `PatternMatchingStage`: Attack pattern detection
+   - `AllowBlockListStage`: Case-insensitive header-name / content-type allow and block lists
+   - `CookiePrefixValidationStage`: RFC 6265bis cookie prefix rules; standalone, invoked via `validateCookie(Cookie)` rather than as part of a factory-built pipeline
+   - `RequestCollectionValidator`: Request-level limits that need collection or attribute context
 
-3. **Client Handlers** (`de.cuioss.http.client.handler`)
-   - `HttpHandler`: General HTTP request/response handling
-   - `SecureSSLContextProvider`: SSL/TLS context management
-   - `HttpStatusFamily`: HTTP status code classification
+3. **Client and Forwarded-Header Packages**
+   - `de.cuioss.http.client`: Log messages and shared client types
+   - `de.cuioss.http.client.adapter`: Async-first adapters with composable retry and ETag caching
+   - `de.cuioss.http.client.converter`: Response-body converters
+   - `de.cuioss.http.client.handler`: `HttpHandler`, `SecureSSLContextProvider`, `HttpStatusFamily`
+   - `de.cuioss.http.client.result`: `HttpResult` sealed interface and `HttpErrorCategory`
+   - `de.cuioss.http.forwarded`: Reverse-proxy / forwarded-header resolution
+
+   See `README.adoc` and `/doc/client-handlers-readme.adoc` for the component documentation.
 
 ### Pipeline Selection Rules
 
-**Use URLPathValidationPipeline for:**
-- All URL validation (paths and full URLs)
-- Attack patterns with or without protocols
-- Directory traversal testing (`../../../etc/passwd`)
-- CVE exploits for specific servers (Apache, IIS, Nginx)
-- XSS or script injection in URLs
-- Full URL parsing with domain validation
+The authoritative selection matrix — one section per concrete pipeline, with Purpose, Use When,
+Current Implementations, and Attack Pattern Examples — lives in
+`/doc/http-security/specification/pipeline-architecture-standards.adoc`. Consult it rather than
+guessing which pipeline a given attack pattern belongs to.
 
 ## Testing Architecture
 

--- a/README.adoc
+++ b/README.adoc
@@ -136,9 +136,11 @@ build-executor commands documented in the "Build Commands" section of `CLAUDE.md
 === Component Documentation
 
 * xref:doc/client-handlers-readme.adoc[HTTP Client Handlers]
+* xref:doc/http-result-pattern.adoc[HTTP Result Pattern] — the `HttpResult<T>` sealed interface and its pattern-matching contract
 * xref:doc/forwarded-header-resolution.adoc[Forwarded / Reverse-Proxy Header Resolution]
 * xref:doc/security-readme.adoc[Security Validation Framework]
 * xref:doc/test-generators-readme.adoc[Security Testing Framework]
+* xref:doc/LogMessages.adoc[Log Messages] — the `HTTP-nnn` message catalogue for the client and forwarded-header components
 
 === Specifications
 

--- a/doc/adr/0004-Documentation_inventories_point_at_package-level_source_trees_not_per-class_enumerations.adoc
+++ b/doc/adr/0004-Documentation_inventories_point_at_package-level_source_trees_not_per-class_enumerations.adoc
@@ -78,9 +78,11 @@ member's existence. If not, the tree already says it better.
 * The "count that carries meaning" carve-out is a judgement, and a generous reading of it
   reintroduces the enumerating shape under an exemption. The carve-out is narrow by intent: the
   number must be an architectural fact, not a convenience.
-* A pointer to a package that is later renamed or removed becomes a broken link. This fails
-  loudly — link validation catches it — whereas a stale enumeration fails silently, so the trade is
-  deliberate.
+* A pointer to a package that is later renamed or removed becomes a broken link. The project runs
+  no link validation today (`pom.xml` configures no AsciiDoc processing, and the Maven workflow
+  skips documentation-only changes), so this breakage is currently silent too. The trade is still
+  deliberate: a broken link is *decidable by a checker*, whereas a stale enumeration is not
+  decidable at all — so the failure mode moves from undetectable to merely undetected.
 
 == Alternatives Considered
 

--- a/doc/adr/0004-Documentation_inventories_point_at_package-level_source_trees_not_per-class_enumerations.adoc
+++ b/doc/adr/0004-Documentation_inventories_point_at_package-level_source_trees_not_per-class_enumerations.adoc
@@ -1,0 +1,111 @@
+= ADR-0004: Documentation inventories point at package-level source trees, not per-class enumerations
+:toc: left
+:toclevels: 2
+:sectnums:
+
+// adr-metadata
+// summary: Documentation that describes a set of code artifacts names the package that holds them and points at the tree, rather than enumerating the members in prose.
+// tags: documentation, drift, maintenance
+// affects: doc/http-security/specification/testing.adoc, doc/http-security/specification/compliance-traceability.adoc, doc/test-framework-structure.adoc, CLAUDE.md
+// supersedes:
+// end-adr-metadata
+
+== Status
+
+Proposed
+
+== Context
+
+Documentation frequently needs to describe a set of code artifacts: the test classes covering a
+subsystem, the concrete implementations behind an interface, the packages a module exports. There
+are two shapes available. The document can enumerate the members — listing each class by name, and
+often stating how many there are — or it can name the package that holds them and point at the tree.
+
+The enumerating shape carries a structural defect: the document asserts a fact the code owns, and
+nothing keeps the two in agreement. Every addition, rename, or removal in the source tree silently
+falsifies the prose, and the falsification is invisible until a reader notices or a review catches
+it. Counts are the sharpest form of this — "(26)" is wrong the moment a twenty-seventh class lands
+— but a per-class link table drifts the same way, just less legibly.
+
+The defect compounds when several documents enumerate the same set. Each becomes an independent
+copy that must be updated together, and a correction applied to one leaves the others asserting the
+old value. A prose count backed by a traceability row is the same claim stored twice; editing one
+face and not the other produces a document that contradicts itself.
+
+Nothing in the build verifies these claims. Type checking, linting, and tests all pass over a
+document whose inventory is a year stale, so the drift accumulates without any signal until it is
+found by inspection.
+
+== Decision
+
+**Documentation that describes a set of code artifacts names the package and points at the tree; it
+does not enumerate the members.**
+
+A section covering a package states what the package is for and links to it. The source tree is the
+inventory, and it is authoritative by construction — it cannot disagree with itself.
+
+Two things survive this rule:
+
+* **A count that carries meaning** may stay in prose when the number is itself the point — an
+  architectural fact a reader needs, not an incidental cardinality. Such a count is verified against
+  the tree when written, and it is edited together with every other statement of the same claim.
+* **An entry with semantic content** may stay enumerated. A list whose entries each say what the
+  member is *for* is documentation, not an inventory; dropping it would lose information the tree
+  does not carry.
+
+The distinguishing question is whether the reader learns something from the entry beyond the
+member's existence. If not, the tree already says it better.
+
+== Consequences
+
+=== Positive
+
+* Inventories cannot drift, because the document no longer asserts what the tree owns.
+* Adding, renaming, or removing a class requires no documentation edit — the pointer stays correct.
+* The surviving counts are few enough to verify by hand, which makes verifying them realistic.
+* A correction has one site rather than several, so the paired-claim class of defect largely
+  disappears.
+
+=== Negative
+
+* A reader who wanted the member list must open the tree; the document no longer answers that
+  question in place.
+* Package-level prose is less specific, so a section that formerly named the exact class covering a
+  behaviour now names only the package.
+
+=== Risks
+
+* The "count that carries meaning" carve-out is a judgement, and a generous reading of it
+  reintroduces the enumerating shape under an exemption. The carve-out is narrow by intent: the
+  number must be an architectural fact, not a convenience.
+* A pointer to a package that is later renamed or removed becomes a broken link. This fails
+  loudly — link validation catches it — whereas a stale enumeration fails silently, so the trade is
+  deliberate.
+
+== Alternatives Considered
+
+**Regenerate the inventories from the tree.** A build step could emit the enumerations, making them
+correct by construction. This solves drift but pays for it in machinery: a generator, a template, an
+invocation in the build, and a diff to review whenever the tree shifts. It also keeps the generated
+prose as a second copy of the tree, so a reader still has two places to look. The cost is
+justifiable where the enumeration carries real value; it is not justifiable to preserve a list whose
+only content is member existence.
+
+**Verify the inventories in CI.** A check could compare each documented list against the tree and
+fail on divergence. This detects drift rather than preventing it, so every unrelated change to the
+tree can turn the documentation build red and demand a doc edit before merging. It converts a
+silent-wrongness problem into a friction problem without removing the duplication that causes both.
+
+**Accept the drift and correct it periodically.** Sweeping the documentation on a schedule keeps the
+enumerations roughly current. This is what produced the divergence the rule exists to remove: between
+sweeps the documents are wrong, nothing signals it, and each sweep must re-derive the same facts.
+
+Each alternative preserves the duplicated claim and then invests in keeping the copies aligned. The
+decision removes the duplication instead, which is why it needs no ongoing machinery.
+
+== References
+
+* `doc/http-security/specification/testing.adoc` — package-level test-framework map
+* `doc/http-security/specification/compliance-traceability.adoc` — count-free coverage summary
+* `doc/test-framework-structure.adoc` — package-level navigation map
+* `CLAUDE.md` — architecture section describing packages rather than enumerating classes

--- a/doc/adr/0005-Documentation_cross-references_use_named_anchors_not_positional_prose.adoc
+++ b/doc/adr/0005-Documentation_cross-references_use_named_anchors_not_positional_prose.adoc
@@ -1,0 +1,97 @@
+= ADR-0005: Documentation cross-references use named anchors, not positional prose
+:toc: left
+:toclevels: 2
+:sectnums:
+
+// adr-metadata
+// summary: A reference from one part of a document to another names its target with an explicit anchor, rather than describing where the target sits on the page.
+// tags: documentation, cross-references, asciidoc
+// affects: doc/http-security/specification/specification.adoc
+// supersedes:
+// end-adr-metadata
+
+== Status
+
+Proposed
+
+== Context
+
+Documents refer to their own other parts constantly — a requirement points at the rule that
+constrains it, a summary points at the detail behind it. The reference can be written two ways. It
+can describe the target's position ("see the note below", "as stated above"), or it can name the
+target with an explicit anchor.
+
+Positional references encode a fact that the document's structure owns and that nothing preserves.
+Any reordering — moving a section, promoting a note, inserting a subsection between the reference
+and its target — silently inverts or breaks the reference, and the document keeps rendering
+perfectly. A "see below" pointing at content that now sits above is not a broken link; it is a
+correct link with wrong prose, so no validator can see it. The reader is simply sent the wrong way.
+
+The failure is asymmetric with the reordering that causes it. Whoever moves a section has no signal
+that a reference elsewhere depended on the old position, and no practical way to find one — the
+dependency is expressed in English, not in markup. So the reference decays as a side effect of an
+edit made somewhere else entirely, by someone who never saw it.
+
+Anchors invert this. A named reference either resolves or it does not, which makes the same class of
+breakage mechanically detectable by the link validation the documentation build already runs.
+
+== Decision
+
+**A cross-reference within a document names its target with an explicit anchor. It does not describe
+the target's position on the page.**
+
+Where a target has no anchor, the reference adds one rather than falling back to positional prose.
+
+Directional words remain acceptable as *narrative flow* when they carry no reference — "the sections
+below cover each stage in turn" orients a reader without pointing at a specific target that could
+move out from under it. The rule governs references, not prose rhythm: the test is whether a reader
+would follow the direction to find a particular thing.
+
+== Consequences
+
+=== Positive
+
+* Reordering a document cannot silently invert a reference; the anchor follows its target.
+* A reference to a removed or renamed target fails loudly at link-validation time instead of
+  misdirecting readers indefinitely.
+* Anchors are navigable — a named reference is a link the reader can follow, where "see below" is
+  an instruction they must execute manually.
+
+=== Negative
+
+* Targets need anchors, so adding a reference sometimes means editing the target section too.
+* Anchor names are themselves a small naming surface to keep sensible and stable.
+
+=== Risks
+
+* A renamed anchor breaks every reference to it. This is the intended trade — the breakage is loud
+  and locatable, where the positional failure it replaces was neither.
+* Auto-generated anchors derived from section titles change when a title is reworded, so a
+  reference can break on an edit that looks purely cosmetic. Link validation catches it, which is
+  precisely the property positional references lack.
+
+== Alternatives Considered
+
+**Keep positional prose and catch drift in review.** Reviewers can notice a "below" that now points
+above. This depends on a reviewer holding both the reference and its target in mind while reading a
+diff that may contain neither — the reference is not part of the change that broke it, so it does
+not appear in the diff at all.
+
+**Keep positional prose and sweep periodically.** A documentation pass can re-read each reference
+and check its direction. This is linear in the number of references, must be redone after every
+structural edit, and leaves the references wrong in between.
+
+**Restrict section reordering.** Freezing document structure would preserve positional references by
+removing the event that breaks them. This subordinates the document's organisation to a limitation
+of its reference style, which is the wrong thing to hold fixed.
+
+The alternatives all leave the reference expressed in a form no tool can check, and then spend
+human attention compensating. The decision moves the reference into a form the existing validation
+already covers.
+
+== References
+
+* `doc/http-security/specification/specification.adoc` — anchored cross-reference to the two-pass
+  pattern-matching note
+* xref:0004-Documentation_inventories_point_at_package-level_source_trees_not_per-class_enumerations.adoc[ADR-0004] —
+  the sibling decision removing prose claims that no tool can verify

--- a/doc/adr/0005-Documentation_cross-references_use_named_anchors_not_positional_prose.adoc
+++ b/doc/adr/0005-Documentation_cross-references_use_named_anchors_not_positional_prose.adoc
@@ -32,8 +32,11 @@ that a reference elsewhere depended on the old position, and no practical way to
 dependency is expressed in English, not in markup. So the reference decays as a side effect of an
 edit made somewhere else entirely, by someone who never saw it.
 
-Anchors invert this. A named reference either resolves or it does not, which makes the same class of
-breakage mechanically detectable by the link validation the documentation build already runs.
+Anchors invert this. A named reference either resolves or it does not, so the same class of breakage
+becomes *mechanically detectable* — a checker can decide it from the document alone, where no tool
+can decide whether "below" still points below. The project runs no such checker today: `pom.xml`
+configures no AsciiDoc processing and the Maven workflow skips documentation-only changes. This
+decision makes the breakage checkable; it does not claim it is currently checked.
 
 == Decision
 
@@ -52,8 +55,8 @@ would follow the direction to find a particular thing.
 === Positive
 
 * Reordering a document cannot silently invert a reference; the anchor follows its target.
-* A reference to a removed or renamed target fails loudly at link-validation time instead of
-  misdirecting readers indefinitely.
+* A reference to a removed or renamed target becomes decidable by a checker, instead of
+  misdirecting readers in a form nothing can detect.
 * Anchors are navigable — a named reference is a link the reader can follow, where "see below" is
   an instruction they must execute manually.
 
@@ -64,11 +67,12 @@ would follow the direction to find a particular thing.
 
 === Risks
 
-* A renamed anchor breaks every reference to it. This is the intended trade — the breakage is loud
-  and locatable, where the positional failure it replaces was neither.
+* A renamed anchor breaks every reference to it. This is the intended trade — the breakage is
+  locatable, where the positional failure it replaces was neither.
 * Auto-generated anchors derived from section titles change when a title is reworded, so a
-  reference can break on an edit that looks purely cosmetic. Link validation catches it, which is
-  precisely the property positional references lack.
+  reference can break on an edit that looks purely cosmetic. **Until a link checker is added to the
+  build, that breakage is silent** — the anchor form makes it findable, not found. Adding such a
+  checker is the follow-on this decision enables and deliberately does not assume.
 
 == Alternatives Considered
 
@@ -85,9 +89,9 @@ structural edit, and leaves the references wrong in between.
 removing the event that breaks them. This subordinates the document's organisation to a limitation
 of its reference style, which is the wrong thing to hold fixed.
 
-The alternatives all leave the reference expressed in a form no tool can check, and then spend
-human attention compensating. The decision moves the reference into a form the existing validation
-already covers.
+The alternatives all leave the reference expressed in a form no tool can check, and then spend human
+attention compensating. The decision moves the reference into a form a tool *could* check — which is
+the precondition for ever automating it, and is worth having before the checker exists.
 
 == References
 

--- a/doc/client-handlers-readme.adoc
+++ b/doc/client-handlers-readme.adoc
@@ -98,6 +98,9 @@ Built-in content converter for String responses.
 
 === Result Handling
 
+For the design rationale behind the sealed hierarchy, the exhaustive pattern-matching contract,
+and worked consumption examples, see xref:http-result-pattern.adoc[HTTP Result Pattern].
+
 ==== xref:../cui-http-core/src/main/java/de/cuioss/http/client/result/HttpResult.java[HttpResult]
 
 Sealed interface for HTTP operation results with type-safe pattern matching.
@@ -128,6 +131,9 @@ Centralized log messages for HTTP operations.
 * Structured logging with CuiLogger
 * Consistent error codes
 * WARN and ERROR levels only
+
+The full `HTTP-nnn` message catalogue — identifier, component, message template, and the
+conditions under which each is emitted — is documented in xref:LogMessages.adoc[Log Messages].
 
 == Usage Examples
 

--- a/doc/http-security/README.adoc
+++ b/doc/http-security/README.adoc
@@ -30,6 +30,9 @@ HTTP/URL path traversal security architecture leveraging Java 21+ built-in types
 xref:specification/pipeline-architecture-standards.adoc[Pipeline Architecture Standards]::
 Detailed standards for validation pipeline selection, configuration, and implementation patterns.
 
+xref:configuration.adoc[Configuration Reference]::
+Central reference for every enforced `SecurityConfiguration` setting: its default across the three presets (`defaults()`, `strict()`, `lenient()`) and the stage or validator that enforces it.
+
 === Security Analysis
 
 xref:analysis/owasp-best-practices.adoc[OWASP Best Practices]::
@@ -49,6 +52,9 @@ In-depth analysis of RFC 6265bis Cookie Chaos vulnerabilities, prefix validation
 xref:specification/testing.adoc[Testing Framework]::
 Complete testing framework specification including CVE-based test vectors, encoding matrices, and automated security validation.
 
+xref:specification/compliance-traceability.adoc[Compliance Traceability Matrix]::
+Traceability from each claimed standard (OWASP Top 10, CWE Top 25, NIST 800-53, ISO 27001, PCI DSS) to the requirements, specifications, and tests that substantiate it.
+
 == Quick Start
 
 For developers implementing path traversal security:
@@ -65,8 +71,7 @@ For developers implementing path traversal security:
 The implementation follows these HTTP and URL standards:
 
 * **RFC 3986** - Uniform Resource Identifier (URI): Generic Syntax
-* **RFC 7230** - Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing
-* **RFC 8941** - Structured Field Values for HTTP
+* **RFC 7230** - Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing — applied to *header names*, whose token grammar `CharacterValidationStage` enforces
 * **RFC 6265** - HTTP State Management Mechanism (Cookies)
 
 === URL Component Validation
@@ -77,14 +82,18 @@ According to RFC 3986, valid URL path components must adhere to:
 * **Reserved Characters**: `:`, `/`, `?`, `#`, `[`, `]`, `@`, `!`, `$`, `&`, `'`, `(`, `)`, `*`, `+`, `,`, `;`, `=`
 * **Percent-Encoding**: Non-ASCII and special characters must be percent-encoded
 
-=== HTTP Parameter Validation
+=== HTTP Header-Name Validation
 
-Valid HTTP parameter names (RFC 7230):
+Header names are validated against the RFC 7230 `token` grammar by `CharacterValidationStage`,
+which rejects CR and LF unconditionally. Header-name matching is case-insensitive, and an
+optional allow/block list (`AllowBlockListStage`) narrows the accepted set further.
 
-* Must start with alphanumeric character
-* Can contain: `A-Z`, `a-z`, `0-9`, `-`, `_`
-* Case-insensitive in headers, case-sensitive in query parameters
-* Maximum length considerations for security
+=== Query-Parameter Name Validation
+
+Query-parameter names are *not* governed by RFC 7230 — they are validated by
+`URLParameterNameValidationPipeline` under RFC 3986 query-component rules, plus rejection of
+delimiters that appear only after decoding. Parameter names are case-sensitive, and length
+limits are enforced by `LengthValidationStage` as the pipeline's first stage.
 
 == Key Security Patterns
 
@@ -97,19 +106,32 @@ Primary attack vectors in HTTP/URL contexts:
 * **UTF-8 Overlong**: Malformed UTF-8 encoding attacks
 * **HTTP Protocol Mixed Encoding**: Combining URL encoding schemes
 
-=== Validation Pipeline
+=== Validation Pipelines
 
-[source]
-----
-Input → Decode → Normalize → Validate → Verify → Output
-----
+There is no single generic stage order. Each of the five concrete pipelines composes its own
+sequence, chosen so that every stage in it actually performs a check for that component type.
+The authoritative description is
+xref:specification/specification.adoc#_validation_stages[the specification]; the orders are:
 
-Each stage must handle:
+`URLPathValidationPipeline`::
+`LengthValidationStage` → `CharacterValidationStage` → `PatternMatchingStage` → `DecodingStage` → `NormalizationStage` → `PatternMatchingStage`.
+Pattern matching runs xref:specification/specification.adoc#_two_pass_pattern_matching[twice by design] — once on the raw input and once after normalization — so this pipeline performs six stage invocations, not five.
 
-* HTTP protocol-layer encoding only (URL encoding, UTF-8, Unicode normalization)
-* Platform-specific separators
-* Context-aware validation
-* Performance optimization
+`URLParameterValidationPipeline` (parameter *values*)::
+`LengthValidationStage` → `CharacterValidationStage` → `DecodingStage` → `NormalizationStage` → `PatternMatchingStage`.
+
+`URLParameterNameValidationPipeline` (parameter *names*)::
+`LengthValidationStage` → `CharacterValidationStage` → `DecodingStage` → `NormalizationStage` → `PatternMatchingStage`.
+
+`HTTPHeaderValidationPipeline`::
+`LengthValidationStage` → `CharacterValidationStage`, plus an `AllowBlockListStage` for `HEADER_NAME` only.
+`DecodingStage`, `NormalizationStage`, and `PatternMatchingStage` are deliberately absent: headers are not percent-decoded, dot-segment resolution applies to path components only, and the attack-pattern databases cover `URL_PATH`, `PARAMETER_NAME`, and `PARAMETER_VALUE` only.
+
+`ContentTypeValidationPipeline`::
+A single `AllowBlockListStage`.
+
+Across all pipelines the stages handle HTTP protocol-layer encoding only — URL encoding, UTF-8,
+and Unicode normalization (NFKC for paths, NFC for parameter values).
 
 **Architectural Boundary**: Application-layer encodings (HTML entities, JavaScript escapes, Base64) handled by higher layers.
 
@@ -130,7 +152,13 @@ When updating this documentation suite:
 
 * https://www.rfc-editor.org/rfc/rfc3986[RFC 3986 - URI Generic Syntax]
 * https://www.rfc-editor.org/rfc/rfc7230[RFC 7230 - HTTP/1.1 Message Syntax]
-* https://www.rfc-editor.org/rfc/rfc8941[RFC 8941 - Structured Field Values]
+* https://www.rfc-editor.org/rfc/rfc6265[RFC 6265 - HTTP State Management Mechanism]
+
+=== Background Reading
+
+Referenced for context; the library does not implement or claim conformance to these:
+
+* https://www.rfc-editor.org/rfc/rfc8941[RFC 8941 - Structured Field Values for HTTP]
 
 === Security Resources
 

--- a/doc/http-security/functional-requirements.adoc
+++ b/doc/http-security/functional-requirements.adoc
@@ -30,13 +30,20 @@ These requirements are derived from:
 * The system must provide separate validators for each component type
 * Reference: xref:specification/specification.adoc#_core_components[Core Components]
 
+NOTE: *Body validation is not provided.* `PipelineFactory.createPipeline(ValidationType.BODY, ...)`
+throws `IllegalArgumentException` with the message "BODY validation pipeline has been removed.
+HTTP body content validation should be handled at application layer." Request-body parameters are
+therefore an application-layer responsibility, not a capability of this library. See
+xref:#HTTP-14[HTTP-14] for the per-validation-type status.
+
 [#HTTP-2]
 === HTTP-2: Minimal Runtime Dependencies
 
 * The system keeps runtime dependencies to a minimum
-* The security-validation core requires only two runtime modules (see `module-info.java`):
+* The `de.cuioss.http` module declares three non-static `requires` (see `module-info.java`):
   ** `org.jspecify` — nullness annotations
-  ** `de.cuioss.java.tools` (cui-java-tools) — core utilities and logging
+  ** `de.cuioss.java.tools` (cui-java-tools) — core utilities and logging; `requires transitive` because `LogRecord` types appear in exported public API signatures
+  ** `java.net.http` — the JDK HTTP client; `requires transitive` because `java.net.http` types appear in exported public API signatures
 * Lombok is a compile-time-only dependency (`requires static lombok`) and is not needed at runtime
 * No third-party HTTP, JSON, or servlet libraries are required
 * The system must be compatible with Jakarta EE environments
@@ -196,6 +203,14 @@ These requirements are derived from:
 * Configurations must be independently configurable
 * Must support configuration inheritance for common settings
 * Reference: xref:specification/specification.adoc#_configuration_architecture[Configuration Architecture]
+
+NOTE: *Not every validation type above has a factory-built pipeline.*
+`PipelineFactory.createPipeline` throws `IllegalArgumentException` for `COOKIE_NAME` and
+`COOKIE_VALUE` ("Cookie validation pipelines are not yet implemented."), and for `BODY`, which was
+removed (see xref:#HTTP-1[HTTP-1]). Cookie prefix rules are nonetheless enforceable standalone via
+`CookiePrefixValidationStage.validateCookie(Cookie)`, which is invoked directly rather than as part
+of a pipeline. The factory-backed types are `URL_PATH`, `PARAMETER_NAME`, `PARAMETER_VALUE`,
+`HEADER_NAME`, and `HEADER_VALUE`.
 
 == Error Handling Requirements
 

--- a/doc/http-security/functional-requirements.adoc
+++ b/doc/http-security/functional-requirements.adoc
@@ -24,8 +24,9 @@ These requirements are derived from:
   ** URL paths (e.g., `/api/users/123`)
   ** Query parameters (e.g., `?search=term&page=1`)
   ** HTTP headers (e.g., `Authorization: Bearer token`)
-  ** Request body parameters (form-data, JSON, XML)
 
+* Request body content (form-data, JSON, XML) is *out of scope*: the system does not
+  validate request bodies, and no body pipeline is provided (see the NOTE below)
 * Each component type must have appropriate validation rules
 * The system must provide separate validators for each component type
 * Reference: xref:specification/specification.adoc#_core_components[Core Components]
@@ -192,7 +193,8 @@ xref:#HTTP-14[HTTP-14] for the per-validation-type status.
 
 * Each validation type must have its own configuration:
   ** `URL_PATH`: Strict path validation rules
-  ** `PARAMETER_NAME`: Parameter name validation rules (RFC 7230 token rules)
+  ** `PARAMETER_NAME`: Parameter name validation rules (RFC 3986 query-component rules, plus
+     rejection of delimiters that appear only after decoding)
   ** `PARAMETER_VALUE`: Parameter value validation rules (URL decoding support)
   ** `HEADER_NAME`: Header name validation rules (RFC 7230 token rules)
   ** `HEADER_VALUE`: Header value validation rules (broader character set)

--- a/doc/http-security/specification/compliance-traceability.adoc
+++ b/doc/http-security/specification/compliance-traceability.adoc
@@ -719,6 +719,7 @@ Each compliance claim is supported by:
 - ✅ Unit test(s) with specific test case examples
 - ✅ Line number references for verification
 
+[#_limitations_and_scope]
 == Limitations and Scope
 
 === HTTP/URL Protocol Layer Scope

--- a/doc/http-security/specification/compliance-traceability.adoc
+++ b/doc/http-security/specification/compliance-traceability.adoc
@@ -222,7 +222,7 @@ persistent audit trails are *not* provided by the validation core.
 
 ==== Unit Tests
 
- * link:../../../cui-http-core/src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java[SecurityEventCounterTest]: Event counter validation
+* link:../../../cui-http-core/src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java[SecurityEventCounterTest]: Event counter validation
 * All attack database tests verify security events are counted:
 * `assertTrue(eventCounter.getTotalCount() > initialEventCount)`
 
@@ -436,7 +436,7 @@ does not persist or ship audit records.
 * Original input
 * Sanitized input (if available)
 * Detailed error message
- * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: In-memory event counting by failure type
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: In-memory event counting by failure type
 
 ==== Unit Tests
 
@@ -457,7 +457,7 @@ generation is not provided.
 
 ==== Specifications
 
- * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: In-memory event counting by failure type
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: In-memory event counting by failure type
 
 ==== Unit Tests
 
@@ -643,7 +643,7 @@ audit *logging* is a caller responsibility, not provided by the validation core.
 ==== Specifications
 
 * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/monitoring/SecurityEventCounter.java[SecurityEventCounter]: In-memory event counting by failure type
- * link:../../../cui-http-core/src/main/java/de/cuioss/http/security/exceptions/UrlSecurityException.java[UrlSecurityException]: Detailed context on each violation
+* link:../../../cui-http-core/src/main/java/de/cuioss/http/security/exceptions/UrlSecurityException.java[UrlSecurityException]: Detailed context on each violation
 
 ==== Unit Tests
 
@@ -668,12 +668,11 @@ audit *logging* is a caller responsibility, not provided by the validation core.
 
 === Test Coverage Summary
 
-* *Total Test Classes*: 70+
-* *Attack Database Tests*: 25+
-* *Validation Stage Tests*: 7
-* *Pipeline Tests*: 4
-* *Integration Tests*: 5+
-* *Attack Patterns Tested*: 1000+
+The test tree is the authoritative inventory — see xref:testing.adoc[Testing Framework] for the
+package map, and browse the `de.cuioss.http.security` test packages in `cui-http-core` for the
+current set of classes. Attack patterns are enumerated by the attack databases themselves rather
+than counted here.
+
 * *Code Coverage*: &gt;80% (enforced by build)
 
 === Key Implementation Artifacts
@@ -687,8 +686,8 @@ audit *logging* is a caller responsibility, not provided by the validation core.
 
 ==== Test Framework
 
-* 14 Databases (10 attack databases: OWASP Top 10, OWASP ZAP, ModSecurity CRS, Apache/IIS/Nginx CVE, Homograph, IDN, IPv6, ProtocolHandler; plus 4 legitimate-pattern databases)
-* 20+ Test Generators
+* 10 attack databases (OWASP Top 10, OWASP ZAP, ModSecurity CRS, Apache/IIS/Nginx CVE, Homograph, IDN, IPv6, ProtocolHandler) and 3 legitimate-pattern databases (edge-case valid URLs, legitimate path patterns, legitimate special characters)
+* `TypedGenerator` implementations grouped by input type — see xref:testing.adoc[Testing Framework]
 * Comprehensive attack pattern coverage
 * CVE-based test cases
 
@@ -751,8 +750,8 @@ This traceability matrix should be updated when:
 - Security vulnerabilities are discovered
 - Code coverage changes significantly
 
-*Last Updated*: 2026-07-04
-*Next Review*: 2026-08-04 (Monthly)
+*Last Updated*: 2026-08-26
+*Next Review*: 2026-09-26 (Monthly)
 
 == References
 

--- a/doc/http-security/specification/compliance-traceability.adoc
+++ b/doc/http-security/specification/compliance-traceability.adoc
@@ -686,7 +686,9 @@ than counted here.
 
 ==== Test Framework
 
-* 10 attack databases (OWASP Top 10, OWASP ZAP, ModSecurity CRS, Apache/IIS/Nginx CVE, Homograph, IDN, IPv6, ProtocolHandler) and 3 legitimate-pattern databases (edge-case valid URLs, legitimate path patterns, legitimate special characters)
+* Attack databases and legitimate-pattern databases — the test tree is the authoritative
+  inventory; see xref:testing.adoc[Testing Framework] for the package map rather than a count
+  repeated here
 * `TypedGenerator` implementations grouped by input type — see xref:testing.adoc[Testing Framework]
 * Comprehensive attack pattern coverage
 * CVE-based test cases

--- a/doc/http-security/specification/pipeline-architecture-standards.adoc
+++ b/doc/http-security/specification/pipeline-architecture-standards.adoc
@@ -39,6 +39,102 @@ This document establishes the authoritative standards for selecting appropriate 
 "/admin/..\\..\\windows\\system32"
 ----
 
+=== URLParameterValidationPipeline - Parameter Value Attacks
+
+**Purpose**: Validates query-parameter *values*, where percent-decoding and encoding attacks matter but path semantics do not.
+
+**Use When**:
+
+* The pattern targets a parameter value rather than a path segment
+* Percent-encoding, double-encoding, or Unicode normalization attacks in parameter values
+* Null-byte and control-character injection carried in a parameter value
+
+**Current Implementations**:
+
+* ✅ `URLParameterValidationPipelineTest` - Parameter-value pipeline behaviour
+* ✅ `PipelineFactoryTest` - Factory construction and stage composition
+
+**Attack Pattern Examples**:
+
+[source]
+----
+"%2e%2e%2f%2e%2e%2fetc%2fpasswd"
+"value%00truncated"
+"%252e%252e%252f"
+----
+
+=== URLParameterNameValidationPipeline - Parameter Name Attacks
+
+**Purpose**: Validates query-parameter *names*. Names are structurally narrower than values: a delimiter that appears only after decoding would silently split the query string, so the pipeline rejects it.
+
+**Use When**:
+
+* The pattern targets the parameter key rather than its value
+* Encoded structural delimiters (`=`, `&`, `;`, space) or encoded CR/LF smuggled into a name
+* Parameter-name length limits
+
+**Current Implementations**:
+
+* ✅ `URLParameterNameValidationPipelineBehaviorTest` - Parameter-name pipeline behaviour
+* ✅ `PipelineFactoryTest` - Factory construction and stage composition
+
+**Attack Pattern Examples**:
+
+[source]
+----
+"name%0d%0aInjected"
+"key%3dvalue"
+"first%26second"
+----
+
+=== HTTPHeaderValidationPipeline - Header Injection Attacks
+
+**Purpose**: Validates HTTP header names and values. Headers are not percent-decoded and carry no path semantics, so the pipeline is deliberately short: `LengthValidationStage` then `CharacterValidationStage`, plus an `AllowBlockListStage` for `HEADER_NAME` only.
+
+**Use When**:
+
+* The pattern targets a header name or header value
+* CRLF / header-injection and response-splitting payloads
+* Header names that must be constrained to the RFC 7230 `token` grammar or to an explicit allow/block list
+
+**Current Implementations**:
+
+* ✅ `HTTPHeaderValidationPipelineTest` - Header pipeline behaviour
+* ✅ `HeaderAndContentTypeEnforcementRegressionTest` - Header-name allow/block-list enforcement
+* ✅ `PipelineFactoryTest` - Factory construction and stage composition
+
+**Attack Pattern Examples**:
+
+[source]
+----
+"Bearer\r\nX-Injected: true"
+"X-Forwarded-For: 127.0.0.1\nX-Admin: true"
+"Set-Cookie: session=abc\r\n\r\n<html>"
+----
+
+=== ContentTypeValidationPipeline - Content-Type Allow/Block Lists
+
+**Purpose**: Enforces an allow/block list over the `Content-Type` header. This pipeline is a single `AllowBlockListStage` — it performs no length, character, decoding, normalization, or pattern-matching check.
+
+**Use When**:
+
+* The decision is "is this media type permitted here?", not "is this string well-formed?"
+* A service accepts only an explicit set of media types, or must reject specific dangerous ones
+
+**Current Implementations**:
+
+* ✅ `ContentTypeValidationPipelineTest` - Allow/block-list semantics, parameter stripping, case folding
+* ✅ `HeaderAndContentTypeEnforcementRegressionTest` - Content-type enforcement regressions
+
+**Attack Pattern Examples**:
+
+[source]
+----
+"text/html"                       # rejected when the allow-list is application/json
+"application/x-msdownload"        # rejected by an explicit block-list entry
+"text/html; charset=UTF-8"        # parameters are stripped before matching
+----
+
 
 == Architectural Principles
 
@@ -121,7 +217,7 @@ SecurityConfiguration unicodeConfig = SecurityConfiguration.builder()
 
 Pipeline architecture audit:
 
-* ✅ Audit of all attack database / integration test classes (26 in `cui-http-core/src/test/java/de/cuioss/http/security/tests`) completed
+* ✅ Audit of all attack database / integration test classes in the `de.cuioss.http.security.tests` package completed
 * ✅ Pipeline selection decision matrix established
 * ✅ All pipeline assignments verified as architecturally correct
 * ✅ No pipeline mismatches identified after thorough analysis
@@ -139,5 +235,5 @@ Pipeline architecture audit:
 . **Security Standards Evolution**: Update standards as HTTP security threats evolve
 
 ---
-_Document Version: 1.1_
+_Document Version: 1.2_
 _Maintained by: HTTP Security Validation Framework Team_

--- a/doc/http-security/specification/specification.adoc
+++ b/doc/http-security/specification/specification.adoc
@@ -285,7 +285,7 @@ The following test suites verify the implementation meets this specification:
 
 - Individual stage: <0.2ms per stage
 - Complete pipeline: <1ms total for typical inputs (the URL path pipeline runs 6 stage
-  invocations — see the two-pass pattern-matching note below)
+  invocations — see xref:#_two_pass_pattern_matching[the two-pass pattern-matching note])
 - Memory: O(n) where n is input length
 - Thread safety: No synchronization needed (immutable)
 - Benchmark: 95th percentile must meet these requirements

--- a/doc/http-security/specification/testing.adoc
+++ b/doc/http-security/specification/testing.adoc
@@ -14,137 +14,48 @@ Testing framework for HTTP security validation with generator-based testing, att
 
 == Test Framework Structure
 
-----
-src/test/java/de/cuioss/http/security/
-├── config/                                  # Configuration tests
-│   ├── SecurityConfigurationBuilderTest.java
-│   ├── SecurityConfigurationTest.java
-│   └── SecurityDefaultsTest.java
-│
-├── core/                                    # Core component tests
-│   ├── HttpSecurityValidatorTest.java
-│   ├── UrlSecurityFailureTypeTest.java
-│   └── ValidationTypeTest.java
-│
-├── data/                                    # Data-model tests
-│   ├── AttributeParserTest.java
-│   ├── CookieTest.java
-│   ├── HTTPBodyTest.java
-│   └── URLParameterTest.java
-│
-├── database/                                # Attack & legitimate pattern databases
-│   ├── AttackDatabase.java                  # Attack-database interface
-│   ├── AttackTestCase.java                  # Attack test-case record
-│   ├── LegitimateTestCase.java              # Legitimate test-case record
-│   ├── package-info.java
-│   ├── ApacheCVEAttackDatabase.java         # Apache CVE patterns
-│   ├── HomographAttackDatabase.java         # Unicode homograph attacks
-│   ├── IDNAttackDatabase.java               # Internationalized domain attacks
-│   ├── IISCVEAttackDatabase.java            # IIS CVE patterns
-│   ├── IPv6AttackDatabase.java              # IPv6 address exploits
-│   ├── ModSecurityCRSAttackDatabase.java    # ModSecurity CRS patterns
-│   ├── NginxCVEAttackDatabase.java          # Nginx CVE patterns
-│   ├── OWASPTop10AttackDatabase.java        # OWASP Top 10 patterns
-│   ├── OWASPZAPAttackDatabase.java          # OWASP ZAP scanner patterns
-│   ├── ProtocolHandlerAttackDatabase.java   # Protocol handler exploits
-│   ├── EdgeCaseValidURLsDatabase.java       # Legitimate edge-case URLs
-│   ├── LegitimatePathPatternsDatabase.java  # Legitimate path patterns
-│   ├── LegitimatePatternDatabase.java       # Legitimate-pattern interface
-│   └── LegitimateSpecialCharactersDatabase.java # Legitimate special chars
-│
-├── exceptions/                              # Exception handling tests
-│   └── UrlSecurityExceptionTest.java
-│
-├── generators/                              # Test data generators + their tests (by type)
-│   ├── AllGeneratorsIntegrationTest.java
-│   ├── SupportedValidationTypeGenerator.java
-│   ├── SupportedValidationTypeGeneratorContractTest.java
-│   ├── cookie/
-│   │   ├── AttackCookieGenerator.java / AttackCookieGeneratorTest.java
-│   │   ├── CookieNameAsciiWhitespaceGenerator.java
-│   │   ├── CookieNameLegacyParsingGenerator.java
-│   │   ├── CookieNameUnicodeWhitespaceGenerator.java
-│   │   ├── CookieNameZeroWidthGenerator.java
-│   │   └── ValidCookieGenerator.java / ValidCookieGeneratorTest.java
-│   ├── encoding/
-│   │   ├── BoundaryFuzzingGenerator.java / BoundaryFuzzingGeneratorTest.java
-│   │   ├── DoubleEncodingAttackGenerator.java / DoubleEncodingAttackGeneratorTest.java
-│   │   ├── EncodingCombinationGenerator.java / EncodingCombinationGeneratorTest.java
-│   │   ├── PathTraversalGenerator.java / PathTraversalGeneratorTest.java
-│   │   ├── UnicodeAttackGenerator.java / UnicodeAttackGeneratorTest.java
-│   │   ├── UnicodeControlCharacterAttackGenerator.java
-│   │   └── UnicodeNormalizationAttackGenerator.java
-│   ├── header/
-│   │   ├── HttpHeaderInjectionAttackGenerator.java
-│   │   ├── HTTPHeaderInjectionGenerator.java / HTTPHeaderInjectionGeneratorTest.java
-│   │   ├── InvalidHTTPHeaderNameGenerator.java / InvalidHTTPHeaderNameGeneratorTest.java
-│   │   ├── ValidHTTPHeaderNameGenerator.java / ValidHTTPHeaderNameGeneratorTest.java
-│   │   └── ValidHTTPHeaderValueGenerator.java
-│   ├── injection/
-│   │   ├── HttpRequestSmugglingAttackGenerator.java / HttpRequestSmugglingAttackGeneratorTest.java
-│   │   ├── ProtocolHandlerAttackGenerator.java
-│   │   └── URLLengthLimitAttackGeneratorTest.java
-│   └── url/
-│       ├── AttackURLParameterGenerator.java
-│       ├── InvalidURLGenerator.java / InvalidURLGeneratorTest.java
-│       ├── NullByteInjectionParameterGenerator.java
-│       ├── NullByteURLGenerator.java / NullByteURLGeneratorTest.java
-│       ├── PathTraversalParameterGenerator.java / PathTraversalParameterGeneratorTest.java
-│       ├── PathTraversalURLGenerator.java / PathTraversalURLGeneratorTest.java
-│       ├── URLLengthLimitAttackGenerator.java
-│       ├── ValidURLGenerator.java / ValidURLGeneratorTest.java
-│       ├── ValidURLParameterGenerator.java / ValidURLParameterGeneratorTest.java
-│       ├── ValidURLParameterStringGenerator.java
-│       └── ValidURLPathGenerator.java / ValidURLPathGeneratorTest.java
-│
-├── monitoring/                              # Security monitoring tests
-│   └── SecurityEventCounterTest.java
-│
-├── pipeline/                                # Validation pipeline tests
-│   ├── HTTPHeaderValidationPipelineTest.java
-│   ├── PipelineFactoryTest.java
-│   ├── URLParameterValidationPipelineTest.java
-│   └── URLPathValidationPipelineTest.java
-│
-├── tests/                                   # Attack-specific test classes (26)
-│   ├── ApacheCVEAttackDatabaseTest.java
-│   ├── CookieChaosAttackTest.java
-│   ├── DoubleEncodingAttackTest.java
-│   ├── EdgeCaseValidURLsDatabaseTest.java
-│   ├── EncodedPathTraversalAttackTest.java
-│   ├── HomographAttackDatabaseTest.java
-│   ├── Http1VulnerabilitiesTest.java
-│   ├── HttpHeaderInjectionAttackTest.java
-│   ├── HttpRequestSmugglingAttackTest.java
-│   ├── IDNAttackDatabaseTest.java
-│   ├── IISCVEAttackDatabaseTest.java
-│   ├── IPv6AttackDatabaseTest.java
-│   ├── LegitimatePathPatternsDatabaseTest.java
-│   ├── LegitimateSpecialCharactersDatabaseTest.java
-│   ├── MixedEncodingAttackTest.java
-│   ├── ModSecurityCRSAttackDatabaseTest.java
-│   ├── NginxCVEAttackDatabaseTest.java
-│   ├── NullBytePathTraversalAttackTest.java
-│   ├── OWASPTop10AttackDatabaseTest.java
-│   ├── OWASPZAPAttackDatabaseTest.java
-│   ├── PathTraversalAttackTest.java
-│   ├── ProtocolHandlerAttackTest.java
-│   ├── UnicodeControlCharacterAttackTest.java
-│   ├── UnicodeNormalizationAttackTest.java
-│   ├── UnicodePathTraversalAttackTest.java
-│   └── URLLengthLimitAttackTest.java
-│
-└── validation/                              # Validation stage tests
-    ├── AllowBlockListStageTest.java
-    ├── CharacterValidationConstantsTest.java
-    ├── CharacterValidationStageTest.java
-    ├── CookiePrefixValidationStageTest.java
-    ├── DecodingStageTest.java
-    ├── LengthValidationStageTest.java
-    ├── NormalizationStageTest.java
-    ├── PatternMatchingStageTest.java
-    └── RequestCollectionValidatorTest.java
-----
+The test tree is the authoritative inventory of test classes. This section is a navigation
+map over the `de.cuioss.http.security` test packages in the `cui-http-core` module — browse
+the package itself for the current set of classes rather than relying on a list here.
+
+[cols="1,3"]
+|===
+|Package |Contents
+
+|`config`
+|Tests for `SecurityConfiguration`, its builder, and the security defaults.
+
+|`core`
+|Tests for the `HttpSecurityValidator` contract, `ValidationType`, and `UrlSecurityFailureType`.
+
+|`data`
+|Tests for the HTTP data model — cookies, URL parameters, bodies, and attribute parsing.
+
+|`database`
+|Attack and legitimate-pattern databases, plus the shared interfaces and records they build on
+(`AttackDatabase`, `AttackTestCase`, `LegitimatePatternDatabase`, `LegitimateTestCase`).
+These classes are curated test *data*; the tests that consume them live in `tests`.
+
+|`exceptions`
+|Tests for `UrlSecurityException` and its builder.
+
+|`generators`
+|`TypedGenerator` implementations and their contract tests, grouped by input type in the
+`cookie`, `encoding`, `header`, `injection`, and `url` sub-packages.
+
+|`monitoring`
+|Tests for `SecurityEventCounter`.
+
+|`pipeline`
+|Tests for `PipelineFactory` and for each concrete validation pipeline.
+
+|`tests`
+|Attack-specific test classes — one per attack family or attack database, each driving a
+pipeline with the corresponding curated patterns.
+
+|`validation`
+|Tests for the individual validation stages and for `RequestCollectionValidator`.
+|===
 
 == Test Components
 

--- a/doc/test-framework-structure.adoc
+++ b/doc/test-framework-structure.adoc
@@ -6,130 +6,34 @@
 :icons: font
 :source-highlighter: highlight.js
 
-The test framework is organized in the following structure under `src/test/java/de/cuioss/http/security/`:
+This document is a *navigation map*, not an exhaustive inventory. It lists one entry per test
+package so the map stays correct as classes come and go; the test tree itself is the authoritative
+inventory of test classes.
 
-=== Configuration Tests
+The security test framework lives under `cui-http-core/src/test/java/de/cuioss/http/security/`.
 
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationTest.java[SecurityConfigurationTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityConfigurationBuilderTest.java[SecurityConfigurationBuilderTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/config/SecurityDefaultsTest.java[SecurityDefaultsTest]
+== Test Packages
 
-=== Core Component Tests
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/config[config] — tests for `SecurityConfiguration`, its builder, and the security defaults.
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/core[core] — tests for the `HttpSecurityValidator` contract, `ValidationType`, and `UrlSecurityFailureType`.
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/data[data] — tests for the HTTP data model: cookies, URL parameters, bodies, and attribute parsing.
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/database/package-info.java[database] — curated attack databases and legitimate-pattern databases, plus the shared interfaces and records they build on. These classes are test *data*; the tests that consume them live in `tests`.
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/exceptions[exceptions] — tests for `UrlSecurityException` and its builder.
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators[generators] — `TypedGenerator` implementations and their contract tests, grouped by input type in the sub-packages below.
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/monitoring[monitoring] — tests for `SecurityEventCounter`.
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/pipeline[pipeline] — tests for `PipelineFactory` and for each concrete validation pipeline.
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests[tests] — attack-specific test classes, one per attack family or attack database, each driving a pipeline with the corresponding curated patterns.
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/validation[validation] — tests for the individual validation stages and for `RequestCollectionValidator`.
 
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/core/HttpSecurityValidatorTest.java[HttpSecurityValidatorTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/core/UrlSecurityFailureTypeTest.java[UrlSecurityFailureTypeTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/core/ValidationTypeTest.java[ValidationTypeTest]
+== Generator Sub-Packages
 
-=== Attack Pattern Databases
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie[generators/cookie] — cookie name and value generators, both attack and legitimate.
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding[generators/encoding] — percent-encoding, double-encoding, boundary-fuzzing, and Unicode generators.
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/header[generators/header] — HTTP header name and value generators, both injection payloads and valid inputs.
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/injection[generators/injection] — protocol-level injection generators: request smuggling, protocol handlers, and length-limit attacks.
+* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/url[generators/url] — URL path and parameter generators, both attack and legitimate.
 
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/database/AttackDatabase.java[AttackDatabase] - Database interface
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/database/AttackTestCase.java[AttackTestCase] - Test case record
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/database/ApacheCVEAttackDatabase.java[ApacheCVEAttackDatabase] - Apache CVE patterns
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/database/HomographAttackDatabase.java[HomographAttackDatabase] - Unicode homograph attacks
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/database/IDNAttackDatabase.java[IDNAttackDatabase] - Internationalized domain attacks
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/database/IISCVEAttackDatabase.java[IISCVEAttackDatabase] - IIS CVE patterns
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/database/IPv6AttackDatabase.java[IPv6AttackDatabase] - IPv6 address exploits
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/database/NginxCVEAttackDatabase.java[NginxCVEAttackDatabase] - Nginx CVE patterns
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/database/OWASPTop10AttackDatabase.java[OWASPTop10AttackDatabase] - OWASP Top 10 patterns
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/database/ProtocolHandlerAttackDatabase.java[ProtocolHandlerAttackDatabase] - Protocol handler exploits
+== See Also
 
-=== Exception Handling Tests
-
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/exceptions/UrlSecurityExceptionTest.java[UrlSecurityExceptionTest]
-
-=== Test Data Generators
-
-==== Main Generator Classes
-
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/AllGeneratorsIntegrationTest.java[AllGeneratorsIntegrationTest] - Generator integration tests
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/SupportedValidationTypeGenerator.java[SupportedValidationTypeGenerator]
-
-==== Cookie Generators
-
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/AttackCookieGenerator.java[AttackCookieGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/cookie/ValidCookieGenerator.java[ValidCookieGenerator]
-
-==== Encoding Attack Generators
-
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/BoundaryFuzzingGenerator.java[BoundaryFuzzingGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/DoubleEncodingAttackGenerator.java[DoubleEncodingAttackGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/EncodingCombinationGenerator.java[EncodingCombinationGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/PathTraversalGenerator.java[PathTraversalGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeAttackGenerator.java[UnicodeAttackGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeControlCharacterAttackGenerator.java[UnicodeControlCharacterAttackGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/encoding/UnicodeNormalizationAttackGenerator.java[UnicodeNormalizationAttackGenerator]
-
-==== HTTP Header Generators
-
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/header/HttpHeaderInjectionAttackGenerator.java[HttpHeaderInjectionAttackGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/header/HTTPHeaderInjectionGenerator.java[HTTPHeaderInjectionGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/header/InvalidHTTPHeaderNameGenerator.java[InvalidHTTPHeaderNameGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/header/ValidHTTPHeaderNameGenerator.java[ValidHTTPHeaderNameGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/header/ValidHTTPHeaderValueGenerator.java[ValidHTTPHeaderValueGenerator]
-
-==== Protocol Injection Generators
-
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/HttpRequestSmugglingAttackGenerator.java[HttpRequestSmugglingAttackGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/injection/ProtocolHandlerAttackGenerator.java[ProtocolHandlerAttackGenerator]
-
-==== URL-Specific Generators
-
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/AttackURLParameterGenerator.java[AttackURLParameterGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/InvalidURLGenerator.java[InvalidURLGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/NullByteInjectionParameterGenerator.java[NullByteInjectionParameterGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/NullByteURLGenerator.java[NullByteURLGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalParameterGenerator.java[PathTraversalParameterGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/PathTraversalURLGenerator.java[PathTraversalURLGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/URLLengthLimitAttackGenerator.java[URLLengthLimitAttackGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLGenerator.java[ValidURLGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLParameterGenerator.java[ValidURLParameterGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLParameterStringGenerator.java[ValidURLParameterStringGenerator]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/generators/url/ValidURLPathGenerator.java[ValidURLPathGenerator]
-
-=== Security Monitoring Tests
-
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/monitoring/SecurityEventCounterTest.java[SecurityEventCounterTest]
-
-=== Validation Pipeline Tests
-
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/HTTPHeaderValidationPipelineTest.java[HTTPHeaderValidationPipelineTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/PipelineFactoryTest.java[PipelineFactoryTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLParameterValidationPipelineTest.java[URLParameterValidationPipelineTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/pipeline/URLPathValidationPipelineTest.java[URLPathValidationPipelineTest]
-
-=== Validation Stage Tests
-
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/validation/CharacterValidationStageTest.java[CharacterValidationStageTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/validation/DecodingStageTest.java[DecodingStageTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/validation/LengthValidationStageTest.java[LengthValidationStageTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/validation/NormalizationStageTest.java[NormalizationStageTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/validation/PatternMatchingStageTest.java[PatternMatchingStageTest]
-
-=== Attack Test Categories
-
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/ApacheCVEAttackDatabaseTest.java[ApacheCVEAttackDatabaseTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/CookieChaosAttackTest.java[CookieChaosAttackTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/DoubleEncodingAttackTest.java[DoubleEncodingAttackTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/EdgeCaseValidURLsDatabaseTest.java[EdgeCaseValidURLsDatabaseTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/EncodedPathTraversalAttackTest.java[EncodedPathTraversalAttackTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/HomographAttackDatabaseTest.java[HomographAttackDatabaseTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/Http1VulnerabilitiesTest.java[Http1VulnerabilitiesTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpHeaderInjectionAttackTest.java[HttpHeaderInjectionAttackTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/HttpRequestSmugglingAttackTest.java[HttpRequestSmugglingAttackTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/IDNAttackDatabaseTest.java[IDNAttackDatabaseTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/IISCVEAttackDatabaseTest.java[IISCVEAttackDatabaseTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/IPv6AttackDatabaseTest.java[IPv6AttackDatabaseTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/LegitimatePathPatternsDatabaseTest.java[LegitimatePathPatternsDatabaseTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/LegitimateSpecialCharactersDatabaseTest.java[LegitimateSpecialCharactersDatabaseTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/MixedEncodingAttackTest.java[MixedEncodingAttackTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/ModSecurityCRSAttackDatabaseTest.java[ModSecurityCRSAttackDatabaseTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/NginxCVEAttackDatabaseTest.java[NginxCVEAttackDatabaseTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/NullBytePathTraversalAttackTest.java[NullBytePathTraversalAttackTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPTop10AttackDatabaseTest.java[OWASPTop10AttackDatabaseTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/OWASPZAPAttackDatabaseTest.java[OWASPZAPAttackDatabaseTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/PathTraversalAttackTest.java[PathTraversalAttackTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/ProtocolHandlerAttackTest.java[ProtocolHandlerAttackTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodeControlCharacterAttackTest.java[UnicodeControlCharacterAttackTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodeNormalizationAttackTest.java[UnicodeNormalizationAttackTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/UnicodePathTraversalAttackTest.java[UnicodePathTraversalAttackTest]
-* link:../cui-http-core/src/test/java/de/cuioss/http/security/tests/URLLengthLimitAttackTest.java[URLLengthLimitAttackTest]
+* xref:http-security/specification/testing.adoc[Testing Framework specification] — attack-database structure, generator usage patterns, and coverage requirements.
+* xref:test-generators-readme.adoc[Test Generators README] — consuming the generators as a test dependency.

--- a/doc/test-generators-readme.adoc
+++ b/doc/test-generators-readme.adoc
@@ -116,5 +116,5 @@ static Stream<AttackTestCase> getAllTestCases() {
 == Related Documentation
 
 * xref:http-security/specification/testing.adoc[Testing Framework] - Complete test framework structure
-* xref:test-framework-structure.adoc[Test Framework Structure] - Detailed file listing with links
+* xref:test-framework-structure.adoc[Test Framework Structure] - Package-level navigation map of the security test tree
 * xref:http-security/analysis/cve-analysis.adoc[CVE Analysis] - Attack patterns and vulnerabilities


### PR DESCRIPTION
## Summary

Refreshes cui-http's documentation tree so it matches the current codebase and closes its own navigation gaps — a scope-corrective accuracy pass, not a restructure. Corrects stale test/pipeline/validation-stage counts and their cross-referenced traceability rows, links two orphaned documents into the relevant readmes, adds two missing security README index entries, records two missing implementation-status notes, refreshes `CLAUDE.md`'s architecture section and the pipeline-selection decision matrix, and fixes several smaller accuracy items (runtime-module count, a misdirected cross-reference, RFC 8941/7230 citations, stale tree-root prefixes, an overdue review date, dangling Javadoc references).

## Changes

- `CLAUDE.md` — refreshed architecture section to list all 5 concrete pipelines and all exported client packages (`de.cuioss.http.forwarded`, `client.adapter`, `client.converter`, `client.result`)
- `README.adoc` — navigation and accuracy corrections
- `doc/client-handlers-readme.adoc` — accuracy corrections
- `doc/http-security/README.adoc` — added missing Document Index entries, linked orphaned documents
- `doc/http-security/functional-requirements.adoc` — added missing implementation-status notes (HTTP-1 body validation throws; HTTP-14 cookie per-type configs not yet implemented)
- `doc/http-security/specification/compliance-traceability.adoc` — corrected stale counts and traceability rows
- `doc/http-security/specification/pipeline-architecture-standards.adoc` — corrected pipeline counts, extended the pipeline-selection decision matrix beyond `URLPathValidationPipeline` alone
- `doc/http-security/specification/specification.adoc` — corrected stale counts and cross-references
- `doc/http-security/specification/testing.adoc` — corrected stale test counts
- `doc/test-framework-structure.adoc` — corrected stale test-tree counts and prefixes
- `doc/test-generators-readme.adoc` — accuracy corrections

## Test Plan

- [ ] Verification command passed (`python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Ppre-commit"`)
- [ ] Manual testing completed (if applicable)

## Related Issues

None.

---
Generated by plan-finalize skill

## Intent

The cui-http documentation tree had drifted behind the code: stale test/pipeline/validation-stage counts, two orphaned documents with zero inbound references, missing implementation-status notes, and an architecture section in CLAUDE.md that named 3 pipelines against the 5 that actually exist.

The fix is a scope-corrective accuracy pass, not a restructure. Every count claim was re-verified against HEAD by name (not line number) since a concurrent test-tree workstream may still be landing changes. Where a document hand-maintained an exhaustive inventory the tree already owns, the inventory is replaced by a pointer to the source of truth rather than re-typed with today's numbers. Where a count carries independent meaning and must stay in prose, it is corrected together with its paired traceability-table row in the same edit, per the paired-claim discipline from a prior landing lesson.

This change does not touch cui-http-core/src/main/java/de/cuioss/http/security/** or any test class — those trees are owned by sibling workstreams and are consulted here only as the source of truth, never edited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded HTTP security documentation with validation pipeline selection guidance.
  * Documented supported validation types, body-validation limitations, cookie-prefix validation, and module requirements.
  * Added references for HTTP result handling and the `HTTP-nnn` message catalogue.
  * Updated compliance, standards, RFC, and cross-reference guidance.
  * Reorganized testing documentation into package-level navigation maps.
  * Added configuration and compliance-traceability documentation to the security index.
  * Added architectural decision records for package-level inventories and named documentation anchors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->