### PR TITLE
fix(client): gate 304 short-circuit by HTTP method and fix ETag cache result fidelity

### DIFF
--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -100,7 +100,7 @@
           "re_review_on_timeout": "ask",
           "review_rate_window_await": false,
           "review_rate_window_timeout_seconds": 3600,
-          "required_bots": "coderabbit,pr-agent",
+          "required_bots": "coderabbit",
           "optional_bots": "sourcery",
           "review_completion_poll_timeout_seconds": 600,
           "lane": "standard",

--- a/.plan/marshal.json
+++ b/.plan/marshal.json
@@ -100,7 +100,7 @@
           "re_review_on_timeout": "ask",
           "review_rate_window_await": false,
           "review_rate_window_timeout_seconds": 3600,
-          "required_bots": "coderabbit",
+          "required_bots": "coderabbit,pr-agent",
           "optional_bots": "sourcery",
           "review_completion_poll_timeout_seconds": 600,
           "lane": "standard",

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
@@ -148,9 +148,9 @@ import static de.cuioss.http.client.HttpLogMessages.WARN;
  * <p><strong>Benign last-writer-wins race on cache maintenance.</strong> Two cache writes are
  * check-then-act sequences on the {@code ConcurrentHashMap} rather than atomic compare-and-set
  * operations: the 304 timestamp refresh (read the entry, then write it back with a new timestamp)
- * and the eviction of a stale entry after an ETag-less {@code 200} (observe the missing validator,
- * then remove). Concurrent revalidations of the same key can therefore interleave, and the last
- * writer wins.</p>
+ * and the eviction of a stale entry after a {@code 200} that could not replace it (observe that no
+ * replacement entry can be built, then remove). Concurrent revalidations of the same key can
+ * therefore interleave, and the last writer wins.</p>
  *
  * <p>This is benign, and deliberately not locked. Every writer for a given key stores a
  * fully-formed immutable {@link CacheEntry}, so no reader can observe a torn or mismatched entry;
@@ -782,7 +782,7 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
 
         if (cache.remove(key) != null) {
             // The key embeds request header values, so it is deliberately not logged.
-            LOGGER.debug("Removed stale cache entry after an ETag-less 200");
+            LOGGER.debug("Removed stale cache entry after a GET 200 that could not replace it");
         }
     }
 
