### PR TITLE
fix(forwarded): enforce parser strictness and ResolvedForwarding invariants

### DIFF
--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -97,7 +97,9 @@ import static de.cuioss.http.forwarded.ForwardedHeaderNames.*;
  * sanitization, <em>or</em> when it carries a malformed {@code forwarded-pair} (a non-blank pair with
  * no {@code =}, an empty directive name, or an empty value — a grammatically legal blank pair is
  * still accepted), the header is treated as present-but-unresolvable for <em>every</em> field it could
- * have carried (scheme, host, client-IP), not as absent. A garbage {@code Forwarded} header therefore
+ * have carried (scheme, host, port, client-IP), not as absent. The port belongs in that enumeration
+ * because a {@code Forwarded} header carries one through a {@code host=example.com:8443} directive.
+ * A garbage {@code Forwarded} header therefore
  * disagrees with — and drops — an otherwise clean {@code X-Forwarded-*} value, instead of letting the
  * de-facto family win by default. Only a header that is genuinely absent, or one that sanitizes and
  * parses cleanly while simply carrying no directive for a given field, leaves that field's de-facto
@@ -166,7 +168,7 @@ public final class ForwardedHeaderResolver {
 
         Optional<String> scheme = resolveScheme(lookup, forwarded);
         HostPort hostPort = resolveHost(lookup, forwarded);
-        OptionalInt port = resolvePort(lookup, hostPort.port());
+        OptionalInt port = resolvePort(lookup, forwarded, hostPort.port());
         String contextPath = resolveContextPath(lookup, forwarded);
         Optional<String> clientIp = resolveClientIp(lookup, forwarded);
 
@@ -289,7 +291,21 @@ public final class ForwardedHeaderResolver {
 
     // --- port --------------------------------------------------------------------------------
 
-    private OptionalInt resolvePort(UnaryOperator<String> lookup, OptionalInt hostPortFallback) {
+    /**
+     * Resolves the port, honoring the present-but-unresolvable rule that already governs scheme,
+     * host, and client-IP: an unresolvable {@code Forwarded} header counts as present for the port
+     * too — it could have carried one via a {@code host=example.com:8443} directive — so it
+     * disagrees with, and drops, any {@code X-Forwarded-Port} value.
+     *
+     * <p>The unresolvable check precedes the {@code hostPortFallback} branch deliberately. That
+     * fallback is derived from the {@code host} directive, so returning it for an unresolvable
+     * header would leak the very source the rule drops; guarding only the explicit port-header
+     * branch would leave that leak open.</p>
+     */
+    private OptionalInt resolvePort(UnaryOperator<String> lookup, ForwardedResult forwarded, OptionalInt hostPortFallback) {
+        if (forwarded.unresolvable()) {
+            return OptionalInt.empty();
+        }
         String raw = firstPresent(lookup, X_FORWARDED_PORT, X_PROXY_PORT);
         if (raw == null) {
             return hostPortFallback;

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -251,6 +251,13 @@ public final class ForwardedHeaderResolver {
             if (!IpAddresses.hasValidBracketTrailer(rest)) {
                 return HostPort.EMPTY;
             }
+            // The brackets promise an IP literal, so validate what is INSIDE them too — checking
+            // only the trailer would let "[]" and "[not-an-ip]" through as a host and hand a
+            // downstream consumer an invalid URL authority. This mirrors
+            // IpAddresses.parseChainEntry, which parses its bracketed literal for the same reason.
+            if (IpAddresses.parse(value.substring(1, close)) == null) {
+                return HostPort.EMPTY;
+            }
             if (!rest.isEmpty()) {
                 port = parsePort(rest.substring(1));
             }

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -92,7 +92,9 @@ import static de.cuioss.http.forwarded.ForwardedHeaderNames.*;
  * source that resolved successfully, so the conflicting-source rule above drops the field.</p>
  *
  * <p>This applies to the RFC 7239 {@code Forwarded} header as a whole: when its raw value fails
- * sanitization, the header is treated as present-but-unresolvable for <em>every</em> field it could
+ * sanitization, <em>or</em> when it carries a malformed {@code forwarded-pair} (a non-blank pair with
+ * no {@code =}, an empty directive name, or an empty value — a grammatically legal blank pair is
+ * still accepted), the header is treated as present-but-unresolvable for <em>every</em> field it could
  * have carried (scheme, host, client-IP), not as absent. A garbage {@code Forwarded} header therefore
  * disagrees with — and drops — an otherwise clean {@code X-Forwarded-*} value, instead of letting the
  * de-facto family win by default. Only a header that is genuinely absent, or one that sanitizes and
@@ -415,9 +417,18 @@ public final class ForwardedHeaderResolver {
         // Sanitize the Forwarded header value before parsing its directives. A rejected value must
         // NOT collapse into the absent case: the header WAS sent, so it stays present-but-unresolvable
         // and disagrees with any de-facto sibling that resolves (fail closed).
-        return sanitize(FORWARDED, raw)
-                .map(value -> new ForwardedResult(true, false, RfcForwardedParser.parse(value)))
-                .orElse(ForwardedResult.UNRESOLVABLE);
+        Optional<String> sanitized = sanitize(FORWARDED, raw);
+        if (sanitized.isEmpty()) {
+            return ForwardedResult.UNRESOLVABLE;
+        }
+        // A grammar-violating forwarded-pair rejects the whole header with the same severity as a
+        // sanitization failure — the directives it could have carried are all unresolvable.
+        RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse(sanitized.get());
+        if (parsed.malformed()) {
+            LOGGER.warn(ForwardedLogMessages.WARN.FORWARDED_DIRECTIVE_MALFORMED, sanitizeForLog(raw));
+            return ForwardedResult.UNRESOLVABLE;
+        }
+        return new ForwardedResult(true, false, parsed);
     }
 
     /**
@@ -532,23 +543,24 @@ public final class ForwardedHeaderResolver {
      *   <li>{@link #ABSENT} — no {@code Forwarded} header was sent; the RFC source contributes
      *       nothing and the de-facto family is honored on its own.</li>
      *   <li>{@link #UNRESOLVABLE} — the header WAS sent but its raw value failed sanitization
-     *       (CR/LF, control characters, over-length, suspicious pattern). The source counts as
-     *       present for <em>every</em> field, so it disagrees with any de-facto sibling that
-     *       resolves and the field is dropped (fail closed).</li>
+     *       (CR/LF, control characters, over-length, suspicious pattern) or violated the RFC 7239
+     *       grammar with a malformed {@code forwarded-pair}. The source counts as present for
+     *       <em>every</em> field, so it disagrees with any de-facto sibling that resolves and the
+     *       field is dropped (fail closed).</li>
      *   <li>Present and sanitized — the parsed directives decide per field. A well-formed value that
      *       simply carries no {@code proto} (say) leaves that one field's RFC source with nothing to
      *       contribute, which is an ordinary fallback rather than a disagreement.</li>
      * </ol>
      *
      * @param present      whether a non-blank {@code Forwarded} header was sent at all
-     * @param unresolvable whether that header's raw value failed sanitization outright
+     * @param unresolvable whether that header failed sanitization outright or parsed as malformed
      * @param parsed       the directives parsed from the sanitized value; empty unless present and
      *                     sanitized
      */
     private record ForwardedResult(boolean present, boolean unresolvable, RfcForwardedParser.Parsed parsed) {
 
         private static final RfcForwardedParser.Parsed NO_DIRECTIVES =
-                new RfcForwardedParser.Parsed(Optional.empty(), Optional.empty(), List.of());
+                new RfcForwardedParser.Parsed(Optional.empty(), Optional.empty(), List.of(), false);
 
         private static final ForwardedResult ABSENT = new ForwardedResult(false, false, NO_DIRECTIVES);
 

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -232,6 +232,16 @@ public final class ForwardedHeaderResolver {
      * to host {@code [::1]}. That rule is not restated here: it is applied through the shared
      * {@link IpAddresses#hasValidBracketTrailer(String)} helper.</p>
      *
+     * <p><strong>The bracket contents must themselves be an IP literal.</strong> {@code []} and
+     * {@code [not-an-ip]} yield {@link HostPort#EMPTY} rather than becoming a host, because the
+     * brackets promise a literal and an invalid one would be composed into an invalid authority.
+     * The check accepts an IPv4 literal as well, so {@code [10.0.0.5]} is honored even though
+     * RFC 3986 reserves the bracketed form for IPv6. That laxity is deliberate and documented
+     * rather than intended: it keeps this path identical to
+     * {@link IpAddresses#parseChainEntry(String)}, which has always accepted the same shape, and
+     * a syntactically valid literal is still required either way. Tighten both together or
+     * neither — a one-sided change reintroduces the host-vs-chain asymmetry.</p>
+     *
      * <p>The {@code host:port} split here intentionally diverges from
      * {@link IpAddresses#parseChainEntry(String)}: this method reconstructs the <em>host string</em>
      * and therefore <em>retains</em> the IPv6 brackets (a host is later composed back into a URL),

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -227,15 +227,15 @@ public final class ForwardedHeaderResolver {
      * <p><strong>Trailing content after {@code ]} is rejected.</strong> The only thing permitted
      * after the closing bracket is a colon followed by one or more ASCII digits, so
      * {@code [::1]garbage} and {@code [::1]x:8443} yield {@link HostPort#EMPTY} instead of resolving
-     * to host {@code [::1]}.</p>
+     * to host {@code [::1]}. That rule is not restated here: it is applied through the shared
+     * {@link IpAddresses#hasValidBracketTrailer(String)} helper.</p>
      *
      * <p>The {@code host:port} split here intentionally diverges from
      * {@link IpAddresses#parseChainEntry(String)}: this method reconstructs the <em>host string</em>
      * and therefore <em>retains</em> the IPv6 brackets (a host is later composed back into a URL),
      * whereas {@code parseChainEntry} strips them to obtain a bare literal for {@code InetAddress}
-     * matching. Only the bracket <em>retention</em> differs — the trailing-content rule above is
-     * identical on both sides. The divergence is deliberate — keep both bracket policies in sync
-     * when either changes.</p>
+     * matching. Only the bracket <em>retention</em> differs: the trailing-content rule has a single
+     * implementation shared by both call sites, so the two bracket policies cannot drift apart.</p>
      */
     private static HostPort parseHostPort(String value) {
         String host;
@@ -246,10 +246,10 @@ public final class ForwardedHeaderResolver {
                 return HostPort.EMPTY;
             }
             String rest = value.substring(close + 1);
+            if (!IpAddresses.hasValidBracketTrailer(rest)) {
+                return HostPort.EMPTY;
+            }
             if (!rest.isEmpty()) {
-                if (rest.charAt(0) != ':' || !isAllAsciiDigits(rest.substring(1))) {
-                    return HostPort.EMPTY;
-                }
                 port = parsePort(rest.substring(1));
             }
             host = value.substring(0, close + 1);

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedHeaderResolver.java
@@ -86,8 +86,10 @@ import static de.cuioss.http.forwarded.ForwardedHeaderNames.*;
  * <p><strong>Present-but-invalid = drop (no fall-through).</strong> A present, non-blank source is
  * validated; if it fails its field guard it is <em>dropped</em> — lower-precedence sources are
  * <em>not</em> consulted as a fallback. In particular a present-but-invalid
- * {@code X-Forwarded-Port} / {@code X-ProxyPort} (non-numeric or outside {@code 1..65535}) yields no
- * port; the host {@code :port} fallback is used only when no explicit port header is present at all.
+ * {@code X-Forwarded-Port} / {@code X-ProxyPort} (not digit-only, or outside {@code 1..65535})
+ * yields no port; the host {@code :port} fallback is used only when no explicit port header is
+ * present at all. Likewise an IPv6 host value must be supplied <em>bracketed</em>
+ * ({@code [2001:db8::1]}) to be honored — an unbracketed multi-colon value yields no host.
  * A source that is present but resolves to nothing valid also <em>disagrees</em> with a sibling
  * source that resolved successfully, so the conflicting-source rule above drops the field.</p>
  *
@@ -217,12 +219,23 @@ public final class ForwardedHeaderResolver {
      * path/backslash/whitespace/URL-authority-delimiter characters. Returns {@link HostPort#EMPTY}
      * for a malformed host.
      *
+     * <p><strong>An IPv6 host must be bracketed.</strong> An unbracketed value carrying more than
+     * one colon (a bare IPv6 literal such as {@code 2001:db8::1}) is rejected: the host is later
+     * composed back into a URL authority, where an unbracketed IPv6 literal produces a malformed or
+     * attacker-steerable authority. Supply it as {@code [2001:db8::1]} to have it honored.</p>
+     *
+     * <p><strong>Trailing content after {@code ]} is rejected.</strong> The only thing permitted
+     * after the closing bracket is a colon followed by one or more ASCII digits, so
+     * {@code [::1]garbage} and {@code [::1]x:8443} yield {@link HostPort#EMPTY} instead of resolving
+     * to host {@code [::1]}.</p>
+     *
      * <p>The {@code host:port} split here intentionally diverges from
      * {@link IpAddresses#parseChainEntry(String)}: this method reconstructs the <em>host string</em>
      * and therefore <em>retains</em> the IPv6 brackets (a host is later composed back into a URL),
      * whereas {@code parseChainEntry} strips them to obtain a bare literal for {@code InetAddress}
-     * matching. The divergence is deliberate — keep both bracket policies in sync when either
-     * changes.</p>
+     * matching. Only the bracket <em>retention</em> differs — the trailing-content rule above is
+     * identical on both sides. The divergence is deliberate — keep both bracket policies in sync
+     * when either changes.</p>
      */
     private static HostPort parseHostPort(String value) {
         String host;
@@ -232,14 +245,20 @@ public final class ForwardedHeaderResolver {
             if (close < 0) {
                 return HostPort.EMPTY;
             }
-            host = value.substring(0, close + 1);
             String rest = value.substring(close + 1);
-            if (rest.startsWith(":")) {
+            if (!rest.isEmpty()) {
+                if (rest.charAt(0) != ':' || !isAllAsciiDigits(rest.substring(1))) {
+                    return HostPort.EMPTY;
+                }
                 port = parsePort(rest.substring(1));
             }
+            host = value.substring(0, close + 1);
         } else if (value.indexOf(':') == value.lastIndexOf(':') && value.indexOf(':') >= 0) {
             host = value.substring(0, value.indexOf(':'));
             port = parsePort(value.substring(value.indexOf(':') + 1));
+        } else if (value.indexOf(':') >= 0) {
+            // Neither bracketed nor host:port, yet colon-bearing: a bare IPv6 literal.
+            return HostPort.EMPTY;
         } else {
             host = value;
         }
@@ -284,13 +303,40 @@ public final class ForwardedHeaderResolver {
                 .orElse(OptionalInt.empty());
     }
 
+    /**
+     * Parses a digit-only port in {@code 1..65535}. The digit-only precondition is what keeps
+     * {@code Integer.parseInt} from honoring its own lenient forms — a leading {@code +} would
+     * otherwise make {@code +443} resolve to {@code 443}, and an interior space would slip through
+     * a purely exception-based guard.
+     */
     private static OptionalInt parsePort(String value) {
-        try {
-            int port = Integer.parseInt(value.strip());
-            return port >= 1 && port <= MAX_PORT ? OptionalInt.of(port) : OptionalInt.empty();
-        } catch (NumberFormatException e) {
+        String trimmed = value.strip();
+        if (!isAllAsciiDigits(trimmed)) {
             return OptionalInt.empty();
         }
+        try {
+            int port = Integer.parseInt(trimmed);
+            return port >= 1 && port <= MAX_PORT ? OptionalInt.of(port) : OptionalInt.empty();
+        } catch (NumberFormatException e) {
+            // A digit run longer than int can hold.
+            return OptionalInt.empty();
+        }
+    }
+
+    /**
+     * @return {@code true} when {@code value} is non-empty and every character is an ASCII digit
+     */
+    private static boolean isAllAsciiDigits(String value) {
+        if (value.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c < '0' || c > '9') {
+                return false;
+            }
+        }
+        return true;
     }
 
     // --- context path ------------------------------------------------------------------------

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedLogMessages.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedLogMessages.java
@@ -68,5 +68,11 @@ public final class ForwardedLogMessages {
                 .identifier(124)
                 .template("Dropping forwarded %s: sources disagree: %s resolves to %s but Forwarded resolves to %s")
                 .build();
+
+        public static final LogRecord FORWARDED_DIRECTIVE_MALFORMED = LogRecordModel.builder()
+                .prefix(PREFIX)
+                .identifier(125)
+                .template("Rejecting Forwarded header: malformed forwarded-pair: %s")
+                .build();
     }
 }

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/IpAddresses.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/IpAddresses.java
@@ -28,11 +28,18 @@ import java.util.regex.Pattern;
 final class IpAddresses {
 
     /**
-     * Dotted-quad with no leading zero in any octet. A leading-zero octet ({@code 010.0.0.5}) is
-     * read as octal by some resolvers, which makes it a classic SSRF / allow-list bypass vector,
-     * so it is rejected outright rather than normalized.
+     * Dotted-quad with no leading zero in any octet and every octet in {@code 0..255}. A
+     * leading-zero octet ({@code 010.0.0.5}) is read as octal by some resolvers, which makes it a
+     * classic SSRF / allow-list bypass vector, so it is rejected outright rather than normalized.
+     * <p>
+     * The range bound is load-bearing, not cosmetic: {@link java.net.InetAddress#getByName} treats
+     * a dotted-quad it cannot parse as an address ({@code 999.1.1.1}) as a <em>hostname</em> and
+     * performs a real, blocking DNS lookup. A shape-only pattern would therefore let an attacker
+     * turn any {@code X-Forwarded-For} entry into an outbound resolver round trip from this
+     * header-parsing path, contradicting the class-level literal-only guarantee.
      */
-    private static final Pattern IPV4_LITERAL = Pattern.compile("(0|[1-9]\\d{0,2})(\\.(0|[1-9]\\d{0,2})){3}");
+    private static final String IPV4_OCTET = "(0|25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d?)";
+    private static final Pattern IPV4_LITERAL = Pattern.compile(IPV4_OCTET + "(\\." + IPV4_OCTET + "){3}");
     private static final Pattern IPV6_LITERAL = Pattern.compile("[0-9A-Fa-f:.]+");
 
     /** The only content permitted after a closing {@code ]}: a colon plus an all-ASCII-digit port. */

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/IpAddresses.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/IpAddresses.java
@@ -43,7 +43,7 @@ final class IpAddresses {
     private static final Pattern IPV6_LITERAL = Pattern.compile("[0-9A-Fa-f:.]+");
 
     /** The only content permitted after a closing {@code ]}: a colon plus an all-ASCII-digit port. */
-    private static final Pattern BRACKET_PORT_SUFFIX = Pattern.compile(":[0-9]+");
+    private static final Pattern BRACKET_PORT_SUFFIX = Pattern.compile(":\\d+");
 
     private IpAddresses() {
     }
@@ -85,8 +85,9 @@ final class IpAddresses {
      * {@code ForwardedHeaderResolver.parseHostPort}: this method <em>strips</em> the IPv6 brackets
      * to obtain a bare literal for {@link InetAddress} matching, whereas {@code parseHostPort}
      * <em>retains</em> them because it reconstructs a host string. Only the bracket <em>retention</em>
-     * differs — the trailing-content rule above is identical on both sides. The divergence is
-     * deliberate — keep both bracket policies in sync when either changes.</p>
+     * differs: the trailing-content rule above has a single implementation,
+     * {@link #hasValidBracketTrailer(String)}, which both call sites share, so the two bracket
+     * policies cannot drift apart.</p>
      *
      * @param entry a single forwarded-chain entry (already trimmed, unquoted)
      * @return the parsed address, or {@code null} when the entry is not a usable IP literal
@@ -103,7 +104,7 @@ final class IpAddresses {
                 return null;
             }
             String rest = token.substring(close + 1);
-            if (!rest.isEmpty() && !BRACKET_PORT_SUFFIX.matcher(rest).matches()) {
+            if (!hasValidBracketTrailer(rest)) {
                 return null;
             }
             ipPart = token.substring(1, close);
@@ -115,6 +116,24 @@ final class IpAddresses {
             ipPart = token;
         }
         return parse(ipPart);
+    }
+
+    /**
+     * The sole implementation of the "only {@code :digits} may follow a closing {@code ]}" rule,
+     * shared by {@link #parseChainEntry(String)} and {@code ForwardedHeaderResolver.parseHostPort}.
+     *
+     * <p>Both call sites must reject trailing content after the closing bracket for the same reason:
+     * a value such as {@code [::1]garbage}, {@code [::1]:notaport}, or a bare trailing {@code [::1]:}
+     * must not silently resolve to the bracketed literal, because that is a host-confusion vector.
+     * The rule therefore lives here once instead of being re-implemented per caller, where the two
+     * copies could drift apart and reopen the vulnerability they jointly prevent.</p>
+     *
+     * @param rest the substring following the closing {@code ]} (possibly empty)
+     * @return {@code true} when {@code rest} is empty, or is a colon followed by one or more ASCII
+     * digits; {@code false} for any other trailing content
+     */
+    static boolean hasValidBracketTrailer(String rest) {
+        return rest.isEmpty() || BRACKET_PORT_SUFFIX.matcher(rest).matches();
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/IpAddresses.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/IpAddresses.java
@@ -27,8 +27,16 @@ import java.util.regex.Pattern;
  */
 final class IpAddresses {
 
-    private static final Pattern IPV4_LITERAL = Pattern.compile("\\d{1,3}(\\.\\d{1,3}){3}");
+    /**
+     * Dotted-quad with no leading zero in any octet. A leading-zero octet ({@code 010.0.0.5}) is
+     * read as octal by some resolvers, which makes it a classic SSRF / allow-list bypass vector,
+     * so it is rejected outright rather than normalized.
+     */
+    private static final Pattern IPV4_LITERAL = Pattern.compile("(0|[1-9]\\d{0,2})(\\.(0|[1-9]\\d{0,2})){3}");
     private static final Pattern IPV6_LITERAL = Pattern.compile("[0-9A-Fa-f:.]+");
+
+    /** The only content permitted after a closing {@code ]}: a colon plus an all-ASCII-digit port. */
+    private static final Pattern BRACKET_PORT_SUFFIX = Pattern.compile(":[0-9]+");
 
     private IpAddresses() {
     }
@@ -61,11 +69,17 @@ final class IpAddresses {
      * {@code [2001:db8::1]:443}, and bare {@code 2001:db8::1}. RFC 7239 {@code unknown} and
      * obfuscated ({@code _hidden}) node identifiers yield {@code null}.</p>
      *
+     * <p><strong>Trailing content after {@code ]} is rejected.</strong> The only thing permitted
+     * after the closing bracket is a colon followed by one or more ASCII digits. Anything else —
+     * {@code [::1]garbage}, {@code [::1]:notaport}, a bare trailing {@code [::1]:} — yields
+     * {@code null} rather than silently resolving to the bracketed literal.</p>
+     *
      * <p>The {@code host:port} split here intentionally diverges from
      * {@code ForwardedHeaderResolver.parseHostPort}: this method <em>strips</em> the IPv6 brackets
      * to obtain a bare literal for {@link InetAddress} matching, whereas {@code parseHostPort}
-     * <em>retains</em> them because it reconstructs a host string. The divergence is deliberate —
-     * keep both bracket policies in sync when either changes.</p>
+     * <em>retains</em> them because it reconstructs a host string. Only the bracket <em>retention</em>
+     * differs — the trailing-content rule above is identical on both sides. The divergence is
+     * deliberate — keep both bracket policies in sync when either changes.</p>
      *
      * @param entry a single forwarded-chain entry (already trimmed, unquoted)
      * @return the parsed address, or {@code null} when the entry is not a usable IP literal
@@ -79,6 +93,10 @@ final class IpAddresses {
         if (token.charAt(0) == '[') {
             int close = token.indexOf(']');
             if (close < 0) {
+                return null;
+            }
+            String rest = token.substring(close + 1);
+            if (!rest.isEmpty() && !BRACKET_PORT_SUFFIX.matcher(rest).matches()) {
                 return null;
             }
             ipPart = token.substring(1, close);

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ResolvedForwarding.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ResolvedForwarding.java
@@ -17,6 +17,7 @@ package de.cuioss.http.forwarded;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -48,6 +49,20 @@ import java.util.OptionalInt;
  *
  * <p>This record is immutable and thread-safe.</p>
  *
+ * <h3>Enforced invariants</h3>
+ * <p>The record is {@code public}, so it is constructible by any caller — the invariants below are
+ * therefore enforced at construction rather than left to the resolver's convention. In particular a
+ * component carrying a control character (CR/LF) is unconstructible, so it can never round-trip out
+ * through {@link #toForwardedHeader()} / {@link #toXForwardedHeaders()} as a header-injection
+ * vector. Rejection messages name the violated component and never echo the offending value.</p>
+ * <ul>
+ *   <li>{@code scheme}, when present, is exactly {@code "http"} or {@code "https"}</li>
+ *   <li>{@code port}, when present, is in {@code 1..65535}</li>
+ *   <li>{@code host} / {@code clientIp}, when present, are non-blank and control-character free</li>
+ *   <li>{@code contextPath} is either empty or starts with exactly one {@code /}, does not end with
+ *       {@code /}, and is control-character free</li>
+ * </ul>
+ *
  * @param scheme      the resolved request scheme ({@code "http"} or {@code "https"}), empty when
  *                    absent or not honored
  * @param host        the resolved host without a port, empty when absent or not honored
@@ -56,6 +71,8 @@ import java.util.OptionalInt;
  *                    slash), or the empty string when none is present or honored
  * @param clientIp    the resolved originating client IP in canonical form, empty when absent or
  *                    not honored
+ * @throws NullPointerException     if any component is {@code null}
+ * @throws IllegalArgumentException if any component violates the invariants listed above
  *
  * @since 1.0
  */
@@ -67,8 +84,64 @@ String contextPath,
 Optional<String> clientIp
 ) {
 
+    private static final int MIN_PORT = 1;
+    private static final int MAX_PORT = 65535;
+
     private static final ResolvedForwarding EMPTY =
             new ResolvedForwarding(Optional.empty(), Optional.empty(), OptionalInt.empty(), "", Optional.empty());
+
+    /**
+     * Enforces the invariants documented on the record.
+     */
+    public ResolvedForwarding {
+        Objects.requireNonNull(scheme, "scheme must not be null");
+        Objects.requireNonNull(host, "host must not be null");
+        Objects.requireNonNull(port, "port must not be null");
+        Objects.requireNonNull(contextPath, "contextPath must not be null");
+        Objects.requireNonNull(clientIp, "clientIp must not be null");
+        // The scheme allow-list subsumes the control-character rule: neither "http" nor "https"
+        // can carry one.
+        if (scheme.isPresent() && !"http".equals(scheme.get()) && !"https".equals(scheme.get())) {
+            throw new IllegalArgumentException("scheme must be \"http\" or \"https\"");
+        }
+        if (port.isPresent() && (port.getAsInt() < MIN_PORT || port.getAsInt() > MAX_PORT)) {
+            throw new IllegalArgumentException("port must be in 1..65535");
+        }
+        host.ifPresent(value -> requireUsableAuthorityComponent(value, "host"));
+        clientIp.ifPresent(value -> requireUsableAuthorityComponent(value, "clientIp"));
+        requireUsableContextPath(contextPath);
+    }
+
+    /**
+     * Rejects a present-but-blank or control-character-bearing {@code host} / {@code clientIp}.
+     */
+    private static void requireUsableAuthorityComponent(String value, String component) {
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(component + " must not be blank when present");
+        }
+        if (ContextPaths.containsControlCharacter(value)) {
+            throw new IllegalArgumentException(component + " must not contain control characters");
+        }
+    }
+
+    /**
+     * Rejects a non-empty {@code contextPath} that is not already in the normalized shape
+     * {@link ContextPaths#normalize(String)} produces.
+     */
+    private static void requireUsableContextPath(String contextPath) {
+        if (contextPath.isEmpty()) {
+            return;
+        }
+        if (ContextPaths.containsControlCharacter(contextPath)) {
+            throw new IllegalArgumentException("contextPath must not contain control characters");
+        }
+        if (!contextPath.startsWith("/") || contextPath.startsWith("//")) {
+            throw new IllegalArgumentException("contextPath must start with exactly one '/'");
+        }
+        if (contextPath.endsWith("/")) {
+            throw new IllegalArgumentException("contextPath must not end with '/'");
+        }
+    }
 
     /**
      * Returns the empty result: no scheme, host, port, or client IP, and an empty context-path.

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ResolvedForwarding.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ResolvedForwarding.java
@@ -15,7 +15,11 @@
  */
 package de.cuioss.http.forwarded;
 
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
 
 /**
  * Immutable, sanitized result of resolving the reverse-proxy / forwarded-header family.

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/ResolvedForwarding.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/ResolvedForwarding.java
@@ -15,11 +15,7 @@
  */
 package de.cuioss.http.forwarded;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.OptionalInt;
+import java.util.*;
 
 /**
  * Immutable, sanitized result of resolving the reverse-proxy / forwarded-header family.

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/RfcForwardedParser.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/RfcForwardedParser.java
@@ -41,6 +41,15 @@ import java.util.Optional;
  * most trustworthy) hop; any earlier occurrence is attacker-supplied when the client sent a
  * {@code Forwarded} header of its own. The {@code for} list is unaffected — it stays in appearance
  * order, because the chain walk consumes it right-to-left itself.</p>
+ *
+ * <p><strong>A malformed pair rejects the whole header.</strong> A {@code forwarded-pair} that is
+ * non-blank yet carries no {@code =}, an empty directive name, or an empty (post-unquoting) value
+ * violates the grammar. Such a pair is not discarded: it marks the result
+ * {@linkplain Parsed#malformed() malformed}, parsing stops immediately, and no directive is reported.
+ * The caller treats the entire {@code Forwarded} value as present-but-unresolvable, matching the
+ * abort severity the {@code X-Forwarded-For} chain walk already applies to the same input class.
+ * The grammar's optional {@code forwarded-pair} is honored: a pair that is blank after stripping
+ * (e.g. a trailing {@code ;}) is legal and is skipped.</p>
  */
 final class RfcForwardedParser {
 
@@ -50,11 +59,20 @@ final class RfcForwardedParser {
     /**
      * The relevant directives pulled from a {@code Forwarded} header value.
      *
+     * <p>When {@code malformed} is {@code true} the header violated the grammar and no directive was
+     * kept: {@code proto} and {@code host} are empty and {@code forValues} is empty. Callers must
+     * treat the whole header as unresolvable rather than reading the (deliberately empty)
+     * directives as "carried nothing".</p>
+     *
      * @param proto     the last {@code proto} directive, if any
      * @param host      the last {@code host} directive, if any
      * @param forValues the ordered {@code for} node identifiers (unquoted), possibly empty
+     * @param malformed whether a non-blank {@code forwarded-pair} violated the grammar
      */
-    record Parsed(Optional<String> proto, Optional<String> host, List<String> forValues) {
+    record Parsed(Optional<String> proto, Optional<String> host, List<String> forValues, boolean malformed) {
+
+        /** The single outcome for a header carrying a grammar-violating pair. */
+        static final Parsed MALFORMED = new Parsed(Optional.empty(), Optional.empty(), List.of(), true);
     }
 
     static Parsed parse(String headerValue) {
@@ -62,29 +80,42 @@ final class RfcForwardedParser {
         for (String element : splitTopLevel(headerValue, ',')) {
             for (String pair : splitTopLevel(element, ';')) {
                 acc.apply(pair);
+                if (acc.malformed) {
+                    return Parsed.MALFORMED;
+                }
             }
         }
-        return new Parsed(Optional.ofNullable(acc.proto), Optional.ofNullable(acc.host), acc.forValues);
+        return new Parsed(Optional.ofNullable(acc.proto), Optional.ofNullable(acc.host), acc.forValues, false);
     }
 
     /**
      * Mutable accumulator that applies one {@code token=value} pair, keeping the last
-     * {@code proto}/{@code host} and appending every {@code for} in appearance order.
+     * {@code proto}/{@code host} and appending every {@code for} in appearance order. A pair that
+     * violates the grammar raises {@link #malformed} instead of being discarded.
      */
     private static final class Accumulator {
 
         private String proto;
         private String host;
+        private boolean malformed;
         private final List<String> forValues = new ArrayList<>();
 
         private void apply(String pair) {
-            int eq = pair.indexOf('=');
-            if (eq <= 0) {
+            String stripped = pair.strip();
+            if (stripped.isEmpty()) {
+                // RFC 7239 §4: forwarded-pair is optional, so a blank pair (e.g. a trailing ';') is legal.
                 return;
             }
-            String name = pair.substring(0, eq).strip().toLowerCase(Locale.ROOT);
-            String value = unquote(pair.substring(eq + 1).strip());
+            // eq == 0 is an empty directive name ("=value"), eq < 0 is a pair without '=' at all.
+            int eq = stripped.indexOf('=');
+            if (eq <= 0) {
+                malformed = true;
+                return;
+            }
+            String name = stripped.substring(0, eq).strip().toLowerCase(Locale.ROOT);
+            String value = unquote(stripped.substring(eq + 1).strip());
             if (value.isEmpty()) {
+                malformed = true;
                 return;
             }
             switch (name) {

--- a/cui-http-core/src/main/java/de/cuioss/http/forwarded/RfcForwardedParser.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/forwarded/RfcForwardedParser.java
@@ -72,7 +72,7 @@ final class RfcForwardedParser {
     record Parsed(Optional<String> proto, Optional<String> host, List<String> forValues, boolean malformed) {
 
         /** The single outcome for a header carrying a grammar-violating pair. */
-        static final Parsed MALFORMED = new Parsed(Optional.empty(), Optional.empty(), List.of(), true);
+        static final Parsed MALFORMED_RESULT = new Parsed(Optional.empty(), Optional.empty(), List.of(), true);
     }
 
     static Parsed parse(String headerValue) {
@@ -81,7 +81,7 @@ final class RfcForwardedParser {
             for (String pair : splitTopLevel(element, ';')) {
                 acc.apply(pair);
                 if (acc.malformed) {
-                    return Parsed.MALFORMED;
+                    return Parsed.MALFORMED_RESULT;
                 }
             }
         }

--- a/cui-http-core/src/test/java/de/cuioss/http/client/result/HttpResultFailureGenerator.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/result/HttpResultFailureGenerator.java
@@ -24,7 +24,7 @@ import de.cuioss.test.generator.TypedGenerator;
  */
 public class HttpResultFailureGenerator implements TypedGenerator<HttpResult<String>> {
 
-    private final TypedGenerator<String> strings = Generators.nonEmptyStrings();
+    private final TypedGenerator<String> strings = Generators.letterStrings(1, 64);
     private final TypedGenerator<HttpErrorCategory> categories = Generators.enumValues(HttpErrorCategory.class);
     private final TypedGenerator<Boolean> hasFallback = Generators.booleans();
     private final TypedGenerator<Integer> statusCodes = Generators.integers(400, 599);

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
@@ -303,6 +303,23 @@ class ForwardedHeaderResolverTest {
         }
 
         @Test
+        @DisplayName("rejects a bracketed host whose contents are not an IP literal")
+        void rejectsBracketedNonLiteralHost() {
+            assertAll("bracket contents",
+                    // Positive control: a well-formed bracketed literal IS honored, so the empty
+                    // results below are attributable to the bracket contents and not to the
+                    // bracketed form being rejected wholesale.
+                    () -> assertEquals(Optional.of("[2001:db8::1]"), trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Host", "[2001:db8::1]"))).host()),
+                    () -> assertTrue(trustAllResolver()
+                                    .resolve(headers(Map.of("X-Forwarded-Host", "[]"))).host().isEmpty(),
+                            "empty brackets carry no literal, so they compose an invalid authority"),
+                    () -> assertTrue(trustAllResolver()
+                                    .resolve(headers(Map.of("X-Forwarded-Host", "[not-an-ip]"))).host().isEmpty(),
+                            "the brackets promise an IP literal; a non-literal must not reach a consumer"));
+        }
+
+        @Test
         @DisplayName("rejects a port that is not digit-only")
         void rejectsNonDigitPort() {
             assertAll("digit-only port",

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
@@ -631,6 +631,24 @@ class ForwardedHeaderResolverTest {
             assertEquals(ResolvedForwarding.empty(), result,
                     "an unresolvable header contributes no value of its own");
         }
+
+        @Test
+        @DisplayName("a malformed Forwarded header drops X-Forwarded-Port")
+        void malformedForwardedDropsDeFactoPort() {
+            var portOnly = proxyAwareResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Port", "8080")));
+            var withMalformed = proxyAwareResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Port", "8080",
+                    "Forwarded", "host=trusted.example;broken")));
+
+            assertAll("port obeys the present-but-unresolvable rule like every other field",
+                    () -> assertEquals(8080, portOnly.port().orElseThrow(),
+                            "the same X-Forwarded-Port resolves on its own, so the drop below is the header's doing"),
+                    () -> assertTrue(withMalformed.port().isEmpty(),
+                            "a malformed forwarded-pair must not leave port as the one field that still honors X-Forwarded-Port"),
+                    () -> assertEquals(ResolvedForwarding.empty(), withMalformed,
+                            "no field survives an unresolvable Forwarded header"));
+        }
     }
 
     @Nested

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedHeaderResolverTest.java
@@ -283,6 +283,53 @@ class ForwardedHeaderResolverTest {
         }
 
         @Test
+        @DisplayName("rejects an unbracketed multi-colon (IPv6) host")
+        void rejectsUnbracketedIpv6Host() {
+            assertTrue(trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Host", "2001:db8::1"))).host().isEmpty(),
+                    "an IPv6 host must be bracketed to be honored, or the composed authority is malformed");
+        }
+
+        @Test
+        @DisplayName("rejects trailing content after a bracketed host")
+        void rejectsBracketTrailingContent() {
+            assertAll("bracket trailing content",
+                    () -> assertTrue(trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Host", "[::1]garbage"))).host().isEmpty()),
+                    () -> assertTrue(trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Host", "[::1]x:8443"))).host().isEmpty()),
+                    () -> assertTrue(trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Host", "[::1]:"))).host().isEmpty()));
+        }
+
+        @Test
+        @DisplayName("rejects a port that is not digit-only")
+        void rejectsNonDigitPort() {
+            assertAll("digit-only port",
+                    () -> assertTrue(trustAllResolver()
+                                    .resolve(headers(Map.of("X-Forwarded-Port", "+443"))).port().isEmpty(),
+                            "Integer.parseInt would otherwise honor the leading plus"),
+                    () -> assertTrue(trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Port", "+0"))).port().isEmpty()),
+                    () -> assertTrue(trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Port", "4 43"))).port().isEmpty()),
+                    () -> assertTrue(trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Port", "-1"))).port().isEmpty()));
+        }
+
+        @Test
+        @DisplayName("still honors the valid host and port forms the guards must not affect")
+        void stillHonorsValidForms() {
+            assertAll("positive controls",
+                    () -> assertEquals("[2001:db8::1]", trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Host", "[2001:db8::1]:8443"))).host().orElseThrow()),
+                    () -> assertEquals("app.example.com", trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Host", "app.example.com:8443"))).host().orElseThrow()),
+                    () -> assertEquals(8443, trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Port", "8443"))).port().orElseThrow()));
+        }
+
+        @Test
         @DisplayName("host and port are not honored without trustAll")
         void notHonoredWithoutTrustAll() {
             var result = resolver(ForwardedResolverConfig.secureDefault())

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedTrustBoundaryTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ForwardedTrustBoundaryTest.java
@@ -55,6 +55,13 @@ import static org.junit.jupiter.api.Assertions.*;
  *   <li><strong>Fail-closed chain walk</strong> — the all-hops-trusted and unparseable-hop
  *       behaviours still yield no client IP, guarding against a regression that opens the chain walk
  *       while the other gaps are closed.</li>
+ *   <li><strong>Parser strictness cluster</strong> — the tightened parser guards, each driven
+ *       end-to-end through the public resolver so the assertion captures the user-visible
+ *       reject outcome: a malformed RFC 7239 {@code forwarded-pair}, a bracketed chain hop with
+ *       trailing garbage, a leading-zero IPv4 octet, an unbracketed IPv6 host, and a non-digit
+ *       port. The symmetric {@code X-Forwarded-Host: [::1]garbage} guard is driven through the
+ *       same public surface by {@link ForwardedHeaderResolverTest}, so it is not duplicated
+ *       here.</li>
  * </ul>
  *
  * <p>Every attack-shape test carries a matched negative control (a benign, agreeing or single-source
@@ -340,6 +347,107 @@ class ForwardedTrustBoundaryTest {
 
             assertEquals("203.0.113.7", result.clientIp().orElseThrow(),
                     "the chain walk is still open for a genuinely untrusted hop");
+        }
+    }
+
+    @Nested
+    @DisplayName("Parser strictness cluster")
+    class ParserStrictness {
+
+        @Test
+        @DisplayName("a malformed Forwarded directive drops the fields a clean de-facto sibling attests")
+        void malformedForwardedDropsDeFactoFields() {
+            var result = trustAllResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Proto", "https",
+                    "X-Forwarded-Host", PROXY_HOST,
+                    "Forwarded", "proto=;host=" + PROXY_HOST)));
+
+            assertAll("the malformed header is present-but-unresolvable for every field it could carry",
+                    () -> assertTrue(result.scheme().isEmpty()),
+                    () -> assertTrue(result.host().isEmpty()));
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "malformed forwarded-pair");
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, SOURCES_DISAGREE);
+        }
+
+        @Test
+        @DisplayName("positive control: a well-formed Forwarded header agreeing with the de-facto family is honored")
+        void wellFormedForwardedHonored() {
+            var result = trustAllResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Proto", "https",
+                    "X-Forwarded-Host", PROXY_HOST,
+                    "Forwarded", "proto=https;host=" + PROXY_HOST)));
+
+            assertAll("a legal header must still reconcile",
+                    () -> assertEquals("https", result.scheme().orElseThrow()),
+                    () -> assertEquals(PROXY_HOST, result.host().orElseThrow()));
+        }
+
+        @Test
+        @DisplayName("a bracketed hop with trailing garbage aborts the chain walk rather than being skipped")
+        void bracketTrailingGarbageAbortsChainWalk() {
+            var result = chainWalkingResolver()
+                    .resolve(headers(Map.of("X-Forwarded-For", "203.0.113.7, [::1]garbage")));
+
+            assertTrue(result.clientIp().isEmpty(),
+                    "203.0.113.7 is untrusted and would resolve if the bad hop were merely skipped");
+            LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN, "unparseable entry");
+        }
+
+        @Test
+        @DisplayName("a leading-zero IPv4 octet in the chain aborts the walk")
+        void leadingZeroOctetAbortsChainWalk() {
+            var result = chainWalkingResolver()
+                    .resolve(headers(Map.of("X-Forwarded-For", "010.0.0.5, 10.0.0.5")));
+
+            assertTrue(result.clientIp().isEmpty(),
+                    "an octal-ambiguous octet is unverifiable, so the chain yields no client");
+        }
+
+        @Test
+        @DisplayName("positive control: the same chain shape resolves with well-formed literals")
+        void wellFormedChainResolves() {
+            var result = chainWalkingResolver()
+                    .resolve(headers(Map.of("X-Forwarded-For", "203.0.113.7, 10.0.0.5")));
+
+            assertEquals("203.0.113.7", result.clientIp().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("an unbracketed IPv6 X-Forwarded-Host yields no host")
+        void unbracketedIpv6HostDropped() {
+            assertTrue(trustAllResolver()
+                            .resolve(headers(Map.of("X-Forwarded-Host", "2001:db8::1"))).host().isEmpty(),
+                    "an unbracketed IPv6 literal would compose into a malformed URL authority");
+        }
+
+        @Test
+        @DisplayName("positive control: the bracketed form of the same host is honored")
+        void bracketedIpv6HostHonored() {
+            assertEquals("[2001:db8::1]", trustAllResolver()
+                    .resolve(headers(Map.of("X-Forwarded-Host", "[2001:db8::1]"))).host().orElseThrow());
+        }
+
+        @Test
+        @DisplayName("a non-digit X-Forwarded-Port yields no port and does not fall back to the host port")
+        void nonDigitPortDoesNotFallBack() {
+            var result = trustAllResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Host", PROXY_HOST + ":8443",
+                    "X-Forwarded-Port", "+443")));
+
+            assertAll("a present-but-invalid port header drops the field outright",
+                    () -> assertTrue(result.port().isEmpty()),
+                    () -> assertEquals(PROXY_HOST, result.host().orElseThrow(),
+                            "only the port is dropped, not the host"));
+        }
+
+        @Test
+        @DisplayName("positive control: a digit-only X-Forwarded-Port overrides the host port")
+        void digitOnlyPortHonored() {
+            var result = trustAllResolver().resolve(headers(Map.of(
+                    "X-Forwarded-Host", PROXY_HOST + ":8443",
+                    "X-Forwarded-Port", "443")));
+
+            assertEquals(443, result.port().orElseThrow());
         }
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/IpAddressesTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/IpAddressesTest.java
@@ -64,8 +64,18 @@ class IpAddressesTest {
                     "a leading-zero octet is read as octal by some resolvers, so it is an allow-list bypass");
         }
 
+        @ParameterizedTest(name = "\"{0}\" carries an out-of-range octet")
+        @ValueSource(strings = {"999.1.1.1", "256.1.1.1", "1.1.1.256", "300.400.500.600"})
+        @DisplayName("rejects an IPv4 literal with an out-of-range octet without a DNS lookup")
+        void rejectsOutOfRangeOctets(String entry) {
+            assertNull(IpAddresses.parseChainEntry(entry),
+                    "InetAddress.getByName treats an unparseable dotted-quad as a hostname and resolves it, "
+                            + "so an out-of-range octet must be rejected by the pattern to keep parsing literal-only");
+        }
+
         @ParameterizedTest(name = "\"{0}\" is still a usable node identifier")
-        @ValueSource(strings = {"[2001:db8::1]", "[2001:db8::1]:443", "0.0.0.0", "10.0.0.5", "2001:db8::1"})
+        @ValueSource(strings = {"[2001:db8::1]", "[2001:db8::1]:443", "0.0.0.0", "10.0.0.5", "2001:db8::1",
+                "255.255.255.255", "192.168.1.1"})
         @DisplayName("still parses the valid literals the tightened guards must not affect")
         void acceptsValidLiterals(String entry) {
             assertNotNull(IpAddresses.parseChainEntry(entry));

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/IpAddressesTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/IpAddressesTest.java
@@ -48,6 +48,29 @@ class IpAddressesTest {
             assertNull(IpAddresses.parseChainEntry(entry));
         }
 
+        @ParameterizedTest(name = "\"{0}\" carries content after the closing bracket")
+        @ValueSource(strings = {"[::1]garbage", "[::1]:notaport", "[::1]:", "[::1]x:8443", "[::1]]"})
+        @DisplayName("rejects trailing content after a closing bracket")
+        void rejectsBracketTrailingContent(String entry) {
+            assertNull(IpAddresses.parseChainEntry(entry),
+                    "only a colon plus ASCII digits may follow the closing bracket");
+        }
+
+        @ParameterizedTest(name = "\"{0}\" carries a leading-zero octet")
+        @ValueSource(strings = {"010.0.0.5", "192.168.01.1", "0.0.0.05", "00.0.0.1"})
+        @DisplayName("rejects an IPv4 literal with a leading-zero octet")
+        void rejectsLeadingZeroOctets(String entry) {
+            assertNull(IpAddresses.parseChainEntry(entry),
+                    "a leading-zero octet is read as octal by some resolvers, so it is an allow-list bypass");
+        }
+
+        @ParameterizedTest(name = "\"{0}\" is still a usable node identifier")
+        @ValueSource(strings = {"[2001:db8::1]", "[2001:db8::1]:443", "0.0.0.0", "10.0.0.5", "2001:db8::1"})
+        @DisplayName("still parses the valid literals the tightened guards must not affect")
+        void acceptsValidLiterals(String entry) {
+            assertNotNull(IpAddresses.parseChainEntry(entry));
+        }
+
         @Test
         @DisplayName("canonicalizes to the host address form")
         void canonicalizes() {

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/ResolvedForwardingTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/ResolvedForwardingTest.java
@@ -43,6 +43,109 @@ class ResolvedForwardingTest {
             assertEquals("", empty.contextPath());
             assertTrue(empty.clientIp().isEmpty());
         }
+
+        @Test
+        @DisplayName("rejects a scheme outside the http/https allow-list")
+        void rejectsForeignScheme() {
+            assertAll("scheme allow-list",
+                    () -> assertThrows(IllegalArgumentException.class, () -> withScheme("ftp")),
+                    () -> assertThrows(IllegalArgumentException.class, () -> withScheme("HTTPS"),
+                            "the resolver lower-cases the scheme, so a mixed-case value is not canonical"),
+                    () -> assertThrows(IllegalArgumentException.class, () -> withScheme("")));
+        }
+
+        @Test
+        @DisplayName("rejects a port outside 1..65535")
+        void rejectsPortOutsideRange() {
+            assertAll("port range",
+                    () -> assertThrows(IllegalArgumentException.class, () -> withPort(0)),
+                    () -> assertThrows(IllegalArgumentException.class, () -> withPort(65536)),
+                    () -> assertThrows(IllegalArgumentException.class, () -> withPort(-1)));
+        }
+
+        @Test
+        @DisplayName("rejects a context path that is not in normalized shape")
+        void rejectsDenormalizedContextPath() {
+            assertAll("context-path shape",
+                    () -> assertThrows(IllegalArgumentException.class, () -> withContextPath("ui"),
+                            "a context path needs a leading slash"),
+                    () -> assertThrows(IllegalArgumentException.class, () -> withContextPath("//ui"),
+                            "a protocol-relative prefix must not survive construction"),
+                    () -> assertThrows(IllegalArgumentException.class, () -> withContextPath("/ui/"),
+                            "a trailing slash is not the normalized shape"),
+                    () -> assertThrows(IllegalArgumentException.class, () -> withContextPath("/")));
+        }
+
+        @Test
+        @DisplayName("rejects a control character in any component, so CR/LF cannot round-trip out")
+        void rejectsControlCharacters() {
+            assertAll("control characters",
+                    () -> assertThrows(IllegalArgumentException.class, () -> withHost("app.example.com\r\nX: y")),
+                    () -> assertThrows(IllegalArgumentException.class, () -> withContextPath("/ui\r\nX: y")),
+                    () -> assertThrows(IllegalArgumentException.class, () -> withClientIp("203.0.113.7\r\nX: y")),
+                    () -> assertThrows(IllegalArgumentException.class, () -> withHost("app.example.com\t")));
+        }
+
+        @Test
+        @DisplayName("rejects a present-but-blank host or client IP")
+        void rejectsBlankPresentComponents() {
+            assertAll("blank components",
+                    () -> assertThrows(IllegalArgumentException.class, () -> withHost("")),
+                    () -> assertThrows(IllegalArgumentException.class, () -> withHost("   ")),
+                    () -> assertThrows(IllegalArgumentException.class, () -> withClientIp("")));
+        }
+
+        @Test
+        @DisplayName("names the violated component without echoing the offending value")
+        void namesComponentWithoutEchoingValue() {
+            var thrown = assertThrows(IllegalArgumentException.class, () -> withHost("evil\r\nX: y"));
+
+            assertAll("message content",
+                    () -> assertTrue(thrown.getMessage().contains("host"), "the message names the component"),
+                    () -> assertFalse(thrown.getMessage().contains("evil"),
+                            "the message must not echo untrusted input"));
+        }
+
+        @Test
+        @DisplayName("accepts every valid shape, including the port range boundaries")
+        void acceptsValidShapes() {
+            assertAll("valid shapes",
+                    () -> assertDoesNotThrow(() -> withScheme("http")),
+                    () -> assertDoesNotThrow(() -> withScheme("https")),
+                    () -> assertDoesNotThrow(() -> withPort(1)),
+                    () -> assertDoesNotThrow(() -> withPort(65535)),
+                    () -> assertDoesNotThrow(() -> withContextPath("")),
+                    () -> assertDoesNotThrow(() -> withContextPath("/ui")),
+                    () -> assertDoesNotThrow(() -> withContextPath("/ui/admin")),
+                    () -> assertDoesNotThrow(() -> withHost("app.example.com")),
+                    () -> assertDoesNotThrow(() -> withHost("[2001:db8::1]")),
+                    () -> assertDoesNotThrow(() -> withClientIp("2001:db8::1")));
+        }
+
+        private static ResolvedForwarding withScheme(String scheme) {
+            return new ResolvedForwarding(Optional.of(scheme), Optional.empty(), OptionalInt.empty(),
+                    "", Optional.empty());
+        }
+
+        private static ResolvedForwarding withHost(String host) {
+            return new ResolvedForwarding(Optional.empty(), Optional.of(host), OptionalInt.empty(),
+                    "", Optional.empty());
+        }
+
+        private static ResolvedForwarding withPort(int port) {
+            return new ResolvedForwarding(Optional.empty(), Optional.empty(), OptionalInt.of(port),
+                    "", Optional.empty());
+        }
+
+        private static ResolvedForwarding withContextPath(String contextPath) {
+            return new ResolvedForwarding(Optional.empty(), Optional.empty(), OptionalInt.empty(),
+                    contextPath, Optional.empty());
+        }
+
+        private static ResolvedForwarding withClientIp(String clientIp) {
+            return new ResolvedForwarding(Optional.empty(), Optional.empty(), OptionalInt.empty(),
+                    "", Optional.of(clientIp));
+        }
     }
 
     @Nested

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/RfcForwardedParserTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/RfcForwardedParserTest.java
@@ -21,7 +21,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("RfcForwardedParser")
 class RfcForwardedParserTest {

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/RfcForwardedParserTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/RfcForwardedParserTest.java
@@ -16,11 +16,14 @@
 package de.cuioss.http.forwarded;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("RfcForwardedParser")
@@ -83,12 +86,58 @@ class RfcForwardedParserTest {
         assertTrue(parsed.forValues().isEmpty());
     }
 
-    @Test
-    @DisplayName("ignores malformed pairs without a value")
-    void ignoresMalformedPairs() {
-        RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse("proto=;host");
+    @Nested
+    @DisplayName("malformed forwarded-pair")
+    class MalformedPairs {
 
-        assertTrue(parsed.proto().isEmpty());
-        assertTrue(parsed.host().isEmpty());
+        @Test
+        @DisplayName("rejects the whole header when a pair carries an empty value")
+        void rejectsEmptyValue() {
+            RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse("proto=;host");
+
+            assertAll("rejected header",
+                    () -> assertTrue(parsed.malformed(), "proto= carries no value, so the header is malformed"),
+                    () -> assertTrue(parsed.proto().isEmpty(), "a malformed header reports no proto"),
+                    () -> assertTrue(parsed.host().isEmpty(), "a malformed header reports no host"),
+                    () -> assertTrue(parsed.forValues().isEmpty(), "a malformed header reports no for chain"));
+        }
+
+        @Test
+        @DisplayName("rejects the whole header when a non-blank pair carries no '='")
+        void rejectsPairWithoutEquals() {
+            RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse("host");
+
+            assertTrue(parsed.malformed(), "a pair without '=' violates the forwarded-pair grammar");
+        }
+
+        @Test
+        @DisplayName("rejects the whole header when a pair carries an empty directive name")
+        void rejectsEmptyDirectiveName() {
+            RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse("=https");
+
+            assertTrue(parsed.malformed(), "an empty directive name violates the forwarded-pair grammar");
+        }
+
+        @Test
+        @DisplayName("accepts a grammatically legal blank pair and still parses the header")
+        void acceptsLegalBlankPair() {
+            RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse("for=203.0.113.7;");
+
+            assertAll("accepted header",
+                    () -> assertFalse(parsed.malformed(),
+                            "RFC 7239 §4 makes forwarded-pair optional, so a trailing ';' is legal"),
+                    () -> assertEquals(List.of("203.0.113.7"), parsed.forValues()));
+        }
+
+        @Test
+        @DisplayName("stops parsing at the first malformed pair")
+        void stopsAtFirstMalformedPair() {
+            RfcForwardedParser.Parsed parsed = RfcForwardedParser.parse("host, proto=https");
+
+            assertAll("abort before the later element",
+                    () -> assertTrue(parsed.malformed()),
+                    () -> assertTrue(parsed.proto().isEmpty(),
+                            "the trailing proto is not accumulated once the header is rejected"));
+        }
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/forwarded/RfcForwardedParserTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/forwarded/RfcForwardedParserTest.java
@@ -21,10 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("RfcForwardedParser")
 class RfcForwardedParserTest {

--- a/doc/LogMessages.adoc
+++ b/doc/LogMessages.adoc
@@ -14,7 +14,7 @@ Module: `de.cuioss.http`
 LogMessages Classes:
 
 - `de.cuioss.http.client.HttpLogMessages` - HTTP client operations (HTTP-106–108, HTTP-110–115, HTTP-200–201)
-- `de.cuioss.http.forwarded.ForwardedLogMessages` - Forwarded / reverse-proxy header resolution (HTTP-120–124)
+- `de.cuioss.http.forwarded.ForwardedLogMessages` - Forwarded / reverse-proxy header resolution (HTTP-120–125)
 
 == HttpLogMessages
 
@@ -119,6 +119,11 @@ LogMessages Classes:
 |Forwarded
 |Dropping forwarded %s: sources disagree: %s resolves to %s but Forwarded resolves to %s
 |Logged when the de-facto X-Forwarded-* / X-Proxy* family and the RFC 7239 Forwarded header resolve a field to different values, so the field is dropped rather than letting either source win. Parameters: field name, de-facto header name, de-facto resolution, RFC 7239 resolution.
+
+|HTTP-125
+|Forwarded
+|Rejecting Forwarded header: malformed forwarded-pair: %s
+|Logged when the RFC 7239 Forwarded header carries a malformed forwarded-pair — a non-blank pair with no `=`, an empty directive name, or an empty value — so the whole header is treated as present-but-unresolvable for every field it could have carried. A grammatically legal blank pair (a trailing `;`) is not malformed. Parameters: sanitized header value.
 |===
 
 == Notes

--- a/doc/LogMessages.adoc
+++ b/doc/LogMessages.adoc
@@ -14,7 +14,7 @@ Module: `de.cuioss.http`
 LogMessages Classes:
 
 - `de.cuioss.http.client.HttpLogMessages` - HTTP client operations (HTTP-106–108, HTTP-110–115, HTTP-200–201)
-- `de.cuioss.http.forwarded.ForwardedLogMessages` - Forwarded / reverse-proxy header resolution (HTTP-120–125)
+- `de.cuioss.http.forwarded.ForwardedLogMessages` - Forwarded / reverse-proxy header resolution (HTTP-120–125) - source: xref:../cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedLogMessages.java[ForwardedLogMessages.java]
 
 == HttpLogMessages
 
@@ -88,6 +88,11 @@ LogMessages Classes:
 |===
 
 == ForwardedLogMessages
+
+The authoritative source for the records below is
+xref:../cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedLogMessages.java[ForwardedLogMessages.java].
+This table is maintained by hand, so it must be updated whenever a record in that class is added,
+removed, renumbered, or reworded.
 
 === WARN Level (100-199)
 

--- a/doc/forwarded-header-resolution.adoc
+++ b/doc/forwarded-header-resolution.adoc
@@ -160,7 +160,7 @@ Immutable trust-model configuration built through a validating builder. See xref
 `HTTP-120`..`HTTP-125` WARN records for rejected/malformed values (context-path control
 characters, protocol-relative/backslash prefixes, values that failed sanitization, unparseable
 client-IP chain entries, — `HTTP-124` — a field dropped because the de-facto `X-Forwarded-*`
-family and the RFC 7239 `Forwarded` header disagree, and — `HTTP-125`
+family and the RFC 7239 `Forwarded` header disagree — and `HTTP-125`
 (`FORWARDED_DIRECTIVE_MALFORMED`) — a `Forwarded` header rejected because it carries a malformed
 `forwarded-pair`).
 

--- a/doc/forwarded-header-resolution.adoc
+++ b/doc/forwarded-header-resolution.adoc
@@ -233,7 +233,7 @@ rejected unless it is `:` plus the port, so `[::1]garbage` yields no host.
 *A malformed `Forwarded` value rejects the whole header.* The rule above applies to the RFC 7239
 `Forwarded` header *as a whole*. When its raw value fails sanitization, *or* when it carries a
 malformed `forwarded-pair`, the header is present-but-unresolvable for *every* field it could have
-carried — scheme, host, and client IP alike — and therefore *disagrees* with an otherwise clean
+carried — scheme, host, port, and client IP alike — and therefore *disagrees* with an otherwise clean
 `X-Forwarded-*` sibling, which drops that field rather than letting the de-facto family win by
 default. A pair is malformed when it is non-blank and carries no `=`, an empty directive name, or an
 empty value. Rejection is logged once as an `HTTP-125` warning with a log-sanitized value.
@@ -243,10 +243,11 @@ that is *blank* is grammatically legal: a trailing `;` is still accepted and par
 
 [source,text]
 ----
-Forwarded: proto=;host=app.internal               -> scheme/host/clientIp = empty  (malformed pair -> whole header rejected)
-Forwarded: host                                   -> scheme/host/clientIp = empty  (no "=" -> malformed)
+Forwarded: proto=;host=app.internal               -> every field = empty           (malformed pair -> whole header rejected)
+Forwarded: host                                   -> every field = empty           (no "=" -> malformed)
 Forwarded: for=203.0.113.7;                       -> parses normally               (trailing ";" is a legal blank pair)
 X-Forwarded-Proto: https + Forwarded: proto=;host -> scheme = empty                (clean sibling dropped by disagreement)
+X-Forwarded-Port: 8080 + Forwarded: host=t.ex;bad -> port = empty                  (port is reachable via host=...:port, so it drops too)
 ----
 
 [#trust-model]

--- a/doc/forwarded-header-resolution.adoc
+++ b/doc/forwarded-header-resolution.adoc
@@ -157,10 +157,12 @@ Immutable trust-model configuration built through a validating builder. See xref
 
 === xref:../cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedLogMessages.java[ForwardedLogMessages]
 
-`HTTP-120`..`HTTP-124` WARN records for rejected/malformed values (context-path control
+`HTTP-120`..`HTTP-125` WARN records for rejected/malformed values (context-path control
 characters, protocol-relative/backslash prefixes, values that failed sanitization, unparseable
-client-IP chain entries, and — `HTTP-124` — a field dropped because the de-facto `X-Forwarded-*`
-family and the RFC 7239 `Forwarded` header disagree).
+client-IP chain entries, — `HTTP-124` — a field dropped because the de-facto `X-Forwarded-*`
+family and the RFC 7239 `Forwarded` header disagree, and — `HTTP-125`
+(`FORWARDED_DIRECTIVE_MALFORMED`) — a `Forwarded` header rejected because it carries a malformed
+`forwarded-pair`).
 
 == Header precedence
 
@@ -221,8 +223,31 @@ X-Forwarded-Proto: https                          -> scheme = https  (single sou
 *Present-but-invalid = drop (no fall-through).* Precedence selects the first present, non-blank
 source for a field; that value is then validated. If it fails its field guard it is *dropped* —
 lower-precedence sources are *not* consulted as a fallback. In particular a present-but-invalid
-`X-Forwarded-Port` / `X-ProxyPort` (non-numeric or outside `1..65535`) yields no port; the host
-`:port` fallback is used only when *no* explicit port header is present at all.
+`X-Forwarded-Port` / `X-ProxyPort` (not digit-only, or outside `1..65535`) yields no port; the host
+`:port` fallback is used only when *no* explicit port header is present at all. An IPv6 host must
+likewise be supplied *bracketed* (`X-Forwarded-Host: [2001:db8::1]`) to be honored — an unbracketed
+multi-colon value yields no host, because the host is composed back into a URL authority where an
+unbracketed IPv6 literal is malformed and attacker-steerable. Content after the closing `]` is
+rejected unless it is `:` plus the port, so `[::1]garbage` yields no host.
+
+*A malformed `Forwarded` value rejects the whole header.* The rule above applies to the RFC 7239
+`Forwarded` header *as a whole*. When its raw value fails sanitization, *or* when it carries a
+malformed `forwarded-pair`, the header is present-but-unresolvable for *every* field it could have
+carried — scheme, host, and client IP alike — and therefore *disagrees* with an otherwise clean
+`X-Forwarded-*` sibling, which drops that field rather than letting the de-facto family win by
+default. A pair is malformed when it is non-blank and carries no `=`, an empty directive name, or an
+empty value. Rejection is logged once as an `HTTP-125` warning with a log-sanitized value.
+
+RFC 7239 §4 defines `forwarded-element = [ forwarded-pair ] *( ";" [ forwarded-pair ] )`, so a pair
+that is *blank* is grammatically legal: a trailing `;` is still accepted and parses normally.
+
+[source,text]
+----
+Forwarded: proto=;host=app.internal               -> scheme/host/clientIp = empty  (malformed pair -> whole header rejected)
+Forwarded: host                                   -> scheme/host/clientIp = empty  (no "=" -> malformed)
+Forwarded: for=203.0.113.7;                       -> parses normally               (trailing ";" is a legal blank pair)
+X-Forwarded-Proto: https + Forwarded: proto=;host -> scheme = empty                (clean sibling dropped by disagreement)
+----
 
 [#trust-model]
 == Trust model (secure by default)
@@ -265,6 +290,13 @@ well-formed address is the client. This prevents a spoofed prepended entry from 
   chain with an unverifiable hop cannot be trusted to identify the client. For example
   `Forwarded: for=203.0.113.7, for=unknown` yields an empty `clientIp` even though a well-formed
   address is also present.
+* Two further shapes count as unusable literals and therefore abort the walk: content after the
+  closing bracket of a bracketed IPv6 hop unless it is `:` plus digits (`[::1]garbage`,
+  `[::1]:notaport`), and an IPv4 octet with a leading zero (`010.0.0.5`), which some resolvers read
+  as octal and which is a classic allow-list bypass. A bare `0` octet remains valid.
+* A malformed RFC 7239 `forwarded-pair` anywhere in the `Forwarded` header makes the whole header
+  unresolvable, so its `for` chain contributes nothing and the field is dropped — see
+  *A malformed `Forwarded` value rejects the whole header* under Header precedence.
 * An empty `trustedProxies` set or an all-trusted chain likewise yields an empty `clientIp`
   (fail-safe).
 
@@ -275,6 +307,8 @@ trustedProxies = [10.0.0.0/8]
 X-Forwarded-For: 203.0.113.7, 10.0.0.5              -> clientIp = 203.0.113.7
 X-Forwarded-For: 1.2.3.4, 203.0.113.7, 10.0.0.5     -> clientIp = 203.0.113.7  (spoofed 1.2.3.4 ignored)
 X-Forwarded-For: 10.0.0.1, 10.0.0.5                 -> clientIp = empty         (all hops trusted)
+X-Forwarded-For: 203.0.113.7, [::1]garbage          -> clientIp = empty         (trailing content -> walk aborts)
+X-Forwarded-For: 010.0.0.5, 10.0.0.5                -> clientIp = empty         (leading-zero octet -> walk aborts)
 (no trustedProxies configured)                       -> clientIp = empty         (nothing honored)
 ----
 


### PR DESCRIPTION
## Summary

Aligns the two forwarded-header parsing paths (RFC 7239 `Forwarded` and the `X-Forwarded-*` chain) on equally strict validation, and adds compact-constructor invariant enforcement to the public `ResolvedForwarding` record. A cluster of IP-literal and host-guard laxities is closed alongside.

## Intent

## Changes

- `RfcForwardedParser.java` — the accumulator no longer silently drops a malformed `forwarded-pair` (missing `=` or empty value); the malformed element now reaches `ForwardedHeaderResolver.walkChain`'s existing abort path instead of being swallowed before `walkChain` ever sees it.
- `ResolvedForwarding.java` — adds a compact constructor enforcing the documented invariants (scheme `http`/`https`, port `1..65535`, `contextPath` with exactly one leading slash, no control characters in any component), so a directly-constructed record can no longer serialize CR/LF through `toXForwardedHeaders`/`toForwardedHeader`.
- `IpAddresses.java` — `parseChainEntry` now rejects a bracketed IPv6 literal with trailing garbage after the closing `]` (e.g. `[::1]garbage`), and tightens the IPv4 literal regex to reject a leading-zero octet (e.g. `010.0.0.5`).
- `ForwardedHeaderResolver.java` — `parsePort` now restricts port parsing to digit-only input (rejecting a leading `+`), and an unbracketed multi-colon host value (a bare IPv6 literal supplied without brackets) is now rejected rather than passed through verbatim.
- `ForwardedLogMessages.java` / `doc/LogMessages.adoc` — new log messages for the added abort/reject paths.
- `doc/forwarded-header-resolution.adoc` — documentation updates reflecting the tightened parsing behavior.
- Test suites under `cui-http-core/src/test/java/de/cuioss/http/forwarded/` extended with regression tests asserting the abort/reject outcome for each tightened case.

## Test Plan

- [ ] Verification command passed (`python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Ppre-commit"`)
- [ ] Manual testing completed (if applicable)

## Related Issues



---
Generated by plan-finalize skill

## Intent

**Problem.** The two forwarded-header parsing paths — RFC 7239 `Forwarded` and the `X-Forwarded-*` chain — were not equally strict: a malformed RFC directive (missing `=`, empty value) was silently dropped by the accumulator before it ever reached the abort-capable `walkChain`, while the XFF chain already aborted on an equivalent malformed hop. Several related laxities compounded the gap: `ResolvedForwarding` is a public record with no compact constructor, so its documented invariants (scheme, port range, single leading-slash contextPath, no control characters) were unenforced against direct construction; bracketed IPv6 literals tolerated trailing garbage after the closing `]`; IPv4 octets accepted leading zeros; ports accepted a leading `+`; and an unbracketed multi-colon host value (a bare IPv6 literal) was passed through unchanged instead of being rejected.

**Approach.** Each gap is closed at its point of origin rather than patched downstream: the RFC accumulator now surfaces malformed elements to the same `walkChain` abort path the XFF chain already uses, `ResolvedForwarding` gets a compact constructor that validates every invariant at construction time, and the IP/host parsing helpers (`IpAddresses`, `ForwardedHeaderResolver`) get targeted regex/parsing tightening for each identified laxity. This keeps the fix surgical — no new abstractions, no configurability — and

_[Intent truncated — 1394 of 1989 characters shown; full outline in the plan workspace]_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for forwarded headers, hosts, ports, and IP addresses.
  * Malformed forwarding data is now rejected consistently, including associated port information.
  * Added safeguards against invalid bracketed IPv6 values, leading-zero IPv4 octets, and unsafe resolved forwarding values.

* **Documentation**
  * Clarified parsing rules, rejection behavior, and warning messages.

* **Tests**
  * Expanded coverage for malformed headers, invalid addresses, ports, and forwarding resolution inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->