@@ -846,9 +846,9 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
      *   <li>304 Not Modified detection, resolved per method by {@link #handleNotModified}</li>
      *   <li>ETag extraction from response headers</li>
      *   <li>Response body conversion using configured converter</li>
-     *   <li>GET {@code 200} cache maintenance — store on an ETag, evict without one. Runs ahead of
-     *       the conversion-failure return so an ETag-less {@code 200} the converter rejects still
-     *       drops the entry it superseded</li>
+     *   <li>GET {@code 200} cache maintenance — store when the response yields both a validator and
+     *       content, evict otherwise. Runs ahead of the conversion-failure return so a {@code 200}
+     *       the converter rejects still drops the entry it superseded</li>
      *   <li>Conversion failure handling for 2xx responses, excluding the no-body statuses
      *       {@code 204} and {@code 205} (see {@link #isNoBodyStatus})</li>
      *   <li>Success/failure result creation based on status code</li>
@@ -887,18 +887,22 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
         Optional<T> content = responseConverter.convert(response.body());
 
         // Cache maintenance for a fresh GET 200. With an ETag and content, store (or refresh) the
-        // entry. Without an ETag the server has returned content it no longer identifies by any
-        // validator, so a previously cached entry is provably stale: drop it rather than leave it
-        // to be served later as fallback content or revalidated with a dead If-None-Match.
+        // entry. Otherwise evict: the 200 is a fresh representation that supersedes whatever was
+        // cached, and no replacement entry could be built from it, so the old one is provably
+        // stale. Both non-replaceable cases reach the eviction, and the reason does not matter -
+        // a missing validator (content the server no longer identifies) and an unparseable body
+        // under an ETag (a validator with nothing to pair it with) are equally unable to produce a
+        // replacement. Leaving the superseded entry behind would let a later failure serve it as
+        // fallback content, or revalidate it with a dead If-None-Match.
         //
-        // This runs BEFORE the conversion-failure return below. An ETag-less 200 whose body the
-        // converter rejects still supersedes the cached entry, and evicting after the early return
-        // would never reach it - leaving a later failure free to serve content the 200 replaced.
+        // This runs BEFORE the conversion-failure return below, which is what makes the
+        // unparseable-body cases reachable at all: evicting after that early return would never
+        // execute for them, leaving a later failure free to serve content the 200 replaced.
         if (method == HttpMethod.GET && statusCode == 200) {
             if (etag != null && content.isPresent()) {
                 putInCache(cacheKey, new CacheEntry<>(content.get(), etag, System.currentTimeMillis()));
                 LOGGER.debug("Cached GET response with ETag: %s", etag);
-            } else if (etag == null) {
+            } else {
                 evictFromCache(cacheKey);
             }
         }

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
@@ -48,17 +48,36 @@ import static de.cuioss.http.client.HttpLogMessages.WARN;
  * <ul>
  *   <li>GET requests with cached responses send If-None-Match header</li>
  *   <li>Server responds with 304 Not Modified if content unchanged</li>
- *   <li>Adapter returns cached content without re-downloading</li>
  *   <li>Only GET responses are cached (POST/PUT/DELETE never cached)</li>
  *   <li>ETags extracted from all responses for optimistic locking patterns</li>
+ * </ul>
+ *
+ * <h3>What a 304 yields, per method</h3>
+ * <p>
+ * RFC 7232 gives {@code 304 Not Modified} a meaning only for a conditional request on a safe
+ * method, so the adapter resolves it differently depending on the method used:
+ * </p>
+ * <ul>
+ *   <li><strong>GET</strong> — success carrying the cached content, the cached ETag and status
+ *       {@code 304}; the cache entry's timestamp is refreshed.</li>
+ *   <li><strong>HEAD</strong> — success carrying status {@code 304} and the ETag but
+ *       <strong>no body</strong>, because a HEAD response has none. Returning a prior GET's cached
+ *       body here would fabricate content the server never sent.</li>
+ *   <li><strong>POST / PUT / DELETE / PATCH / OPTIONS</strong> — an {@code INVALID_CONTENT}
+ *       failure with status {@code 304}, carrying neither content nor ETag. RFC 7232 requires a
+ *       failed precondition on an unsafe method to be answered with {@code 412 Precondition
+ *       Failed}, so a 304 here is a server protocol violation, never a success.</li>
  * </ul>
  *
  * <p><strong>Do not supply your own {@code If-None-Match} header.</strong> The adapter manages
  * conditional GETs itself: when it holds a cached entry for a GET it sets {@code If-None-Match} to
  * the cached ETag, replacing (not appending to) any caller-supplied value. A caller-driven
- * conditional request is therefore only partially honored, and on a caching-disabled adapter a
- * caller-triggered {@code 304} has no cached entry to return and is reported as an
- * {@code INVALID_CONTENT} failure. Let the adapter drive revalidation instead.</p>
+ * conditional request is therefore only partially honored. Because caller headers are applied to
+ * <em>every</em> method, a caller-supplied {@code If-None-Match} is also the only way a non-GET
+ * request can draw a {@code 304} at all — which then resolves per the table above rather than as a
+ * success. On a caching-disabled adapter a caller-triggered {@code 304} has no cached entry to
+ * return and is reported as an {@code INVALID_CONTENT} failure. Let the adapter drive revalidation
+ * instead.</p>
  *
  * <h2>Example: Basic Usage</h2>
  * <pre>{@code
@@ -779,7 +798,7 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
      * This method encapsulates the complete response handling logic including:
      * </p>
      * <ul>
-     *   <li>304 Not Modified detection and cached content return</li>
+     *   <li>304 Not Modified detection, resolved per method by {@link #handleNotModified}</li>
      *   <li>ETag extraction from response headers</li>
      *   <li>Response body conversion using configured converter</li>
      *   <li>Conversion failure handling for 2xx responses</li>
@@ -801,22 +820,16 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
     ) {
         int statusCode = response.statusCode();
 
-        // Handle 304 Not Modified - return cached content
-        if (statusCode == 304 && cachedEntry != null) {
-            LOGGER.debug("304 Not Modified - returning cached content");
-            // Refresh the entry's timestamp on successful revalidation so that hot entries
-            // (revalidated frequently) are not evicted before cold entries under the timestamp-based
-            // eviction heuristic. Only GET responses are cached, so this only applies to GET.
-            if (method == HttpMethod.GET) {
-                putInCache(cacheKey, new CacheEntry<>(cachedEntry.content(), cachedEntry.etag(), System.currentTimeMillis()));
-            }
-            return HttpResult.<T>success(cachedEntry.content(), cachedEntry.etag(), 304);
-        }
-
-        // Extract ETag from response (all methods, not just GET)
+        // Extract ETag from response (all methods, not just GET). Extracted ahead of the 304 branch
+        // so a HEAD revalidation can prefer the validator the 304 itself returned.
         String etag = response.headers()
                 .firstValue("ETag")
                 .orElse(null);
+
+        // Handle 304 Not Modified - the outcome depends on the request method (RFC 7232)
+        if (statusCode == 304 && cachedEntry != null) {
+            return handleNotModified(method, cachedEntry, cacheKey, etag);
+        }
 
         // Convert response body
         Optional<T> content = responseConverter.convert(response.body());
@@ -862,6 +875,60 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
                 errorCategory,
                 canUseCachedFallback ? cachedEntry.etag() : null, // cached GET ETag when available
                 statusCode // include HTTP status code
+        );
+    }
+
+    /**
+     * Produces the result for a {@code 304 Not Modified} response on a request that holds a cached
+     * entry. RFC 7232 gives 304 a meaning only for a conditional request on a safe method, so the
+     * outcome is gated on the method:
+     *
+     * <ul>
+     *   <li><strong>GET</strong> — the cached body <em>is</em> the response body. The entry's
+     *       timestamp is refreshed so a frequently revalidated entry is not evicted ahead of a
+     *       colder one under the timestamp-based eviction heuristic.</li>
+     *   <li><strong>HEAD</strong> — status and validator only. A HEAD response carries no body, so
+     *       surfacing a prior GET's cached body here would fabricate content the server never sent.
+     *       The cache is populated by GET alone, so no timestamp refresh applies.</li>
+     *   <li><strong>Any other method</strong> — a protocol violation. RFC 7232 requires a failed
+     *       precondition on an unsafe method to be answered with {@code 412 Precondition Failed},
+     *       never 304. Reported as an {@link HttpErrorCategory#INVALID_CONTENT} failure carrying
+     *       neither cached content nor a cached validator, so no prior GET's data can leak out
+     *       through the method-agnostic cache key.</li>
+     * </ul>
+     *
+     * @param method HTTP method the request used
+     * @param cachedEntry cached entry held for this request
+     * @param cacheKey cache key the entry is stored under
+     * @param responseEtag ETag the 304 carried, or null when it carried none
+     * @return the method-appropriate result
+     */
+    private HttpResult<T> handleNotModified(
+            HttpMethod method,
+            CacheEntry<T> cachedEntry,
+            String cacheKey,
+            @Nullable String responseEtag
+    ) {
+        if (method == HttpMethod.GET) {
+            LOGGER.debug("304 Not Modified - returning cached content");
+            putInCache(cacheKey, new CacheEntry<>(cachedEntry.content(), cachedEntry.etag(), System.currentTimeMillis()));
+            return HttpResult.<T>success(cachedEntry.content(), cachedEntry.etag(), 304);
+        }
+
+        if (method == HttpMethod.HEAD) {
+            LOGGER.debug("304 Not Modified for HEAD - returning status and ETag without a body");
+            return HttpResult.<T>success(null, responseEtag != null ? responseEtag : cachedEntry.etag(), 304);
+        }
+
+        LOGGER.debug("304 Not Modified is not a valid response to %s - reporting a protocol violation",
+                method.methodName());
+        return HttpResult.<T>failureWithFallback(
+                "HTTP 304 is not a valid response to a %s request (RFC 7232 requires 412)".formatted(method.methodName()),
+                null,
+                null,
+                HttpErrorCategory.INVALID_CONTENT,
+                null,
+                304
         );
     }
 

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
@@ -843,10 +843,16 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
                 && !isNoBodyStatus(statusCode)
                 && !responseConverter.emptyContentIsValid()) {
             LOGGER.warn(WARN.RESPONSE_CONVERSION_FAILED, statusCode);
-            return HttpResult.<T>failure(
-                    "Failed to convert response body",
+            // Carry the status and the response ETag: both are in hand here, and discarding them
+            // leaves the caller unable to tell "200 but unparseable" from any other invalid-content
+            // case. fallbackContent stays null - a conversion failure implies no cached content.
+            return HttpResult.<T>failureWithFallback(
+                    "Failed to convert response body (HTTP %d)".formatted(statusCode),
                     null,
-                    HttpErrorCategory.INVALID_CONTENT
+                    null,
+                    HttpErrorCategory.INVALID_CONTENT,
+                    etag,
+                    statusCode
             );
         }
 

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
@@ -801,7 +801,8 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
      *   <li>304 Not Modified detection, resolved per method by {@link #handleNotModified}</li>
      *   <li>ETag extraction from response headers</li>
      *   <li>Response body conversion using configured converter</li>
-     *   <li>Conversion failure handling for 2xx responses</li>
+     *   <li>Conversion failure handling for 2xx responses, excluding the no-body statuses
+     *       {@code 204} and {@code 205} (see {@link #isNoBodyStatus})</li>
      *   <li>Successful GET response caching with ETag</li>
      *   <li>Success/failure result creation based on status code</li>
      * </ul>
@@ -834,9 +835,12 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
         // Convert response body
         Optional<T> content = responseConverter.convert(response.body());
 
-        // Handle conversion failure. Converters that intentionally produce no content
-        // (e.g. VoidResponseConverter for status-code-only operations) are exempt.
+        // Handle conversion failure. Two exemptions: converters that intentionally produce no
+        // content (e.g. VoidResponseConverter for status-code-only operations), and statuses RFC
+        // 7231 defines as carrying no body at all, where emptiness is the protocol-mandated
+        // outcome rather than a failed conversion.
         if (content.isEmpty() && HttpStatusFamily.isSuccess(statusCode)
+                && !isNoBodyStatus(statusCode)
                 && !responseConverter.emptyContentIsValid()) {
             LOGGER.warn(WARN.RESPONSE_CONVERSION_FAILED, statusCode);
             return HttpResult.<T>failure(
@@ -876,6 +880,25 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
                 canUseCachedFallback ? cachedEntry.etag() : null, // cached GET ETag when available
                 statusCode // include HTTP status code
         );
+    }
+
+    /**
+     * Reports whether RFC 7231 defines {@code statusCode} as carrying no response body.
+     *
+     * <p>A converter that maps an empty payload to {@link Optional#empty()} would otherwise turn a
+     * perfectly valid {@code 204}/{@code 205} into an {@code INVALID_CONTENT} failure. Emptiness is
+     * the protocol-mandated outcome for these two statuses, so they bypass the conversion-failure
+     * guard regardless of the converter in use.</p>
+     *
+     * <p>Deliberately limited to {@code 204} and {@code 205}. An empty {@code 200} is <em>not</em> a
+     * protocol-defined no-body response; whether it is acceptable stays governed by
+     * {@link HttpResponseConverter#emptyContentIsValid()}.</p>
+     *
+     * @param statusCode the response status code
+     * @return true for {@code 204 No Content} and {@code 205 Reset Content}, false otherwise
+     */
+    private static boolean isNoBodyStatus(int statusCode) {
+        return statusCode == 204 || statusCode == 205;
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
@@ -136,7 +136,7 @@ import static de.cuioss.http.client.HttpLogMessages.WARN;
  *
  * <h2>Thread Safety</h2>
  * <p>
- * Fully thread-safe:
+ * Safe for concurrent use, subject to the one documented benign race below:
  * </p>
  * <ul>
  *   <li>Builder: NOT thread-safe (build once per adapter)</li>
@@ -144,6 +144,21 @@ import static de.cuioss.http.client.HttpLogMessages.WARN;
  *   <li>HttpClient: Created once in constructor, reused for all requests</li>
  *   <li>Cache: ConcurrentHashMap with local reference pattern for 304 handling</li>
  * </ul>
+ *
+ * <p><strong>Benign last-writer-wins race on cache maintenance.</strong> Two cache writes are
+ * check-then-act sequences on the {@code ConcurrentHashMap} rather than atomic compare-and-set
+ * operations: the 304 timestamp refresh (read the entry, then write it back with a new timestamp)
+ * and the eviction of a stale entry after an ETag-less {@code 200} (observe the missing validator,
+ * then remove). Concurrent revalidations of the same key can therefore interleave, and the last
+ * writer wins.</p>
+ *
+ * <p>This is benign, and deliberately not locked. Every writer for a given key stores a
+ * fully-formed immutable {@link CacheEntry}, so no reader can observe a torn or mismatched entry;
+ * concurrent 304 refreshes write the same content and the same ETag, differing only in a timestamp
+ * that feeds the eviction heuristic alone. The observable outcomes are an entry surviving a moment
+ * longer than a competing eviction intended, or an eviction discarding a just-refreshed timestamp
+ * — neither affects correctness, and both resolve on the next request. Adding locking or a
+ * compute-style CAS here would cost contention on the hot path to buy nothing.</p>
  *
  * @param <T> Response body type
  * @since 1.0
@@ -752,6 +767,25 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
     }
 
     /**
+     * Removes the entry stored under {@code key}, if any.
+     *
+     * <p>Guarded by {@code etagCachingEnabled} exactly as {@link #putInCache} is, so a
+     * caching-disabled adapter never touches the map.</p>
+     *
+     * @param key Cache key to drop
+     */
+    private void evictFromCache(String key) {
+        if (!etagCachingEnabled) {
+            return;
+        }
+
+        if (cache.remove(key) != null) {
+            // The key embeds request header values, so it is deliberately not logged.
+            LOGGER.debug("Removed stale cache entry after an ETag-less 200");
+        }
+    }
+
+    /**
      * Evicts oldest 10% of entries when cache size exceeds maxCacheSize.
      *
      * <p>
@@ -856,12 +890,17 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
             );
         }
 
-        // Cache successful GET responses with ETag (only when content exists;
-        // no-content converters have nothing to cache)
-        if (method == HttpMethod.GET && statusCode == 200 && etag != null && content.isPresent()) {
-            CacheEntry<T> newEntry = new CacheEntry<>(content.get(), etag, System.currentTimeMillis());
-            putInCache(cacheKey, newEntry);
-            LOGGER.debug("Cached GET response with ETag: %s", etag);
+        // Cache maintenance for a fresh GET 200. With an ETag and content, store (or refresh) the
+        // entry. Without an ETag the server has returned content it no longer identifies by any
+        // validator, so a previously cached entry is provably stale: drop it rather than leave it
+        // to be served later as fallback content or revalidated with a dead If-None-Match.
+        if (method == HttpMethod.GET && statusCode == 200) {
+            if (etag != null && content.isPresent()) {
+                putInCache(cacheKey, new CacheEntry<>(content.get(), etag, System.currentTimeMillis()));
+                LOGGER.debug("Cached GET response with ETag: %s", etag);
+            } else if (etag == null) {
+                evictFromCache(cacheKey);
+            }
         }
 
         // Return success for 2xx status codes

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
@@ -503,7 +503,8 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
      *   <li>Retrieve cache entry BEFORE building request (local reference held)</li>
      *   <li>Add If-None-Match header if cache entry exists (GET only)</li>
      *   <li>Execute request asynchronously via HttpClient</li>
-     *   <li>Handle 304 using cached entry (structurally guaranteed non-null)</li>
+     *   <li>Route every 304 through {@link #handleNotModified}, which resolves it against the
+     *       cached entry when one is held and reports the RFC 7232 violation when none is</li>
      * </ol>
      *
      * @param method HTTP method (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS)
@@ -871,8 +872,12 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
                 .firstValue("ETag")
                 .orElse(null);
 
-        // Handle 304 Not Modified - the outcome depends on the request method (RFC 7232)
-        if (statusCode == 304 && cachedEntry != null) {
+        // Handle 304 Not Modified - the outcome depends on the request method (RFC 7232). The gate
+        // is the status alone: a cache entry exists only for GET and HEAD (see canReadCache), so
+        // additionally requiring one here would make the unsafe-method branch unreachable and let a
+        // POST/PUT/PATCH/DELETE/OPTIONS 304 fall through to the generic error path below, where the
+        // RFC 7232 violation is never named. handleNotModified resolves the null-entry cases itself.
+        if (statusCode == 304) {
             return handleNotModified(method, cachedEntry, cacheKey, etag);
         }
 
@@ -975,57 +980,79 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
     }
 
     /**
-     * Produces the result for a {@code 304 Not Modified} response on a request that holds a cached
-     * entry. RFC 7232 gives 304 a meaning only for a conditional request on a safe method, so the
-     * outcome is gated on the method:
+     * Produces the result for every {@code 304 Not Modified} response. RFC 7232 gives 304 a meaning
+     * only for a conditional request on a safe method, so the method is examined <em>before</em> the
+     * cache entry:
      *
      * <ul>
+     *   <li><strong>Any method other than GET or HEAD</strong> — a protocol violation, decided first
+     *       and independently of the cache. RFC 7232 requires a failed precondition on an unsafe
+     *       method to be answered with {@code 412 Precondition Failed}, never 304. Reported as an
+     *       {@link HttpErrorCategory#INVALID_CONTENT} failure carrying neither cached content nor a
+     *       cached validator, so no prior GET's data can leak out through the method-agnostic cache
+     *       key. This branch is reachable precisely because it does not require a cache entry:
+     *       {@link #prepareCacheContext} yields a null entry for every unsafe method, so a gate that
+     *       demanded one would be dead code and the violation would never be named.</li>
+     *   <li><strong>GET or HEAD with no cached entry</strong> — an unsolicited 304. The adapter only
+     *       sends {@code If-None-Match} when it holds an entry, so a 304 with nothing to resolve it
+     *       against (a caller-supplied conditional header, or a caching-disabled adapter) is equally
+     *       an {@link HttpErrorCategory#INVALID_CONTENT} failure with no content and no validator.</li>
      *   <li><strong>GET</strong> — the cached body <em>is</em> the response body. The entry's
      *       timestamp is refreshed so a frequently revalidated entry is not evicted ahead of a
      *       colder one under the timestamp-based eviction heuristic.</li>
      *   <li><strong>HEAD</strong> — status and validator only. A HEAD response carries no body, so
      *       surfacing a prior GET's cached body here would fabricate content the server never sent.
      *       The cache is populated by GET alone, so no timestamp refresh applies.</li>
-     *   <li><strong>Any other method</strong> — a protocol violation. RFC 7232 requires a failed
-     *       precondition on an unsafe method to be answered with {@code 412 Precondition Failed},
-     *       never 304. Reported as an {@link HttpErrorCategory#INVALID_CONTENT} failure carrying
-     *       neither cached content nor a cached validator, so no prior GET's data can leak out
-     *       through the method-agnostic cache key.</li>
      * </ul>
      *
      * @param method HTTP method the request used
-     * @param cachedEntry cached entry held for this request
+     * @param cachedEntry cached entry held for this request, or null when none is held
      * @param cacheKey cache key the entry is stored under
      * @param responseEtag ETag the 304 carried, or null when it carried none
      * @return the method-appropriate result
      */
     private HttpResult<T> handleNotModified(
             HttpMethod method,
-            CacheEntry<T> cachedEntry,
+            @Nullable CacheEntry<T> cachedEntry,
             String cacheKey,
             @Nullable String responseEtag
     ) {
+        if (!canReadCache(method)) {
+            LOGGER.debug("304 Not Modified is not a valid response to %s - reporting a protocol violation",
+                    method.methodName());
+            return HttpResult.<T>failureWithFallback(
+                    "HTTP 304 is not a valid response to a %s request (RFC 7232 requires 412)".formatted(method.methodName()),
+                    null,
+                    null,
+                    HttpErrorCategory.INVALID_CONTENT,
+                    null,
+                    304
+            );
+        }
+
+        if (cachedEntry == null) {
+            LOGGER.debug("304 Not Modified for %s with no cached entry - reporting an unsolicited 304",
+                    method.methodName());
+            return HttpResult.<T>failureWithFallback(
+                    "HTTP 304 for a %s request with no cached entry to resolve it against (RFC 7232 permits 304 only in response to a conditional request the adapter issued)"
+                            .formatted(method.methodName()),
+                    null,
+                    null,
+                    HttpErrorCategory.INVALID_CONTENT,
+                    null,
+                    304
+            );
+        }
+
         if (method == HttpMethod.GET) {
             LOGGER.debug("304 Not Modified - returning cached content");
             putInCache(cacheKey, new CacheEntry<>(cachedEntry.content(), cachedEntry.etag(), System.currentTimeMillis()));
             return HttpResult.<T>success(cachedEntry.content(), cachedEntry.etag(), 304);
         }
 
-        if (method == HttpMethod.HEAD) {
-            LOGGER.debug("304 Not Modified for HEAD - returning status and ETag without a body");
-            return HttpResult.<T>success(null, responseEtag != null ? responseEtag : cachedEntry.etag(), 304);
-        }
-
-        LOGGER.debug("304 Not Modified is not a valid response to %s - reporting a protocol violation",
-                method.methodName());
-        return HttpResult.<T>failureWithFallback(
-                "HTTP 304 is not a valid response to a %s request (RFC 7232 requires 412)".formatted(method.methodName()),
-                null,
-                null,
-                HttpErrorCategory.INVALID_CONTENT,
-                null,
-                304
-        );
+        // Only HEAD remains: the unsafe methods returned above and GET was handled just now.
+        LOGGER.debug("304 Not Modified for HEAD - returning status and ETag without a body");
+        return HttpResult.<T>success(null, responseEtag != null ? responseEtag : cachedEntry.etag(), 304);
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
@@ -793,6 +793,16 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
      * ConcurrentModificationException. In-flight requests holding local references
      * are unaffected by eviction.
      * </p>
+     *
+     * <h3>Cost</h3>
+     * <p>
+     * Each over-limit put sorts the whole cache by timestamp, so the eviction pass is
+     * {@code O(n log n)} in the cache size. That cost is amortized across the batch: one pass frees
+     * 10% of {@code maxCacheSize} entries, so it recurs only once per that many over-limit puts. At
+     * the default size of 1000 the pass is measured in microseconds. A very large
+     * {@code maxCacheSize} trades a proportionally more expensive eviction pass for a higher hit
+     * rate — see {@link Builder#maxCacheSize(int)}.
+     * </p>
      */
     private void checkAndEvict() {
         if (cache.size() <= maxCacheSize) {
@@ -928,6 +938,24 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
     }
 
     /**
+     * Reports whether {@code method} can resolve a cache entry.
+     *
+     * <p>GET populates and reads the cache; HEAD reads it so a conditional HEAD answered with
+     * {@code 304} can be resolved against the stored validator (see {@link #handleNotModified}).
+     * No other method touches it.</p>
+     *
+     * <p><strong>Do not narrow this to GET.</strong> Dropping HEAD would leave a conditional HEAD
+     * with no cached entry, silently turning its {@code 304} into a plain failure and deleting the
+     * documented HEAD behaviour.</p>
+     *
+     * @param method the request method
+     * @return true for GET and HEAD, false otherwise
+     */
+    private static boolean canReadCache(HttpMethod method) {
+        return method == HttpMethod.GET || method == HttpMethod.HEAD;
+    }
+
+    /**
      * Reports whether RFC 7231 defines {@code statusCode} as carrying no response body.
      *
      * <p>A converter that maps an empty payload to {@link Optional#empty()} would otherwise turn a
@@ -1019,13 +1047,18 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
             );
         }
 
-        // Generate cache key (only meaningful for GET with caching enabled)
+        // Only GET and HEAD can interact with the cache: GET populates and reads it, HEAD reads it
+        // to resolve a 304 revalidation. For any other method - and for an adapter built with
+        // etagCachingEnabled(false), which includes every statusCodeOnly adapter - the key would be
+        // built, sorted and escaped on every request and then never read, so skip the work.
+        if (!etagCachingEnabled || !canReadCache(method)) {
+            return new CacheContext<>("", null);
+        }
+
         String cacheKey = generateCacheKey(httpHandler.getUri(), headers, cacheKeyHeaderFilter);
 
         // Retrieve cache entry BEFORE building request (hold local reference for 304 handling)
-        CacheEntry<T> cachedEntry = etagCachingEnabled ? cache.get(cacheKey) : null;
-
-        return new CacheContext<>(cacheKey, cachedEntry);
+        return new CacheContext<>(cacheKey, cache.get(cacheKey));
     }
 
     /**
@@ -1133,6 +1166,14 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
          *   <li>Small (100-500): Mobile apps, embedded systems, memory-constrained environments</li>
          *   <li>Large (5000+): High-traffic servers with many unique endpoints</li>
          * </ul>
+         *
+         * <h3>Cost Trade-off</h3>
+         * <p>
+         * Eviction sorts the whole cache by timestamp, so each over-limit put that triggers a pass
+         * costs {@code O(n log n)} in this value — amortized across the 10% batch it frees. Raising
+         * {@code maxCacheSize} therefore buys hit rate at the price of a proportionally more
+         * expensive (though proportionally rarer) eviction pass.
+         * </p>
          *
          * @param maxCacheSize Maximum number of cache entries (must be positive)
          * @return this builder

--- a/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapter.java
@@ -846,9 +846,11 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
      *   <li>304 Not Modified detection, resolved per method by {@link #handleNotModified}</li>
      *   <li>ETag extraction from response headers</li>
      *   <li>Response body conversion using configured converter</li>
+     *   <li>GET {@code 200} cache maintenance — store on an ETag, evict without one. Runs ahead of
+     *       the conversion-failure return so an ETag-less {@code 200} the converter rejects still
+     *       drops the entry it superseded</li>
      *   <li>Conversion failure handling for 2xx responses, excluding the no-body statuses
      *       {@code 204} and {@code 205} (see {@link #isNoBodyStatus})</li>
-     *   <li>Successful GET response caching with ETag</li>
      *   <li>Success/failure result creation based on status code</li>
      * </ul>
      *
@@ -884,6 +886,23 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
         // Convert response body
         Optional<T> content = responseConverter.convert(response.body());
 
+        // Cache maintenance for a fresh GET 200. With an ETag and content, store (or refresh) the
+        // entry. Without an ETag the server has returned content it no longer identifies by any
+        // validator, so a previously cached entry is provably stale: drop it rather than leave it
+        // to be served later as fallback content or revalidated with a dead If-None-Match.
+        //
+        // This runs BEFORE the conversion-failure return below. An ETag-less 200 whose body the
+        // converter rejects still supersedes the cached entry, and evicting after the early return
+        // would never reach it - leaving a later failure free to serve content the 200 replaced.
+        if (method == HttpMethod.GET && statusCode == 200) {
+            if (etag != null && content.isPresent()) {
+                putInCache(cacheKey, new CacheEntry<>(content.get(), etag, System.currentTimeMillis()));
+                LOGGER.debug("Cached GET response with ETag: %s", etag);
+            } else if (etag == null) {
+                evictFromCache(cacheKey);
+            }
+        }
+
         // Handle conversion failure. Two exemptions: converters that intentionally produce no
         // content (e.g. VoidResponseConverter for status-code-only operations), and statuses RFC
         // 7231 defines as carrying no body at all, where emptiness is the protocol-mandated
@@ -903,19 +922,6 @@ public class ETagAwareHttpAdapter<T> implements HttpAdapter<T> {
                     etag,
                     statusCode
             );
-        }
-
-        // Cache maintenance for a fresh GET 200. With an ETag and content, store (or refresh) the
-        // entry. Without an ETag the server has returned content it no longer identifies by any
-        // validator, so a previously cached entry is provably stale: drop it rather than leave it
-        // to be served later as fallback content or revalidated with a dead If-None-Match.
-        if (method == HttpMethod.GET && statusCode == 200) {
-            if (etag != null && content.isPresent()) {
-                putInCache(cacheKey, new CacheEntry<>(content.get(), etag, System.currentTimeMillis()));
-                LOGGER.debug("Cached GET response with ETag: %s", etag);
-            } else if (etag == null) {
-                evictFromCache(cacheKey);
-            }
         }
 
         // Return success for 2xx status codes

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
@@ -235,6 +235,25 @@ class ETagAwareHttpAdapterIntegrationTest {
                 () -> assertTrue(result.getContent().isEmpty(), "No content should be fabricated"));
     }
 
+    @Test
+    @DisplayName("A conversion failure should preserve the HTTP status and the response ETag")
+    @ModuleDispatcher
+    void conversionFailureShouldPreserveStatusAndETag(URIBuilder uriBuilder) {
+        dispatcher.withSuccessAndETag(TypedResponseConverter.UNPARSEABLE_BODY, "\"etag-unparseable\"");
+        HttpAdapter<String> adapter = typedAdapter(uriBuilder);
+
+        HttpResult<String> result = adapter.getBlocking();
+
+        assertAll("200 whose body the converter rejects",
+                () -> assertFalse(result.isSuccess(), "An unparseable body is a conversion failure"),
+                () -> assertEquals(HttpErrorCategory.INVALID_CONTENT, result.getErrorCategory().orElse(null)),
+                () -> assertEquals(Optional.of(200), result.getHttpStatus(),
+                        "The status was in hand and must not be discarded"),
+                () -> assertEquals("\"etag-unparseable\"", result.getETag().orElse(null),
+                        "The response ETag was in hand and must not be discarded"),
+                () -> assertTrue(result.getContent().isEmpty(), "No fallback content should be fabricated"));
+    }
+
     /**
      * Builds an adapter over {@link TypedResponseConverter} — the converter shape that can actually
      * reach the conversion-failure branch.
@@ -565,6 +584,9 @@ class ETagAwareHttpAdapterIntegrationTest {
      * empty-content defects went unnoticed. Cases that need that branch use this converter instead.
      */
     private static class TypedResponseConverter implements HttpResponseConverter<String> {
+
+        /** A non-empty body this converter cannot parse, used to drive the conversion-failure branch. */
+        static final String UNPARSEABLE_BODY = "not-a-json-object";
 
         @Override
         public Optional<String> convert(@Nullable Object rawContent) {

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
@@ -328,6 +328,40 @@ class ETagAwareHttpAdapterIntegrationTest {
     }
 
     /**
+     * The converter-blind half of the same invalidation invariant. {@link StringResponseConverter}
+     * maps an empty body to {@code Optional.of("")}, so the sibling case above never reaches the
+     * conversion-failure return and cannot observe whether eviction happens before or after it. A
+     * typed converter that rejects the body does return early, so this sequence pins the ordering:
+     * an ETag-less 200 must drop the superseded entry even when its body is unparseable, or the
+     * following 503 serves content the 200 already replaced.
+     */
+    @Test
+    @DisplayName("An ETag-less 200 should invalidate the cached entry even when conversion fails")
+    @ModuleDispatcher
+    void etagLess200WithFailedConversionShouldInvalidateCachedEntry(URIBuilder uriBuilder) {
+        HttpAdapter<String> adapter = typedAdapter(uriBuilder);
+
+        dispatcher.withSuccessAndETag(SEED_CONTENT, SEED_ETAG);
+        assertTrue(adapter.getBlocking().isSuccess(), "Seeding GET should succeed and populate the cache");
+
+        dispatcher.withSuccessAndETag(TypedResponseConverter.UNPARSEABLE_BODY, null);
+        HttpResult<String> unparseable = adapter.getBlocking();
+        assertFalse(unparseable.isSuccess(), "An unparseable body is a conversion failure");
+
+        dispatcher.withServerError();
+        HttpResult<String> failure = adapter.getBlocking();
+
+        assertAll("Failure after an ETag-less, unparseable 200 evicted the entry",
+                () -> assertFalse(failure.isSuccess(), "503 should surface as a failure"),
+                () -> assertTrue(failure.getContent().isEmpty(),
+                        "The evicted entry must not be served as fallback content"),
+                () -> assertTrue(failure.getETag().isEmpty(),
+                        "The evicted entry's validator must not be served either"),
+                () -> assertTrue(dispatcher.getLastIfNoneMatch().isEmpty(),
+                        "No stale If-None-Match should be sent once the entry is gone"));
+    }
+
+    /**
      * Builds an adapter over {@link TypedResponseConverter} — the converter shape that can actually
      * reach the conversion-failure branch.
      */

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
@@ -362,6 +362,51 @@ class ETagAwareHttpAdapterIntegrationTest {
     }
 
     /**
+     * The validator-bearing half of the invalidation invariant, and the case an eviction gated on a
+     * missing ETag misses entirely. A {@code 200} carrying an ETag whose body the converter rejects
+     * yields no content, so no replacement entry can be built from it — yet it is still a fresh
+     * representation that supersedes the cached one. What makes the old entry stale is that the
+     * fresh {@code 200} could not replace it, not the reason it could not, so this sequence must
+     * evict exactly as the ETag-less sibling above does.
+     * <p>
+     * Three independent observables pin it, and all three are wrong when the eviction is skipped:
+     * the later failure carries neither the superseded body nor the superseded validator, and the
+     * request that draws it sends no stale {@code If-None-Match}. The intermediate assertion that
+     * the conversion failure reports the <em>fresh</em> ETag rather than the seeded one keeps the
+     * scenario honest — it confirms the second response really did carry its own validator, so the
+     * case exercises the ETag-bearing branch and not the ETag-less one.
+     */
+    @Test
+    @DisplayName("An ETag-bearing 200 whose body is unparseable should invalidate the cached entry")
+    @ModuleDispatcher
+    void unparseable200WithETagShouldInvalidateCachedEntry(URIBuilder uriBuilder) {
+        HttpAdapter<String> adapter = typedAdapter(uriBuilder);
+
+        dispatcher.withSuccessAndETag(SEED_CONTENT, SEED_ETAG);
+        assertTrue(adapter.getBlocking().isSuccess(), "Seeding GET should succeed and populate the cache");
+
+        dispatcher.withSuccessAndETag(TypedResponseConverter.UNPARSEABLE_BODY, "\"etag-fresh\"");
+        HttpResult<String> unparseable = adapter.getBlocking();
+
+        assertAll("200 carrying an ETag whose body the converter rejects",
+                () -> assertFalse(unparseable.isSuccess(), "An unparseable body is a conversion failure"),
+                () -> assertEquals("\"etag-fresh\"", unparseable.getETag().orElse(null),
+                        "The response's own validator should be reported - proving this is the ETag-bearing branch"));
+
+        dispatcher.withServerError();
+        HttpResult<String> failure = adapter.getBlocking();
+
+        assertAll("Failure after an ETag-bearing, unparseable 200 evicted the entry",
+                () -> assertFalse(failure.isSuccess(), "503 should surface as a failure"),
+                () -> assertTrue(failure.getContent().isEmpty(),
+                        "The superseded entry must not be served as fallback content"),
+                () -> assertTrue(failure.getETag().isEmpty(),
+                        "The superseded entry's validator must not be served either"),
+                () -> assertTrue(dispatcher.getLastIfNoneMatch().isEmpty(),
+                        "No stale If-None-Match should be sent once the entry is gone"));
+    }
+
+    /**
      * Builds an adapter over {@link TypedResponseConverter} — the converter shape that can actually
      * reach the conversion-failure branch.
      */

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
@@ -16,6 +16,7 @@
 package de.cuioss.http.client.adapter;
 
 import de.cuioss.http.client.ContentType;
+import de.cuioss.http.client.HttpMethod;
 import de.cuioss.http.client.converter.HttpRequestConverter;
 import de.cuioss.http.client.converter.HttpResponseConverter;
 import de.cuioss.http.client.handler.HttpHandler;
@@ -29,6 +30,8 @@ import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -55,6 +58,10 @@ import static org.junit.jupiter.api.Assertions.*;
 @EnableMockWebServer(useHttps = false)
 @DisplayName("ETagAwareHttpAdapter Integration Tests")
 class ETagAwareHttpAdapterIntegrationTest {
+
+    private static final String SEED_CONTENT = "{\"id\":1,\"name\":\"seeded\"}";
+    private static final String SEED_ETAG = "\"etag-seed\"";
+    private static final Map<String, String> CONDITIONAL_HEADERS = Map.of("If-None-Match", SEED_ETAG);
 
     private final TestApiDispatcher dispatcher = new TestApiDispatcher();
 
@@ -100,6 +107,81 @@ class ETagAwareHttpAdapterIntegrationTest {
         // Verify If-None-Match header was sent on second request
         assertTrue(dispatcher.getLastIfNoneMatch().isPresent(), "If-None-Match header should be sent");
         assertEquals("\"etag-123\"", dispatcher.getLastIfNoneMatch().orElse(null));
+    }
+
+    @Test
+    @DisplayName("A 304 to HEAD should report status and ETag with no body")
+    @ModuleDispatcher
+    void head304ShouldReportStatusAndETagWithoutBody(URIBuilder uriBuilder) {
+        dispatcher.withSeedThen304(SEED_CONTENT, SEED_ETAG);
+        HttpAdapter<String> adapter = matrixAdapter(uriBuilder);
+        assertTrue(adapter.getBlocking().isSuccess(), "Seeding GET should succeed and populate the cache");
+
+        HttpResult<String> result = adapter.head(CONDITIONAL_HEADERS).join();
+
+        assertAll("HEAD revalidated with 304",
+                () -> assertTrue(result.isSuccess(), "A 304 to HEAD is a valid revalidation"),
+                () -> assertEquals(Optional.of(304), result.getHttpStatus(), "Status should be reported as 304"),
+                () -> assertEquals(SEED_ETAG, result.getETag().orElse(null), "The validator should be reported"),
+                () -> assertTrue(result.getContent().isEmpty(), "A HEAD response carries no body"));
+    }
+
+    /**
+     * A 304 answering an unsafe method is a server protocol violation (RFC 7232 mandates 412), so it
+     * must surface as a failure that leaks neither the cached body nor the cached validator.
+     * <p>
+     * PATCH and OPTIONS belong to this equivalence class and are gated identically in production,
+     * but cannot be exercised here: the MockWebServer fixture cannot serve them yet.
+     */
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(value = HttpMethod.class, names = {"POST", "PUT", "DELETE"})
+    @DisplayName("A 304 to an unsafe method should fail without leaking cached content or ETag")
+    @ModuleDispatcher
+    void unsafeMethod304ShouldFailWithoutLeakingCachedData(HttpMethod method, URIBuilder uriBuilder) {
+        dispatcher.withSeedThen304(SEED_CONTENT, SEED_ETAG);
+        HttpAdapter<String> adapter = matrixAdapter(uriBuilder);
+        assertTrue(adapter.getBlocking().isSuccess(), "Seeding GET should succeed and populate the cache");
+
+        HttpResult<String> result = revalidateWith(adapter, method);
+
+        assertAll("%s revalidated with 304".formatted(method.methodName()),
+                () -> assertFalse(result.isSuccess(), "A 304 to an unsafe method is a protocol violation"),
+                () -> assertEquals(HttpErrorCategory.INVALID_CONTENT, result.getErrorCategory().orElse(null),
+                        "The violation should be categorised as invalid content"),
+                () -> assertEquals(Optional.of(304), result.getHttpStatus(), "The observed status should be preserved"),
+                () -> assertTrue(result.getContent().isEmpty(), "The cached GET body must not leak"),
+                () -> assertTrue(result.getETag().isEmpty(), "The cached GET validator must not leak"));
+    }
+
+    /**
+     * Builds the adapter used by the 304 matrix. The cache key is URI-only so that the
+     * caller-supplied {@code If-None-Match} on the revalidating request resolves to the very entry
+     * the seeding GET stored — with the default {@code ALL} filter the extra header would produce a
+     * different key and the 304 branch would never be reached.
+     */
+    private HttpAdapter<String> matrixAdapter(URIBuilder uriBuilder) {
+        String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
+
+        return ETagAwareHttpAdapter.<String>builder()
+                .httpHandler(handler)
+                .responseConverter(new StringResponseConverter())
+                .cacheKeyHeaderFilter(CacheKeyHeaderFilter.NONE)
+                .build();
+    }
+
+    /**
+     * Issues a body-less request under {@code method} carrying a caller-supplied
+     * {@code If-None-Match} — the only way a non-GET request can draw a 304 from a conformant server.
+     */
+    private HttpResult<String> revalidateWith(HttpAdapter<String> adapter, HttpMethod method) {
+        return switch (method) {
+            case POST -> adapter.post((String) null, CONDITIONAL_HEADERS).join();
+            case PUT -> adapter.put((String) null, CONDITIONAL_HEADERS).join();
+            case DELETE -> adapter.delete(CONDITIONAL_HEADERS).join();
+            default -> throw new IllegalArgumentException(
+                    "The 304 matrix does not drive " + method.methodName());
+        };
     }
 
     /**

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
@@ -130,6 +130,13 @@ class ETagAwareHttpAdapterIntegrationTest {
      * A 304 answering an unsafe method is a server protocol violation (RFC 7232 mandates 412), so it
      * must surface as a failure that leaks neither the cached body nor the cached validator.
      * <p>
+     * The message assertion is what makes this test verify the unsafe-method gate rather than a
+     * coincidence. An unsafe method never holds a cache entry, so a 304 that is not resolved by the
+     * dedicated gate falls through to the generic error path — which yields {@code INVALID_CONTENT},
+     * status 304 and no fallback content all by itself, satisfying every other assertion here. Only
+     * the RFC-specific message distinguishes the two paths, so this case fails if the gate is
+     * bypassed.
+     * <p>
      * PATCH and OPTIONS belong to this equivalence class and are gated identically in production,
      * but cannot be exercised here: the MockWebServer fixture cannot serve them yet.
      */
@@ -149,8 +156,40 @@ class ETagAwareHttpAdapterIntegrationTest {
                 () -> assertEquals(HttpErrorCategory.INVALID_CONTENT, result.getErrorCategory().orElse(null),
                         "The violation should be categorised as invalid content"),
                 () -> assertEquals(Optional.of(304), result.getHttpStatus(), "The observed status should be preserved"),
+                () -> assertEquals(
+                        "HTTP 304 is not a valid response to a %s request (RFC 7232 requires 412)".formatted(method.methodName()),
+                        result.getErrorMessage().orElse(null),
+                        "The failure must name the RFC 7232 violation - the generic error path would report 'HTTP 304: %s' instead"
+                                .formatted(method.methodName())),
                 () -> assertTrue(result.getContent().isEmpty(), "The cached GET body must not leak"),
                 () -> assertTrue(result.getETag().isEmpty(), "The cached GET validator must not leak"));
+    }
+
+    /**
+     * A 304 on a safe method with no cached entry is equally unresolvable: the adapter only issues a
+     * conditional request when it holds a validator, so an unsolicited 304 has nothing to be resolved
+     * against. It must fail as {@code INVALID_CONTENT} rather than surface as an empty success.
+     */
+    @Test
+    @DisplayName("A 304 with no cached entry should fail rather than yield an empty success")
+    @ModuleDispatcher
+    void unsolicited304WithoutCachedEntryShouldFail(URIBuilder uriBuilder) {
+        dispatcher.with304();
+        HttpAdapter<String> adapter = matrixAdapter(uriBuilder);
+
+        HttpResult<String> result = adapter.getBlocking();
+
+        assertAll("GET answered with an unsolicited 304",
+                () -> assertFalse(result.isSuccess(), "A 304 with nothing to resolve it against is not a success"),
+                () -> assertEquals(HttpErrorCategory.INVALID_CONTENT, result.getErrorCategory().orElse(null),
+                        "The unresolvable 304 should be categorised as invalid content"),
+                () -> assertEquals(Optional.of(304), result.getHttpStatus(), "The observed status should be preserved"),
+                () -> assertEquals(
+                        "HTTP 304 for a GET request with no cached entry to resolve it against (RFC 7232 permits 304 only in response to a conditional request the adapter issued)",
+                        result.getErrorMessage().orElse(null),
+                        "The failure must name why the 304 could not be resolved"),
+                () -> assertTrue(result.getContent().isEmpty(), "No content should be fabricated"),
+                () -> assertTrue(result.getETag().isEmpty(), "No validator should be fabricated"));
     }
 
     /**

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
@@ -255,6 +255,40 @@ class ETagAwareHttpAdapterIntegrationTest {
     }
 
     /**
+     * An ETag-less 200 means the server returned content it no longer identifies by any validator,
+     * so the previously cached entry is provably stale and must go. Two independent observables pin
+     * the same invariant, so the case cannot pass by accident: the later failure carries no
+     * fallback content, and the following request sends no stale {@code If-None-Match}.
+     */
+    @Test
+    @DisplayName("An ETag-less 200 should invalidate the cached entry")
+    @ModuleDispatcher
+    void etagLess200ShouldInvalidateCachedEntry(URIBuilder uriBuilder) {
+        String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
+        HttpAdapter<String> adapter = ETagAwareHttpAdapter.<String>builder()
+                .httpHandler(handler)
+                .responseConverter(new StringResponseConverter())
+                .build();
+
+        dispatcher.withSuccessAndETag(SEED_CONTENT, SEED_ETAG);
+        assertTrue(adapter.getBlocking().isSuccess(), "Seeding GET should succeed and populate the cache");
+
+        dispatcher.withSuccessAndETag("{\"id\":1,\"name\":\"unvalidated\"}", null);
+        assertTrue(adapter.getBlocking().isSuccess(), "The ETag-less GET should still succeed");
+
+        dispatcher.withServerError();
+        HttpResult<String> failure = adapter.getBlocking();
+
+        assertAll("Failure after an ETag-less 200 evicted the entry",
+                () -> assertFalse(failure.isSuccess(), "503 should surface as a failure"),
+                () -> assertTrue(failure.getContent().isEmpty(),
+                        "The evicted entry must not be served as fallback content"),
+                () -> assertTrue(dispatcher.getLastIfNoneMatch().isEmpty(),
+                        "No stale If-None-Match should be sent once the entry is gone"));
+    }
+
+    /**
      * Builds an adapter over {@link TypedResponseConverter} — the converter shape that can actually
      * reach the conversion-failure branch.
      */

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterIntegrationTest.java
@@ -184,6 +184,71 @@ class ETagAwareHttpAdapterIntegrationTest {
         };
     }
 
+    @Test
+    @DisplayName("A 204 should succeed even when the converter yields no content")
+    @ModuleDispatcher
+    void noContent204WithTypedConverterShouldSucceed(URIBuilder uriBuilder) {
+        dispatcher.withNoContent();
+        HttpAdapter<String> adapter = typedAdapter(uriBuilder);
+
+        HttpResult<String> result = adapter.deleteBlocking();
+
+        assertAll("DELETE answered with 204",
+                () -> assertTrue(result.isSuccess(), "204 carries no body by definition, so emptiness is not a conversion failure"),
+                () -> assertEquals(Optional.of(204), result.getHttpStatus()),
+                () -> assertTrue(result.getErrorCategory().isEmpty(), "Success must not carry an error category"));
+    }
+
+    @Test
+    @DisplayName("A 205 should succeed even when the converter yields no content")
+    @ModuleDispatcher
+    void resetContent205WithTypedConverterShouldSucceed(URIBuilder uriBuilder) {
+        dispatcher.withNoContentAndStatus(205);
+        HttpAdapter<String> adapter = typedAdapter(uriBuilder);
+
+        HttpResult<String> result = adapter.put((String) null).join();
+
+        assertAll("PUT answered with 205",
+                () -> assertTrue(result.isSuccess(), "205 carries no body by definition, so emptiness is not a conversion failure"),
+                () -> assertEquals(Optional.of(205), result.getHttpStatus()),
+                () -> assertTrue(result.getErrorCategory().isEmpty(), "Success must not carry an error category"));
+    }
+
+    /**
+     * The non-widening control for the no-body exemption: an empty {@code 200} is not a
+     * protocol-defined no-body response, so it must keep failing unless the converter opts in via
+     * {@code emptyContentIsValid()}. Without this case the exemption could silently widen to the
+     * whole 2xx family and swallow genuine conversion failures.
+     */
+    @Test
+    @DisplayName("An empty 200 should still fail as INVALID_CONTENT")
+    @ModuleDispatcher
+    void empty200WithTypedConverterShouldStillFail(URIBuilder uriBuilder) {
+        dispatcher.withSuccessAndETag("", "\"etag-empty-200\"");
+        HttpAdapter<String> adapter = typedAdapter(uriBuilder);
+
+        HttpResult<String> result = adapter.getBlocking();
+
+        assertAll("GET answered with an empty 200",
+                () -> assertFalse(result.isSuccess(), "200 is not a no-body status - the exemption must not widen to it"),
+                () -> assertEquals(HttpErrorCategory.INVALID_CONTENT, result.getErrorCategory().orElse(null)),
+                () -> assertTrue(result.getContent().isEmpty(), "No content should be fabricated"));
+    }
+
+    /**
+     * Builds an adapter over {@link TypedResponseConverter} — the converter shape that can actually
+     * reach the conversion-failure branch.
+     */
+    private HttpAdapter<String> typedAdapter(URIBuilder uriBuilder) {
+        String serverUrl = uriBuilder.addPathSegments("api", "data").build().toString();
+        HttpHandler handler = HttpHandler.builder().url(serverUrl).allowInsecureHttp(true).build();
+
+        return ETagAwareHttpAdapter.<String>builder()
+                .httpHandler(handler)
+                .responseConverter(new TypedResponseConverter())
+                .build();
+    }
+
     /**
      * Test POST request: body sent with Content-Type, response converted, ETag extracted but not cached
      */
@@ -478,6 +543,36 @@ class ETagAwareHttpAdapterIntegrationTest {
         @Override
         public Optional<String> convert(@Nullable Object rawContent) {
             return rawContent == null ? Optional.empty() : Optional.of(rawContent.toString());
+        }
+
+        @Override
+        public HttpResponse.BodyHandler<?> getBodyHandler() {
+            return HttpResponse.BodyHandlers.ofString();
+        }
+
+        @Override
+        public ContentType contentType() {
+            return ContentType.APPLICATION_JSON;
+        }
+    }
+
+    /**
+     * A stand-in for a real typed (JSON/XML) converter: it yields a value only for a payload it can
+     * parse, and {@link Optional#empty()} for anything else — including an empty body.
+     * <p>
+     * {@link StringResponseConverter} maps an empty body to {@code Optional.of("")} and therefore
+     * can never reach the adapter's conversion-failure branch, which is precisely why the
+     * empty-content defects went unnoticed. Cases that need that branch use this converter instead.
+     */
+    private static class TypedResponseConverter implements HttpResponseConverter<String> {
+
+        @Override
+        public Optional<String> convert(@Nullable Object rawContent) {
+            if (rawContent == null) {
+                return Optional.empty();
+            }
+            String raw = rawContent.toString();
+            return raw.startsWith("{") ? Optional.of(raw) : Optional.empty();
         }
 
         @Override

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/ETagAwareHttpAdapterTest.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -611,6 +612,101 @@ class ETagAwareHttpAdapterTest {
         assertInstanceOf(CompletableFuture.class, adapter.delete(), "DELETE should return CompletableFuture");
         assertInstanceOf(CompletableFuture.class, adapter.head(), "HEAD should return CompletableFuture");
         assertInstanceOf(CompletableFuture.class, adapter.options(), "OPTIONS should return CompletableFuture");
+    }
+
+    // === Cache Key Allocation Skip Tests ===
+
+    /**
+     * Positive control for the allocation skip: GET reads and populates the cache, so it must build
+     * a key. Without this the negative cases below would also pass against an adapter that never
+     * generated a key at all.
+     */
+    @Test
+    void getShouldGenerateCacheKey() {
+        var filter = new CountingCacheKeyHeaderFilter();
+        var adapter = cachingAdapterWith(filter);
+
+        adapter.get(Map.of("Accept", "application/json"));
+
+        assertTrue(filter.consultations() > 0, "GET reads the cache and must build a key");
+    }
+
+    /**
+     * HEAD reads the cache to resolve a conditional 304 against the stored validator, so it must
+     * build a key too. This is the guard against narrowing the lookup to GET alone, which would
+     * silently delete the documented HEAD 304 behaviour.
+     */
+    @Test
+    void headShouldGenerateCacheKey() {
+        var filter = new CountingCacheKeyHeaderFilter();
+        var adapter = cachingAdapterWith(filter);
+
+        adapter.head(Map.of("Accept", "application/json"));
+
+        assertTrue(filter.consultations() > 0, "HEAD reads the cache to resolve a 304 and must build a key");
+    }
+
+    @Test
+    void nonCacheableMethodsShouldNotGenerateCacheKey() {
+        var headers = Map.of("Accept", "application/json");
+        var postFilter = new CountingCacheKeyHeaderFilter();
+        var putFilter = new CountingCacheKeyHeaderFilter();
+        var patchFilter = new CountingCacheKeyHeaderFilter();
+        var deleteFilter = new CountingCacheKeyHeaderFilter();
+
+        cachingAdapterWith(postFilter).post((String) null, headers);
+        cachingAdapterWith(putFilter).put((String) null, headers);
+        cachingAdapterWith(patchFilter).patch((String) null, headers);
+        cachingAdapterWith(deleteFilter).delete(headers);
+
+        assertAll("Methods that never touch the cache should not build a key",
+                () -> assertEquals(0, postFilter.consultations(), "POST should not build a cache key"),
+                () -> assertEquals(0, putFilter.consultations(), "PUT should not build a cache key"),
+                () -> assertEquals(0, patchFilter.consultations(), "PATCH should not build a cache key"),
+                () -> assertEquals(0, deleteFilter.consultations(), "DELETE should not build a cache key"));
+    }
+
+    @Test
+    void cachingDisabledAdapterShouldNotGenerateCacheKey() {
+        var filter = new CountingCacheKeyHeaderFilter();
+        var adapter = ETagAwareHttpAdapter.<String>builder()
+                .httpHandler(handler)
+                .responseConverter(responseConverter)
+                .cacheKeyHeaderFilter(filter)
+                .etagCachingEnabled(false)
+                .build();
+
+        adapter.get(Map.of("Accept", "application/json"));
+
+        assertEquals(0, filter.consultations(),
+                "A caching-disabled adapter never reads the key, so it should not build one");
+    }
+
+    private ETagAwareHttpAdapter<String> cachingAdapterWith(CacheKeyHeaderFilter filter) {
+        return ETagAwareHttpAdapter.<String>builder()
+                .httpHandler(handler)
+                .responseConverter(responseConverter)
+                .cacheKeyHeaderFilter(filter)
+                .build();
+    }
+
+    /**
+     * Records how often the filter is consulted. Key generation is the only caller, so a
+     * consultation count of zero is the observable for "no cache key was built".
+     */
+    private static final class CountingCacheKeyHeaderFilter implements CacheKeyHeaderFilter {
+
+        private final AtomicInteger consultations = new AtomicInteger();
+
+        @Override
+        public boolean includeInCacheKey(String headerName) {
+            consultations.incrementAndGet();
+            return true;
+        }
+
+        int consultations() {
+            return consultations.get();
+        }
     }
 
     // === Cache Key Injection Prevention Tests ===

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/TestApiDispatcher.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/TestApiDispatcher.java
@@ -29,7 +29,8 @@ import java.util.Set;
 
 /**
  * Test dispatcher for HTTP adapter integration tests.
- * Supports all HTTP methods (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS).
+ * Registers GET, POST, PUT, DELETE and HEAD — the methods
+ * {@link de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper} exposes.
  * <p>
  * Features:
  * <ul>
@@ -37,6 +38,7 @@ import java.util.Set;
  *   <li>ETag support for caching scenarios</li>
  *   <li>Request tracking (body, headers, call count)</li>
  *   <li>304 Not Modified simulation</li>
+ *   <li>Seed-then-304 mode: {@code 200 + ETag} on the first call, {@code 304} thereafter</li>
  * </ul>
  *
  * @author Oliver Wolff
@@ -99,6 +101,18 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
     @Getter
     @Setter
     private String errorSuccessEtag = null;
+
+    @Getter
+    @Setter
+    private boolean seedThen304Mode = false;
+
+    @Getter
+    @Setter
+    private String seedContent = "";
+
+    @Getter
+    @Setter
+    private String seedEtag = null;
 
     @Override
     public Optional<MockResponse> handleGet(@NonNull RecordedRequest request) {
@@ -175,6 +189,19 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
             }
         }
 
+        // Special mode: first call seeds the cache with 200 + ETag, subsequent calls revalidate with 304
+        if (seedThen304Mode) {
+            Headers.Builder headersBuilder = new Headers.Builder()
+                    .add("Content-Type", "application/json");
+            if (seedEtag != null) {
+                headersBuilder.add("ETag", seedEtag);
+            }
+            if (callCounter == 1) {
+                return Optional.of(new MockResponse(200, headersBuilder.build(), seedContent));
+            }
+            return Optional.of(new MockResponse(304, headersBuilder.build(), ""));
+        }
+
         // Normal mode: use configured status/content
         Headers.Builder headersBuilder = new Headers.Builder()
                 .add("Content-Type", "application/json");
@@ -226,7 +253,18 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
      * Configure for 204 No Content response.
      */
     public TestApiDispatcher withNoContent() {
-        this.statusCode = 204;
+        return withNoContentAndStatus(204);
+    }
+
+    /**
+     * Configure for a body-less response under an explicit status code, so protocol-defined
+     * no-body statuses other than 204 — notably {@code 205 Reset Content} — are expressible.
+     *
+     * @param noBodyStatus the status code to answer with
+     * @return this dispatcher
+     */
+    public TestApiDispatcher withNoContentAndStatus(int noBodyStatus) {
+        this.statusCode = noBodyStatus;
         this.responseContent = "";
         this.etag = null;
         return this;
@@ -261,6 +299,7 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
         this.successEtag = etagValue;
         this.successThenErrorMode = true;
         this.errorThenSuccessMode = false;
+        this.seedThen304Mode = false;
         this.callCounter = 0;
         return this;
     }
@@ -274,6 +313,30 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
         this.errorSuccessEtag = etagValue;
         this.errorThenSuccessMode = true;
         this.successThenErrorMode = false;
+        this.seedThen304Mode = false;
+        this.callCounter = 0;
+        return this;
+    }
+
+    /**
+     * Configure the dispatcher to seed a cache entry on the first call and revalidate on every
+     * call after it: {@code 200} carrying {@code content} and {@code etagValue}, then
+     * {@code 304 Not Modified} carrying the same ETag and no body.
+     * <p>
+     * This lets a single scenario seed the cache with a GET and then issue the revalidating
+     * request under a <em>different</em> HTTP method, which the configure-then-reconfigure
+     * helpers cannot express.
+     *
+     * @param content   the body served on the seeding call
+     * @param etagValue the ETag served on the seeding call and echoed on each 304
+     * @return this dispatcher
+     */
+    public TestApiDispatcher withSeedThen304(String content, String etagValue) {
+        this.seedContent = content;
+        this.seedEtag = etagValue;
+        this.seedThen304Mode = true;
+        this.successThenErrorMode = false;
+        this.errorThenSuccessMode = false;
         this.callCounter = 0;
         return this;
     }
@@ -289,6 +352,7 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
         this.lastContentType = null;
         this.successThenErrorMode = false;
         this.errorThenSuccessMode = false;
+        this.seedThen304Mode = false;
         return this;
     }
 

--- a/cui-http-core/src/test/java/de/cuioss/http/client/adapter/TestApiDispatcher.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/adapter/TestApiDispatcher.java
@@ -233,6 +233,7 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
      * Configure for successful response with ETag.
      */
     public TestApiDispatcher withSuccessAndETag(String content, String etagValue) {
+        clearSequenceModes();
         this.statusCode = 200;
         this.responseContent = content;
         this.etag = etagValue;
@@ -243,6 +244,7 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
      * Configure for 304 Not Modified response.
      */
     public TestApiDispatcher with304() {
+        clearSequenceModes();
         this.statusCode = 304;
         this.responseContent = "";
         // Keep existing etag
@@ -264,6 +266,7 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
      * @return this dispatcher
      */
     public TestApiDispatcher withNoContentAndStatus(int noBodyStatus) {
+        clearSequenceModes();
         this.statusCode = noBodyStatus;
         this.responseContent = "";
         this.etag = null;
@@ -274,6 +277,7 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
      * Configure for server error (5xx).
      */
     public TestApiDispatcher withServerError() {
+        clearSequenceModes();
         this.statusCode = 503;
         this.responseContent = "";
         this.etag = null;
@@ -284,6 +288,7 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
      * Configure for client error (4xx).
      */
     public TestApiDispatcher withClientError() {
+        clearSequenceModes();
         this.statusCode = 404;
         this.responseContent = "";
         this.etag = null;
@@ -295,11 +300,10 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
      * Useful for testing cache fallback scenarios.
      */
     public TestApiDispatcher withSuccessThenError(String initialContent, String etagValue) {
+        clearSequenceModes();
         this.successContent = initialContent;
         this.successEtag = etagValue;
         this.successThenErrorMode = true;
-        this.errorThenSuccessMode = false;
-        this.seedThen304Mode = false;
         this.callCounter = 0;
         return this;
     }
@@ -309,11 +313,10 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
      * Useful for testing retry scenarios.
      */
     public TestApiDispatcher withServerErrorThenSuccess(String recoveryContent, String etagValue) {
+        clearSequenceModes();
         this.errorSuccessContent = recoveryContent;
         this.errorSuccessEtag = etagValue;
         this.errorThenSuccessMode = true;
-        this.successThenErrorMode = false;
-        this.seedThen304Mode = false;
         this.callCounter = 0;
         return this;
     }
@@ -332,13 +335,27 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
      * @return this dispatcher
      */
     public TestApiDispatcher withSeedThen304(String content, String etagValue) {
+        clearSequenceModes();
         this.seedContent = content;
         this.seedEtag = etagValue;
         this.seedThen304Mode = true;
-        this.successThenErrorMode = false;
-        this.errorThenSuccessMode = false;
         this.callCounter = 0;
         return this;
+    }
+
+    /**
+     * Clears every sequence mode so at most one is ever active.
+     * <p>
+     * Every configurator calls this first — the sequence configurators so the modes stay mutually
+     * exclusive, and the single-shot ones so a previously configured sequence cannot outlive the
+     * reconfiguration and keep serving its own responses. Adding the reset to each configurator
+     * individually is what let {@code withNoContentAndStatus} be missed: a sequence configured
+     * earlier stayed active and served its seed response instead of the requested status.
+     */
+    private void clearSequenceModes() {
+        this.successThenErrorMode = false;
+        this.errorThenSuccessMode = false;
+        this.seedThen304Mode = false;
     }
 
     /**
@@ -350,9 +367,7 @@ public class TestApiDispatcher implements ModuleDispatcherElement {
         this.lastIfNoneMatch = null;
         this.lastAccept = null;
         this.lastContentType = null;
-        this.successThenErrorMode = false;
-        this.errorThenSuccessMode = false;
-        this.seedThen304Mode = false;
+        clearSequenceModes();
         return this;
     }
 


### PR DESCRIPTION
## Summary

Close the cache-correctness hole in `ETagAwareHttpAdapter.handleHttpResponse` where a `304`
response to **any** HTTP method returned a prior GET's cached body as a success — so a `DELETE`
could appear to have succeeded and hand back a stale body. The fix replaces the unconditional
304 short-circuit with a three-way, RFC 7232-aligned distinction (GET → cached content; HEAD →
status + ETag, no body; POST/PUT/DELETE/PATCH → failure), and repairs four surrounding
result-fidelity and cache-hygiene defects in the same response path.

## Changes

- `ETagAwareHttpAdapter.java`: gate the 304 short-circuit by HTTP method (GET/HEAD/other);
  exempt protocol-defined no-body statuses (204/205) from the empty-content failure; preserve
  the HTTP status on a conversion failure; invalidate the cache entry on an ETag-less 200; avoid
  the cache-key allocation and bound eviction cost for non-cacheable requests.
- `ETagAwareHttpAdapterIntegrationTest.java` / `ETagAwareHttpAdapterTest.java`: regression
  coverage for the three-way 304 matrix, no-body-status handling, conversion-failure status
  preservation, ETag-less-200 cache invalidation, and cache-key/eviction bypass for
  non-cacheable requests.
- `TestApiDispatcher.java`: fixture extension providing the new response scenarios the above
  test cases exercise.

## Test Plan

- [ ] Verification command passed (`python3 .plan/execute-script.py plan-marshall:build-maven:maven run --command-args "verify -Ppre-commit -pl cui-http-core -am"`)
- [ ] Manual testing completed (if applicable)

---
Generated by plan-finalize skill

## Intent

**The problem.** `ETagAwareHttpAdapter.handleHttpResponse` treated a `304 Not Modified` as an
unconditional "return the cached body" signal regardless of the request's HTTP method. Because a
prior GET's cache entry stays keyed the same way, a subsequent `DELETE` (or `PUT`/`POST`/`PATCH`)
that legitimately received a 304 from a caching intermediary would silently succeed with the
stale GET body instead of failing — a correctness hole with no crash and no log signal. Four
smaller defects sat in the same response path: 204/205 (protocol-defined no-body statuses) were
misreported as `INVALID_CONTENT`; a body-conversion failure discarded the real HTTP status that
was already in hand; an ETag-less 200 left a now-stale cache entry in place; and every
non-cacheable request still paid for a cache-key allocation plus an O(n log n) eviction sort.

**The chosen approach.** Replace the single 304 branch with an explicit three-way,
RFC-7232-aligned dispatch on HTTP method: GET returns the cached content, HEAD returns success
with the ETag and no body, and every other method (POST/PUT/DELETE/PATCH) treats the 304 as a
failure rather than a masked success. The four surrounding defects are fixed in the same pass
because they live in the same method and are exercised by the same response-handling test
matrix: no-body statuses get an explicit exemption from the empty-content check, a

_[Intent truncated — 1387 of 2220 characters shown; full outline in the plan workspace]_



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTTP `304 Not Modified` responses based on request method.
  * Preserved cached content for eligible GET requests while correctly handling HEAD responses without a body.
  * Prevented cached content or ETags from being exposed for unsupported methods or unsolicited `304` responses.
  * Improved conversion-failure reporting with response status and ETag details.
  * Correctly invalidated stale cached entries when successful responses omit an ETag.
  * Added accurate handling for bodyless `204` and `205` responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->