### PR TITLE
feat(handler): add opt-in verifyHostname(false) TLS relaxation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -71,6 +71,7 @@ xref:doc/client-handlers-readme.adoc[HTTP Client Handlers]:
 * `HttpHandler` - Builder-based HTTP client with SSL defaults
 * `SecureSSLContextProvider` - TLS 1.2+ SSL context
 * `HttpStatusFamily` - RFC 7231 status classification
+* Opt-in hostname-verification relaxation (`verifyHostname(false)`) - skips TLS identity matching only; certificate-chain validation is unaffected (xref:doc/client-handlers-readme.adoc[details])
 
 === Forwarded / Reverse-Proxy Header Resolution
 

--- a/cui-http-core/src/main/java/de/cuioss/http/client/HttpLogMessages.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/HttpLogMessages.java
@@ -102,6 +102,17 @@ public final class HttpLogMessages {
                 .identifier(115)
                 .template("Using cleartext HTTP for %s (allowInsecureHttp=true); data is transmitted unencrypted")
                 .build();
+
+        /**
+         * Logged when an HTTPS handler is built with TLS hostname verification relaxed via the
+         * {@code verifyHostname(false)} opt-in.
+         * Used in: HttpHandler.HttpHandlerBuilder.build (https scheme with verifyHostname=false)
+         */
+        public static final LogRecord HOSTNAME_VERIFICATION_DISABLED = LogRecordModel.builder()
+                .prefix(PREFIX)
+                .identifier(116)
+                .template("TLS hostname verification disabled for %s (verifyHostname=false); certificate chain validation remains enforced")
+                .build();
     }
 
     /**

--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/HostnameVerificationRelaxingTrustManager.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/HostnameVerificationRelaxingTrustManager.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.client.handler;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import java.net.Socket;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+
+/**
+ * A delegating {@link X509ExtendedTrustManager} that skips TLS
+ * hostname/endpoint-identification checks and nothing else.
+ *
+ * <h2>What is relaxed - and what is not</h2>
+ * <p>
+ * The <strong>only</strong> check this wrapper suppresses is the match between the peer
+ * certificate's identity (subject alternative names / common name) and the host the connection
+ * was opened against. Every other part of the peer verification is performed unchanged by the
+ * wrapped delegate:
+ * <ul>
+ *   <li>certificate-chain trust - the chain must still terminate in a trust anchor the delegate
+ *       accepts; a certificate signed by an unknown CA is still rejected</li>
+ *   <li>validity period - expired and not-yet-valid certificates are still rejected</li>
+ *   <li>revocation posture - whatever revocation checking the delegate is configured for still
+ *       applies</li>
+ *   <li>algorithm constraints - the JDK's disabled-algorithm and key-size policies still apply</li>
+ * </ul>
+ *
+ * <h2>Mechanism</h2>
+ * <p>
+ * The relaxation is not a re-implementation of certificate validation; it is the documented
+ * {@link X509ExtendedTrustManager} contract. The endpoint-identification algorithm that triggers
+ * hostname matching is carried by the {@link SSLEngine} / {@link Socket} handed to the extended
+ * {@code checkServerTrusted} / {@code checkClientTrusted} overloads. Per that contract, when the
+ * engine or socket argument is {@code null} the trust manager performs the full chain validation
+ * but has no peer-identity context and therefore performs no identity matching. This class
+ * consequently forwards the extended overloads to the delegate with an explicit {@code null}
+ * engine/socket, and forwards the plain two-argument {@link javax.net.ssl.X509TrustManager} forms
+ * and {@link #getAcceptedIssuers()} verbatim - those never perform identity checks to begin with.
+ *
+ * <h2>Usage</h2>
+ * <p>
+ * This class is deliberately package-private and strictly opt-in: it is only reachable through
+ * {@link SecureSSLContextProvider#createHostnameRelaxedSSLContext()}, which in turn is only
+ * selected by an explicit {@code HttpHandlerBuilder.verifyHostname(false)}. Relaxing hostname
+ * verification removes the protection against an attacker presenting a valid certificate issued
+ * for a <em>different</em> host, so it must never be enabled by default.
+ *
+ * @author Oliver Wolff
+ * @since 1.3
+ * @see SecureSSLContextProvider#createHostnameRelaxedSSLContext()
+ */
+final class HostnameVerificationRelaxingTrustManager extends X509ExtendedTrustManager {
+
+    private final X509ExtendedTrustManager delegate;
+
+    /**
+     * Creates a wrapper around the given trust manager.
+     *
+     * @param delegate the trust manager performing the actual chain validation, must not be null
+     * @throws NullPointerException if {@code delegate} is null
+     */
+    HostnameVerificationRelaxingTrustManager(X509ExtendedTrustManager delegate) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate must not be null");
+    }
+
+    /**
+     * Wraps every {@link X509ExtendedTrustManager} element of the given array in a
+     * {@link HostnameVerificationRelaxingTrustManager}, passing any other element through
+     * unchanged.
+     * <p>
+     * Elements that are not {@link X509ExtendedTrustManager} instances cannot carry the
+     * endpoint-identification context in the first place, so there is nothing to relax for them.
+     *
+     * @param delegates the trust managers to wrap, must not be null
+     * @return a new array of the same length holding the wrapped and pass-through elements
+     * @throws NullPointerException if {@code delegates} is null
+     */
+    static TrustManager[] relaxHostnameVerification(TrustManager[] delegates) {
+        Objects.requireNonNull(delegates, "delegates must not be null");
+        TrustManager[] relaxed = new TrustManager[delegates.length];
+        for (int i = 0; i < delegates.length; i++) {
+            TrustManager candidate = delegates[i];
+            relaxed[i] = candidate instanceof X509ExtendedTrustManager extended
+                    ? new HostnameVerificationRelaxingTrustManager(extended)
+                    : candidate;
+        }
+        return relaxed;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Forwards to the delegate with a {@code null} {@link Socket}, which suppresses
+     * hostname/endpoint-identification matching while keeping chain validation intact.
+     */
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
+        delegate.checkClientTrusted(chain, authType, (Socket) null);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Forwards to the delegate with a {@code null} {@link SSLEngine}, which suppresses
+     * hostname/endpoint-identification matching while keeping chain validation intact.
+     */
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
+        delegate.checkClientTrusted(chain, authType, (SSLEngine) null);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Forwards to the delegate with a {@code null} {@link Socket}, which suppresses
+     * hostname/endpoint-identification matching while keeping chain validation intact.
+     */
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
+        delegate.checkServerTrusted(chain, authType, (Socket) null);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Forwards to the delegate with a {@code null} {@link SSLEngine}, which suppresses
+     * hostname/endpoint-identification matching while keeping chain validation intact.
+     */
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
+        delegate.checkServerTrusted(chain, authType, (SSLEngine) null);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Delegated verbatim - the two-argument form never performs identity matching.
+     */
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        delegate.checkClientTrusted(chain, authType);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Delegated verbatim - the two-argument form never performs identity matching.
+     */
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        delegate.checkServerTrusted(chain, authType);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Delegated verbatim - the accepted issuers are unaffected by hostname verification.
+     */
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        return delegate.getAcceptedIssuers();
+    }
+}

--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java
@@ -110,13 +110,20 @@ import java.util.regex.Pattern;
  * ({@link HttpHandlerBuilder#verifyHostname(boolean)}, default {@code true}). Setting it to
  * {@code false} is a deliberate opt-in that skips <em>only</em> the match between the peer
  * certificate's identity (SAN / CN) and the connected host. Certificate-chain trust, validity
- * period, revocation posture, and algorithm constraints remain fully enforced, and a WARN
+ * period, and algorithm constraints remain fully enforced; revocation posture is unchanged from
+ * whatever the JVM's default PKIX trust manager already applies (the JDK's default PKIX
+ * configuration does not itself enable revocation checking - see
+ * {@link SecureSSLContextProvider#createHostnameRelaxedSSLContext()}). A WARN
  * ({@code HTTP-116}) is logged for every handler built this way.</p>
  * <p>The relaxation is confined to the default-trust-store context this class derives itself, so
  * combining {@code verifyHostname(false)} with a caller-supplied
  * {@link HttpHandlerBuilder#sslContext(SSLContext)} is rejected at {@link HttpHandlerBuilder#build()}
  * time with {@link IllegalArgumentException}. A context {@link #asBuilder()} carries over from a
- * handler's own derivation is not caller-supplied and round-trips cleanly.</p>
+ * handler's own derivation is not caller-supplied and round-trips cleanly. Flipping
+ * {@code verifyHostname} back to {@code true} on a builder cloned from a relaxed handler never
+ * silently keeps the relaxed context: {@link HttpHandlerBuilder#build()} discards it and derives a
+ * fresh secure context instead, so the relaxation cannot leak into a handler that reports hostname
+ * verification as enabled.</p>
  * <pre>
  * // Opt in to hostname relaxation (e.g. connecting to an internal host by IP)
  * HttpHandler relaxed = HttpHandler.builder()
@@ -232,6 +239,11 @@ public final class HttpHandler {
     }
 
     // Constructor for HTTPS URIs (SSL context required)
+    // NOSONAR java:S107 - private constructor invoked only from HttpHandlerBuilder#build(); the wide
+    // parameter list mirrors the builder's own fields one-for-one and is the intended shape for a
+    // Lombok-style immutable value object assembled by a single caller-facing builder. Splitting it
+    // into a parameter object would only move the same fields to a second private type.
+    @SuppressWarnings("java:S107")
     private HttpHandler(URI uri, URL url, SSLContext sslContext, SecureSSLContextProvider secureSSLContextProvider,
             int connectionTimeoutSeconds, int readTimeoutSeconds, boolean allowInsecureHttp,
             boolean verifyHostname, boolean sslContextCallerSupplied) {
@@ -281,11 +293,17 @@ public final class HttpHandler {
      * which can be used to create a new handler with modified URL.</p>
      *
      * <p>A context this handler <em>derived</em> for itself is re-injected through the
-     * package-private {@link HttpHandlerBuilder#derivedSslContext(SSLContext)} seam, so it does not
-     * become "caller-supplied" on the returned builder. This is what lets a handler built with
-     * {@code verifyHostname(false)} round-trip through {@code asBuilder().build()} without tripping
-     * the mutual-exclusion rejection. A context that genuinely came from the caller is re-injected
-     * through {@link HttpHandlerBuilder#sslContext(SSLContext)} and keeps that provenance.</p>
+     * package-private {@link HttpHandlerBuilder#derivedSslContext(SSLContext, boolean)} seam, so it
+     * does not become "caller-supplied" on the returned builder. This is what lets a handler built
+     * with {@code verifyHostname(false)} round-trip through {@code asBuilder().build()} without
+     * tripping the mutual-exclusion rejection. A context that genuinely came from the caller is
+     * re-injected through {@link HttpHandlerBuilder#sslContext(SSLContext)} and keeps that
+     * provenance.</p>
+     * <p>The re-injected derived context also carries whether it is <em>hostname-relaxed</em> — i.e.
+     * whether this handler itself was built with {@code verifyHostname(false)}. {@link
+     * HttpHandlerBuilder#build()} consults that flag to refuse silently reusing a relaxed context for
+     * a handler that flips {@code verifyHostname} back to {@code true} on the returned builder: see
+     * {@link HttpHandlerBuilder#build()} for the mechanism.</p>
      *
      * @return A pre-configured {@link HttpHandlerBuilder} with the same timeouts as this handler
      */
@@ -298,7 +316,7 @@ public final class HttpHandler {
                 .verifyHostname(verifyHostname);
         return sslContextCallerSupplied
                 ? handlerBuilder.sslContext(sslContext)
-                : handlerBuilder.derivedSslContext(sslContext);
+                : handlerBuilder.derivedSslContext(sslContext, !verifyHostname);
     }
 
     /**
@@ -379,6 +397,11 @@ public final class HttpHandler {
         private boolean allowInsecureHttp = false;
         private boolean verifyHostname = true;
         private boolean sslContextCallerSupplied = false;
+        // True when the current (derived, non-caller-supplied) sslContext was produced by
+        // createHostnameRelaxedSSLContext() on the handler asBuilder() cloned this builder from.
+        // build() consults this to refuse silently reusing a relaxed context once verifyHostname
+        // has been flipped back to true on this builder - see build() for the rationale.
+        private boolean derivedSslContextRelaxed = false;
 
         /**
          * Sets the URI as a string.
@@ -477,6 +500,7 @@ public final class HttpHandler {
         public HttpHandlerBuilder sslContext(@Nullable SSLContext sslContext) {
             this.sslContext = sslContext;
             this.sslContextCallerSupplied = sslContext != null;
+            this.derivedSslContextRelaxed = false;
             return this;
         }
 
@@ -489,12 +513,24 @@ public final class HttpHandler {
          * {@link #verifyHostname(boolean) verifyHostname(false)} is rejected against. It is otherwise
          * identical to {@link #sslContext(SSLContext)}.
          * </p>
+         * <p>
+         * {@code relaxed} records whether the carried-over context is the hostname-relaxed context
+         * produced by {@link SecureSSLContextProvider#createHostnameRelaxedSSLContext()} - i.e.
+         * whether the source handler was built with {@code verifyHostname(false)}. {@link #build()}
+         * uses this to detect a builder that has since flipped {@code verifyHostname} back to
+         * {@code true}: reusing the relaxed context in that case would silently keep hostname
+         * verification disabled on a handler that reports it as enabled, so {@link #build()} discards
+         * the relaxed context instead of reusing it - see {@link #build()}.
+         * </p>
          *
          * @param sslContext The already-resolved SSL context to carry over.
+         * @param relaxed    {@code true} when {@code sslContext} is the hostname-relaxed context the
+         *                   source handler was built with.
          * @return This builder instance.
          */
-        HttpHandlerBuilder derivedSslContext(@Nullable SSLContext sslContext) {
+        HttpHandlerBuilder derivedSslContext(@Nullable SSLContext sslContext, boolean relaxed) {
             this.sslContext = sslContext;
+            this.derivedSslContextRelaxed = relaxed;
             return this;
         }
 
@@ -563,7 +599,9 @@ public final class HttpHandler {
          * Setting this to {@code false} is a deliberate, narrowly scoped opt-in: the <strong>only</strong>
          * check that is skipped is the match between the peer certificate's identity (SAN / CN) and
          * the connected host. Certificate-chain trust against the JVM default trust store, validity
-         * period, revocation posture, and algorithm constraints all remain fully enforced - see
+         * period, and algorithm constraints all remain fully enforced; revocation posture is
+         * unchanged from whatever the JVM's default PKIX trust manager already applies (the JDK's
+         * default PKIX configuration does not itself enable revocation checking) - see
          * {@link SecureSSLContextProvider#createHostnameRelaxedSSLContext()}. A WARN
          * ({@code HTTP-116}) is logged for every handler built this way.
          * </p>
@@ -639,13 +677,7 @@ public final class HttpHandler {
                 // For HTTPS, create or validate SSL context and pin the enabled protocols
                 SecureSSLContextProvider actualSecureSSLContextProvider = secureSSLContextProvider != null ?
                         secureSSLContextProvider : new SecureSSLContextProvider();
-                SSLContext secureContext;
-                if (verifyHostname) {
-                    secureContext = actualSecureSSLContextProvider.getOrCreateSecureSSLContext(sslContext);
-                } else {
-                    secureContext = actualSecureSSLContextProvider.createHostnameRelaxedSSLContext();
-                    LOGGER.warn(HttpLogMessages.WARN.HOSTNAME_VERIFICATION_DISABLED, uri);
-                }
+                SSLContext secureContext = resolveHttpsSecureContext(actualSecureSSLContextProvider);
                 return new HttpHandler(uri, verifiedUrl, secureContext, actualSecureSSLContextProvider,
                         actualConnectionTimeoutSeconds, actualReadTimeoutSeconds, allowInsecureHttp,
                         verifyHostname, sslContextCallerSupplied);
@@ -662,6 +694,34 @@ public final class HttpHandler {
             }
             throw new IllegalArgumentException("Unsupported URI scheme '" + scheme + "' for " + uri
                     + "; only http and https are supported.");
+        }
+
+        /**
+         * Resolves the {@link SSLContext} for an HTTPS handler, honoring the {@link #verifyHostname}
+         * opt-in and refusing to silently reuse a stale hostname-relaxed context.
+         * <p>
+         * When {@link #verifyHostname} is {@code false}, a fresh hostname-relaxed context is created
+         * and the {@code HTTP-116} WARN is logged. When {@code true}, a derived (non-caller-supplied)
+         * context carried over from {@link HttpHandler#asBuilder()} may be the hostname-relaxed
+         * context of a source handler built with {@code verifyHostname(false)}; reusing it verbatim
+         * here would silently keep hostname verification disabled underneath a handler that reports
+         * {@code isVerifyHostname() == true}. Such a context is discarded (falling back to
+         * {@code null}, which {@link SecureSSLContextProvider#getOrCreateSecureSSLContext(SSLContext)}
+         * resolves to a fresh secure default context) rather than let the relaxation leak through a
+         * {@code verifyHostname(true)} rebuild. A genuinely caller-supplied context is never
+         * discarded - {@link #sslContextCallerSupplied} gates it.
+         *
+         * @param provider the TLS-floor provider used to create or validate the context
+         * @return the resolved {@link SSLContext} for the handler under construction
+         */
+        private SSLContext resolveHttpsSecureContext(SecureSSLContextProvider provider) {
+            if (!verifyHostname) {
+                SSLContext relaxedContext = provider.createHostnameRelaxedSSLContext();
+                LOGGER.warn(HttpLogMessages.WARN.HOSTNAME_VERIFICATION_DISABLED, uri);
+                return relaxedContext;
+            }
+            boolean discardStaleRelaxedContext = !sslContextCallerSupplied && derivedSslContextRelaxed;
+            return provider.getOrCreateSecureSSLContext(discardStaleRelaxedContext ? null : sslContext);
         }
 
         /**

--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/HttpHandler.java
@@ -105,6 +105,26 @@ import java.util.regex.Pattern;
  * {@code [TLSv1.3]}. A caller cannot express "TLS&nbsp;1.3-only" via the generic {@code "TLS"}
  * string. See {@link SecureSSLContextProvider}.</p>
  *
+ * <h3>Hostname verification</h3>
+ * <p>TLS hostname verification is <strong>on by default</strong>
+ * ({@link HttpHandlerBuilder#verifyHostname(boolean)}, default {@code true}). Setting it to
+ * {@code false} is a deliberate opt-in that skips <em>only</em> the match between the peer
+ * certificate's identity (SAN / CN) and the connected host. Certificate-chain trust, validity
+ * period, revocation posture, and algorithm constraints remain fully enforced, and a WARN
+ * ({@code HTTP-116}) is logged for every handler built this way.</p>
+ * <p>The relaxation is confined to the default-trust-store context this class derives itself, so
+ * combining {@code verifyHostname(false)} with a caller-supplied
+ * {@link HttpHandlerBuilder#sslContext(SSLContext)} is rejected at {@link HttpHandlerBuilder#build()}
+ * time with {@link IllegalArgumentException}. A context {@link #asBuilder()} carries over from a
+ * handler's own derivation is not caller-supplied and round-trips cleanly.</p>
+ * <pre>
+ * // Opt in to hostname relaxation (e.g. connecting to an internal host by IP)
+ * HttpHandler relaxed = HttpHandler.builder()
+ *     .uri("https://10.0.0.7/api")
+ *     .verifyHostname(false)
+ *     .build();
+ * </pre>
+ *
  * @since 1.0
  * @see HttpClient
  * @see SecureSSLContextProvider
@@ -162,6 +182,26 @@ public final class HttpHandler {
     @ToString.Exclude
     @Getter
     private final boolean allowInsecureHttp;
+    /**
+     * Whether TLS hostname/endpoint-identification verification is performed for this handler
+     * ({@code true} by default). When {@code false}, the handler was built through the explicit
+     * {@link HttpHandlerBuilder#verifyHostname(boolean)} opt-in and its TLS peer identity is not
+     * checked against the connected host; certificate-chain trust, validity period, and algorithm
+     * constraints remain enforced. It is part of the handler's configuration identity
+     * ({@code equals}/{@code hashCode}) and is rendered in {@code toString}.
+     *
+     * @return {@code true} if TLS hostname verification is active for this handler
+     */
+    @Getter
+    private final boolean verifyHostname;
+    // Build-time provenance only: records whether the SSLContext was supplied by the caller rather
+    // than derived by this class. It is not configuration - two handlers that differ only in how
+    // their (identical) context was obtained are the same configuration - so it is excluded from
+    // equals/hashCode and toString, and no getter is exposed. asBuilder() reads it to decide
+    // whether to re-inject the context through the caller-facing or the derived seam.
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private final boolean sslContextCallerSupplied;
     // Excluded from equals/hashCode/toString: HttpClient has identity equality (two
     // identically-configured handlers hold distinct client instances) and is derived from
     // the configuration above.
@@ -180,6 +220,10 @@ public final class HttpHandler {
         this.readTimeoutSeconds = readTimeoutSeconds;
         // Reached only via the opt-in, so this handler was explicitly permitted to use cleartext.
         this.allowInsecureHttp = true;
+        // No TLS is involved, so hostname verification keeps its secure default and no SSLContext
+        // was consumed from the caller.
+        this.verifyHostname = true;
+        this.sslContextCallerSupplied = false;
 
         // Create the HttpClient for HTTP
         this.httpClient = HttpClient.newBuilder()
@@ -189,7 +233,8 @@ public final class HttpHandler {
 
     // Constructor for HTTPS URIs (SSL context required)
     private HttpHandler(URI uri, URL url, SSLContext sslContext, SecureSSLContextProvider secureSSLContextProvider,
-            int connectionTimeoutSeconds, int readTimeoutSeconds, boolean allowInsecureHttp) {
+            int connectionTimeoutSeconds, int readTimeoutSeconds, boolean allowInsecureHttp,
+            boolean verifyHostname, boolean sslContextCallerSupplied) {
         this.uri = uri;
         this.url = url;
         this.sslContext = sslContext;
@@ -197,6 +242,8 @@ public final class HttpHandler {
         this.connectionTimeoutSeconds = connectionTimeoutSeconds;
         this.readTimeoutSeconds = readTimeoutSeconds;
         this.allowInsecureHttp = allowInsecureHttp;
+        this.verifyHostname = verifyHostname;
+        this.sslContextCallerSupplied = sslContextCallerSupplied;
 
         // JDK 11+ HttpClient enables hostname verification by default.
         // Pin the enabled TLS protocols so the configured minimum version is a hard
@@ -233,15 +280,25 @@ public final class HttpHandler {
      * <p>This method allows creating a new builder based on the current handler's configuration,
      * which can be used to create a new handler with modified URL.</p>
      *
+     * <p>A context this handler <em>derived</em> for itself is re-injected through the
+     * package-private {@link HttpHandlerBuilder#derivedSslContext(SSLContext)} seam, so it does not
+     * become "caller-supplied" on the returned builder. This is what lets a handler built with
+     * {@code verifyHostname(false)} round-trip through {@code asBuilder().build()} without tripping
+     * the mutual-exclusion rejection. A context that genuinely came from the caller is re-injected
+     * through {@link HttpHandlerBuilder#sslContext(SSLContext)} and keeps that provenance.</p>
+     *
      * @return A pre-configured {@link HttpHandlerBuilder} with the same timeouts as this handler
      */
     public HttpHandlerBuilder asBuilder() {
-        return builder()
+        HttpHandlerBuilder handlerBuilder = builder()
                 .connectionTimeoutSeconds(connectionTimeoutSeconds)
                 .readTimeoutSeconds(readTimeoutSeconds)
-                .sslContext(sslContext)
                 .tlsVersions(secureSSLContextProvider)
-                .allowInsecureHttp(allowInsecureHttp);
+                .allowInsecureHttp(allowInsecureHttp)
+                .verifyHostname(verifyHostname);
+        return sslContextCallerSupplied
+                ? handlerBuilder.sslContext(sslContext)
+                : handlerBuilder.derivedSslContext(sslContext);
     }
 
     /**
@@ -320,6 +377,8 @@ public final class HttpHandler {
         private @Nullable Integer connectionTimeoutSeconds;
         private @Nullable Integer readTimeoutSeconds;
         private boolean allowInsecureHttp = false;
+        private boolean verifyHostname = true;
+        private boolean sslContextCallerSupplied = false;
 
         /**
          * Sets the URI as a string.
@@ -405,11 +464,36 @@ public final class HttpHandler {
          * <p>
          * If not set, a default secure SSL context will be created.
          * </p>
+         * <p>
+         * Passing a non-null context marks it as <em>caller-supplied</em>, which is mutually
+         * exclusive with {@link #verifyHostname(boolean) verifyHostname(false)} and makes
+         * {@link #build()} reject that combination. Passing {@code null} clears both the context and
+         * the caller-supplied claim.
+         * </p>
          *
          * @param sslContext The SSL context to use.
          * @return This builder instance.
          */
         public HttpHandlerBuilder sslContext(@Nullable SSLContext sslContext) {
+            this.sslContext = sslContext;
+            this.sslContextCallerSupplied = sslContext != null;
+            return this;
+        }
+
+        /**
+         * Re-injects an already-resolved SSL context without marking it caller-supplied.
+         * <p>
+         * This seam exists for {@link HttpHandler#asBuilder()}: the context it carries over was
+         * <em>derived</em> by {@link HttpHandler} itself, not handed in by the caller, so it must not
+         * assert the caller-supplied provenance that
+         * {@link #verifyHostname(boolean) verifyHostname(false)} is rejected against. It is otherwise
+         * identical to {@link #sslContext(SSLContext)}.
+         * </p>
+         *
+         * @param sslContext The already-resolved SSL context to carry over.
+         * @return This builder instance.
+         */
+        HttpHandlerBuilder derivedSslContext(@Nullable SSLContext sslContext) {
             this.sslContext = sslContext;
             return this;
         }
@@ -473,12 +557,54 @@ public final class HttpHandler {
         }
 
         /**
+         * Controls whether the TLS hostname/endpoint-identification check is performed for HTTPS
+         * connections. Default: {@code true}.
+         * <p>
+         * Setting this to {@code false} is a deliberate, narrowly scoped opt-in: the <strong>only</strong>
+         * check that is skipped is the match between the peer certificate's identity (SAN / CN) and
+         * the connected host. Certificate-chain trust against the JVM default trust store, validity
+         * period, revocation posture, and algorithm constraints all remain fully enforced - see
+         * {@link SecureSSLContextProvider#createHostnameRelaxedSSLContext()}. A WARN
+         * ({@code HTTP-116}) is logged for every handler built this way.
+         * </p>
+         * <p>
+         * The relaxation is confined to the default-trust-store context this class builds itself.
+         * Combining {@code verifyHostname(false)} with a caller-supplied
+         * {@link #sslContext(SSLContext)} is therefore rejected by {@link #build()} with
+         * {@link IllegalArgumentException} - the relaxation cannot be silently applied to, or
+         * silently dropped from, trust material this class does not own. A context that
+         * {@link HttpHandler#asBuilder()} carries over from a handler's own derivation is not
+         * caller-supplied and does not trip the rejection.
+         * </p>
+         *
+         * @param verifyHostname {@code false} to skip TLS hostname verification.
+         * @return This builder instance.
+         */
+        public HttpHandlerBuilder verifyHostname(boolean verifyHostname) {
+            this.verifyHostname = verifyHostname;
+            return this;
+        }
+
+        /**
          * Builds a new {@link HttpHandler} instance with the configured parameters.
          *
          * @return A new {@link HttpHandler} instance.
-         * @throws IllegalArgumentException If any parameter is invalid.
+         * @throws IllegalArgumentException If any parameter is invalid, or if
+         *                                  {@code verifyHostname(false)} is combined with a
+         *                                  caller-supplied {@link #sslContext(SSLContext)}.
          */
         public HttpHandler build() {
+            // The relaxation only applies to the default-trust-store context this class derives
+            // itself; it must never be applied to (or silently dropped from) caller-owned trust
+            // material. Keyed off the provenance flag, not off sslContext != null, so a context
+            // asBuilder() re-injected via derivedSslContext(...) does not trip it.
+            if (!verifyHostname && sslContextCallerSupplied) {
+                throw new IllegalArgumentException("verifyHostname(false) cannot be combined with a "
+                        + "caller-supplied sslContext(...); the hostname relaxation only applies to the "
+                        + "default-trust-store context this builder derives. Either drop the custom "
+                        + "sslContext(...) or keep verifyHostname(true).");
+            }
+
             // Resolve the URI from the provided inputs
             resolveUri();
 
@@ -513,9 +639,16 @@ public final class HttpHandler {
                 // For HTTPS, create or validate SSL context and pin the enabled protocols
                 SecureSSLContextProvider actualSecureSSLContextProvider = secureSSLContextProvider != null ?
                         secureSSLContextProvider : new SecureSSLContextProvider();
-                SSLContext secureContext = actualSecureSSLContextProvider.getOrCreateSecureSSLContext(sslContext);
+                SSLContext secureContext;
+                if (verifyHostname) {
+                    secureContext = actualSecureSSLContextProvider.getOrCreateSecureSSLContext(sslContext);
+                } else {
+                    secureContext = actualSecureSSLContextProvider.createHostnameRelaxedSSLContext();
+                    LOGGER.warn(HttpLogMessages.WARN.HOSTNAME_VERIFICATION_DISABLED, uri);
+                }
                 return new HttpHandler(uri, verifiedUrl, secureContext, actualSecureSSLContextProvider,
-                        actualConnectionTimeoutSeconds, actualReadTimeoutSeconds, allowInsecureHttp);
+                        actualConnectionTimeoutSeconds, actualReadTimeoutSeconds, allowInsecureHttp,
+                        verifyHostname, sslContextCallerSupplied);
             }
             if ("http".equalsIgnoreCase(scheme)) {
                 if (!allowInsecureHttp) {

--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/SecureSSLContextProvider.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/SecureSSLContextProvider.java
@@ -222,8 +222,10 @@ public record SecureSSLContextProvider(String minimumTlsVersion) {
      * </ol>
      * <p>
      * <strong>Hostname/endpoint-identification matching is the only check that is relaxed.</strong>
-     * Certificate-chain trust against the JVM's default trust store, validity period, revocation
-     * posture, and algorithm constraints all remain fully enforced - see
+     * Certificate-chain trust against the JVM's default trust store, validity period, and algorithm
+     * constraints all remain fully enforced; revocation posture is unchanged from whatever the
+     * default PKIX trust manager already applies - the {@code TrustManagerFactory.init((KeyStore)
+     * null)} call this method uses does not itself enable revocation checking - see
      * {@link HostnameVerificationRelaxingTrustManager} for the mechanism.
      * <p>
      * This context is <strong>strictly opt-in</strong> and is not reachable without an explicit

--- a/cui-http-core/src/main/java/de/cuioss/http/client/handler/SecureSSLContextProvider.java
+++ b/cui-http-core/src/main/java/de/cuioss/http/client/handler/SecureSSLContextProvider.java
@@ -208,6 +208,48 @@ public record SecureSSLContextProvider(String minimumTlsVersion) {
     }
 
     /**
+     * Creates an SSLContext that is identical to {@link #createSecureSSLContext()} except that TLS
+     * hostname/endpoint-identification checks are skipped.
+     * <p>
+     * This method:
+     * <ol>
+     *   <li>Creates an SSLContext instance with the secure protocol version</li>
+     *   <li>Initializes a TrustManagerFactory with the default algorithm</li>
+     *   <li>Configures the TrustManagerFactory to use the default trust store</li>
+     *   <li>Wraps the resulting trust managers in
+     *       {@link HostnameVerificationRelaxingTrustManager}</li>
+     *   <li>Initializes the SSLContext with the wrapped trust managers and a secure random source</li>
+     * </ol>
+     * <p>
+     * <strong>Hostname/endpoint-identification matching is the only check that is relaxed.</strong>
+     * Certificate-chain trust against the JVM's default trust store, validity period, revocation
+     * posture, and algorithm constraints all remain fully enforced - see
+     * {@link HostnameVerificationRelaxingTrustManager} for the mechanism.
+     * <p>
+     * This context is <strong>strictly opt-in</strong> and is not reachable without an explicit
+     * {@code HttpHandlerBuilder.verifyHostname(false)}. It removes the protection against a peer
+     * presenting an otherwise valid certificate issued for a <em>different</em> host, so it must
+     * only be used where that risk is understood and accepted.
+     *
+     * @return a configured SSLContext that uses a secure TLS protocol version and skips hostname
+     *         verification (never null)
+     * @throws IllegalStateException if the hostname-relaxed SSLContext cannot be created
+     */
+    public SSLContext createHostnameRelaxedSSLContext() {
+        try {
+            SSLContext relaxedContext = SSLContext.getInstance(minimumTlsVersion);
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init((KeyStore) null);
+            TrustManager[] relaxedTrustManagers =
+                    HostnameVerificationRelaxingTrustManager.relaxHostnameVerification(trustManagerFactory.getTrustManagers());
+            relaxedContext.init(null, relaxedTrustManagers, new SecureRandom());
+            return relaxedContext;
+        } catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
+            throw new IllegalStateException("Failed to create a hostname-relaxed SSL context", e);
+        }
+    }
+
+    /**
      * Returns an SSLContext for HTTPS, honoring a caller-supplied context as-is.
      * <p>
      * This method:

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/HostnameVerificationRelaxingTrustManagerTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/HostnameVerificationRelaxingTrustManagerTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.client.handler;
+
+import okhttp3.tls.HandshakeCertificates;
+import okhttp3.tls.HeldCertificate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.net.InetSocketAddress;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Behavioural proof for {@link HostnameVerificationRelaxingTrustManager}.
+ *
+ * <p>The tests drive a real TLS handshake against the shared {@link OneShotTlsServer} helper with
+ * the client's endpoint-identification algorithm pinned to {@code "HTTPS"} - the setting that makes
+ * hostname matching happen at all. A matched positive/negative control pair proves the wrapper is
+ * the only reason a mismatched SAN is accepted, and the remaining cases prove that chain trust and
+ * validity-period enforcement survive the relaxation.</p>
+ *
+ * <p>No {@code javax.net.ssl.trustStore} system property is mutated: the client trust material is
+ * built per test from okhttp {@link HandshakeCertificates}.</p>
+ */
+@DisplayName("HostnameVerificationRelaxingTrustManager relaxes hostname checks only")
+class HostnameVerificationRelaxingTrustManagerTest {
+
+    private static final long ONE_DAY_MILLIS = TimeUnit.DAYS.toMillis(1);
+
+    @Test
+    @DisplayName("Should wrap extended trust managers and pass other entries through unchanged")
+    void shouldWrapExtendedTrustManagersOnly() {
+        HeldCertificate anchor = new HeldCertificate.Builder().commonName("anchor").build();
+        TrustManager extended = platformTrustManager(anchor);
+        TrustManager plain = new PlainTrustManager();
+
+        TrustManager[] relaxed = HostnameVerificationRelaxingTrustManager
+                .relaxHostnameVerification(new TrustManager[]{extended, plain});
+
+        assertAll("relaxHostnameVerification wrapping",
+                () -> assertEquals(2, relaxed.length, "The wrapped array must keep its length"),
+                () -> assertInstanceOf(HostnameVerificationRelaxingTrustManager.class, relaxed[0],
+                        "An X509ExtendedTrustManager entry must be wrapped"),
+                () -> assertInstanceOf(X509ExtendedTrustManager.class, extended,
+                        "The platform trust manager is expected to be an X509ExtendedTrustManager"),
+                () -> assertSame(plain, relaxed[1],
+                        "A non-extended entry carries no identity context and must pass through unchanged"));
+    }
+
+    @Test
+    @DisplayName("Should accept a mismatched-SAN certificate when the wrapper is applied")
+    void shouldAcceptMismatchedHostnameWhenRelaxed() throws Exception {
+        HeldCertificate ca = certificateAuthority();
+        HeldCertificate leaf = leafSignedBy(ca, "wrong.host.invalid");
+
+        try (OneShotTlsServer server = OneShotTlsServer.start(leaf)) {
+            TrustManager[] relaxed = HostnameVerificationRelaxingTrustManager
+                    .relaxHostnameVerification(new TrustManager[]{platformTrustManager(ca)});
+
+            assertDoesNotThrow(() -> handshake(relaxed, server.port()),
+                    "The relaxing wrapper must accept a certificate whose SAN does not match the host");
+        }
+    }
+
+    @Test
+    @DisplayName("Should reject a mismatched-SAN certificate without the wrapper (control)")
+    void shouldRejectMismatchedHostnameWithoutWrapper() throws Exception {
+        HeldCertificate ca = certificateAuthority();
+        HeldCertificate leaf = leafSignedBy(ca, "wrong.host.invalid");
+
+        try (OneShotTlsServer server = OneShotTlsServer.start(leaf)) {
+            TrustManager[] strict = {platformTrustManager(ca)};
+
+            assertThrows(SSLHandshakeException.class, () -> handshake(strict, server.port()),
+                    "Without the wrapper the same certificate must be rejected - "
+                            + "otherwise the positive case proves nothing");
+        }
+    }
+
+    @Test
+    @DisplayName("Should still reject a certificate signed by an untrusted CA when relaxed")
+    void shouldRejectUntrustedCaWhenRelaxed() throws Exception {
+        HeldCertificate servingCa = certificateAuthority();
+        HeldCertificate otherCa = certificateAuthority();
+        HeldCertificate leaf = leafSignedBy(servingCa, "localhost");
+
+        try (OneShotTlsServer server = OneShotTlsServer.start(leaf)) {
+            TrustManager[] relaxed = HostnameVerificationRelaxingTrustManager
+                    .relaxHostnameVerification(new TrustManager[]{platformTrustManager(otherCa)});
+
+            assertThrows(SSLHandshakeException.class, () -> handshake(relaxed, server.port()),
+                    "Chain trust must survive the relaxation: an unknown CA must still be rejected");
+        }
+    }
+
+    @Test
+    @DisplayName("Should still reject an expired certificate when relaxed")
+    void shouldRejectExpiredCertificateWhenRelaxed() throws Exception {
+        HeldCertificate ca = certificateAuthority();
+        long now = System.currentTimeMillis();
+        HeldCertificate expiredLeaf = new HeldCertificate.Builder()
+                .signedBy(ca)
+                .commonName("localhost")
+                .addSubjectAlternativeName("localhost")
+                .validityInterval(now - 2 * ONE_DAY_MILLIS, now - ONE_DAY_MILLIS)
+                .build();
+
+        try (OneShotTlsServer server = OneShotTlsServer.start(expiredLeaf)) {
+            TrustManager[] relaxed = HostnameVerificationRelaxingTrustManager
+                    .relaxHostnameVerification(new TrustManager[]{platformTrustManager(ca)});
+
+            assertThrows(SSLHandshakeException.class, () -> handshake(relaxed, server.port()),
+                    "Validity-period enforcement must survive the relaxation");
+        }
+    }
+
+    @Test
+    @DisplayName("Should still reject a not-yet-valid certificate when relaxed")
+    void shouldRejectNotYetValidCertificateWhenRelaxed() throws Exception {
+        HeldCertificate ca = certificateAuthority();
+        long now = System.currentTimeMillis();
+        HeldCertificate futureLeaf = new HeldCertificate.Builder()
+                .signedBy(ca)
+                .commonName("localhost")
+                .addSubjectAlternativeName("localhost")
+                .validityInterval(now + ONE_DAY_MILLIS, now + 2 * ONE_DAY_MILLIS)
+                .build();
+
+        try (OneShotTlsServer server = OneShotTlsServer.start(futureLeaf)) {
+            TrustManager[] relaxed = HostnameVerificationRelaxingTrustManager
+                    .relaxHostnameVerification(new TrustManager[]{platformTrustManager(ca)});
+
+            assertThrows(SSLHandshakeException.class, () -> handshake(relaxed, server.port()),
+                    "A not-yet-valid certificate must still be rejected under the relaxing wrapper");
+        }
+    }
+
+    /**
+     * Opens a real TLS connection to {@code localhost:port} using the supplied trust managers with
+     * the endpoint-identification algorithm pinned to {@code "HTTPS"} - the switch that makes the
+     * JSSE trust manager perform hostname matching in the first place.
+     */
+    private static void handshake(TrustManager[] trustManagers, int port) throws Exception {
+        SSLContext context = SSLContext.getInstance(SecureSSLContextProvider.TLS_V1_2);
+        context.init(null, trustManagers, new SecureRandom());
+        try (SSLSocket socket = (SSLSocket) context.getSocketFactory().createSocket()) {
+            SSLParameters parameters = socket.getSSLParameters();
+            parameters.setEndpointIdentificationAlgorithm("HTTPS");
+            socket.setSSLParameters(parameters);
+            socket.setSoTimeout(5_000);
+            socket.connect(new InetSocketAddress("localhost", port), 5_000);
+            socket.startHandshake();
+        }
+    }
+
+    /**
+     * Builds the platform trust manager that trusts exactly the given certificate as a trust anchor.
+     */
+    private static TrustManager platformTrustManager(HeldCertificate anchor) {
+        return new HandshakeCertificates.Builder()
+                .addTrustedCertificate(anchor.certificate())
+                .build()
+                .trustManager();
+    }
+
+    private static HeldCertificate certificateAuthority() {
+        return new HeldCertificate.Builder()
+                .certificateAuthority(0)
+                .commonName("cui-http-test-ca")
+                .build();
+    }
+
+    private static HeldCertificate leafSignedBy(HeldCertificate ca, String hostname) {
+        return new HeldCertificate.Builder()
+                .signedBy(ca)
+                .commonName(hostname)
+                .addSubjectAlternativeName(hostname)
+                .build();
+    }
+
+    /**
+     * A trust manager that is deliberately <em>not</em> an {@link X509ExtendedTrustManager}, used to
+     * prove that {@code relaxHostnameVerification} passes such entries through untouched.
+     */
+    private static final class PlainTrustManager implements X509TrustManager {
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+            // no-op: never consulted by these tests
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+            // no-op: never consulted by these tests
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    }
+}

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/HostnameVerificationRelaxingTrustManagerTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/HostnameVerificationRelaxingTrustManagerTest.java
@@ -20,24 +20,13 @@ import okhttp3.tls.HeldCertificate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLParameters;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509ExtendedTrustManager;
-import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.*;
 import java.net.InetSocketAddress;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Behavioural proof for {@link HostnameVerificationRelaxingTrustManager}.

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerHostnameVerificationTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerHostnameVerificationTest.java
@@ -21,14 +21,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLServerSocket;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.Socket;
-import java.nio.charset.StandardCharsets;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -42,6 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * certificate whose SAN does <em>not</em> match the connected host is rejected, while an otherwise
  * identical matching certificate is accepted - so a future {@code SSLParameters} refactor cannot
  * silently disable hostname verification.</p>
+ *
+ * <p>These tests pin the <em>default-on</em> hostname-verification behaviour; the in-JVM TLS server
+ * helper they drive now lives in the shared {@link OneShotTlsServer} class so sibling tests in this
+ * package can reuse the single implementation.</p>
  */
 @DisplayName("HttpHandler TLS hostname verification (F-19)")
 class HttpHandlerHostnameVerificationTest {
@@ -106,60 +102,5 @@ class HttpHandlerHostnameVerificationTest {
                 .addTrustedCertificate(cert.certificate())
                 .build()
                 .sslContext();
-    }
-
-    /**
-     * A minimal single-connection TLS server that presents the supplied certificate and answers the
-     * first request with an empty {@code 200 OK}. Runs its accept loop on a background thread.
-     */
-    private static final class OneShotTlsServer implements AutoCloseable {
-
-        private final SSLServerSocket serverSocket;
-        private final ExecutorService executor;
-
-        private OneShotTlsServer(SSLServerSocket serverSocket, ExecutorService executor) {
-            this.serverSocket = serverSocket;
-            this.executor = executor;
-        }
-
-        static OneShotTlsServer start(HeldCertificate cert) throws IOException {
-            SSLContext serverContext = new HandshakeCertificates.Builder()
-                    .heldCertificate(cert)
-                    .build()
-                    .sslContext();
-            SSLServerSocket socket = (SSLServerSocket) serverContext.getServerSocketFactory()
-                    .createServerSocket(0);
-            ExecutorService executor = Executors.newSingleThreadExecutor();
-            OneShotTlsServer server = new OneShotTlsServer(socket, executor);
-            executor.submit(server::serveOnce);
-            return server;
-        }
-
-        private void serveOnce() {
-            try (Socket client = serverSocket.accept();
-                 InputStream in = client.getInputStream();
-                 OutputStream out = client.getOutputStream()) {
-                // Drain the request line/headers (best effort) so the client can finish sending.
-                byte[] buffer = new byte[1024];
-                if (in.read(buffer) > 0) {
-                    // ignore contents; we only need the request to arrive
-                }
-                out.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
-                        .getBytes(StandardCharsets.US_ASCII));
-                out.flush();
-            } catch (IOException e) {
-                // Expected when the handshake is rejected by the client (hostname mismatch).
-            }
-        }
-
-        int port() {
-            return serverSocket.getLocalPort();
-        }
-
-        @Override
-        public void close() throws IOException {
-            executor.shutdownNow();
-            serverSocket.close();
-        }
     }
 }

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerTest.java
@@ -702,6 +702,29 @@ class HttpHandlerTest {
         }
 
         @Test
+        @DisplayName("asBuilder().verifyHostname(true) must not silently keep the relaxed context")
+        void shouldDiscardRelaxedContextWhenReVerifyingHostname() {
+            HttpHandler relaxed = HttpHandler.builder()
+                    .uri(VALID_URL)
+                    .verifyHostname(false)
+                    .build();
+            SSLContext relaxedContext = relaxed.getSslContext();
+
+            HttpHandler reVerified = relaxed.asBuilder()
+                    .uri(VALID_URL)
+                    .verifyHostname(true)
+                    .build();
+
+            assertAll("re-verified handler must not reuse the relaxed context",
+                    () -> assertTrue(reVerified.isVerifyHostname(),
+                            "verifyHostname(true) must be reflected on the rebuilt handler"),
+                    () -> assertNotSame(relaxedContext, reVerified.getSslContext(),
+                            "A handler that re-enables hostname verification must not silently keep "
+                                    + "the hostname-relaxed SSLContext carried over from asBuilder(); "
+                                    + "it must be discarded in favor of a fresh secure context"));
+        }
+
+        @Test
         @DisplayName("Caller-supplied provenance survives an asBuilder round-trip")
         void shouldKeepCallerSuppliedProvenanceThroughAsBuilder() throws Exception {
             HttpHandler handler = HttpHandler.builder()

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/HttpHandlerTest.java
@@ -613,6 +613,147 @@ class HttpHandlerTest {
     }
 
     @Nested
+    @DisplayName("Hostname verification policy")
+    class HostnameVerificationPolicy {
+
+        @Test
+        @DisplayName("Hostname verification is on by default")
+        void shouldVerifyHostnameByDefault() {
+            HttpHandler handler = HttpHandler.builder().uri(VALID_URL).build();
+
+            assertTrue(handler.isVerifyHostname(),
+                    "Hostname verification must default to enabled");
+        }
+
+        @Test
+        @DisplayName("verifyHostname(false) builds an https handler and logs the HTTP-116 WARN")
+        void shouldBuildRelaxedHandler() {
+            HttpHandler handler = HttpHandler.builder()
+                    .uri(VALID_URL)
+                    .verifyHostname(false)
+                    .build();
+
+            assertAll("relaxed handler",
+                    () -> assertFalse(handler.isVerifyHostname(),
+                            "The opt-in must be reflected on the handler"),
+                    () -> assertNotNull(handler.getSslContext(),
+                            "A relaxed https handler must still carry an SSL context"),
+                    () -> LogAsserts.assertLogMessagePresentContaining(TestLogLevel.WARN,
+                            "verifyHostname=false"));
+        }
+
+        @Test
+        @DisplayName("verifyHostname(false) with a caller-supplied sslContext is rejected")
+        void shouldRejectRelaxationWithCallerSuppliedContext() throws Exception {
+            var builder = HttpHandler.builder()
+                    .uri(VALID_URL)
+                    .sslContext(SSLContext.getDefault())
+                    .verifyHostname(false);
+
+            var exception = assertThrows(IllegalArgumentException.class, builder::build);
+
+            assertAll("rejection message names both knobs",
+                    () -> assertTrue(exception.getMessage().contains("verifyHostname(false)"),
+                            "Message must name the verifyHostname knob: " + exception.getMessage()),
+                    () -> assertTrue(exception.getMessage().contains("sslContext"),
+                            "Message must name the sslContext knob: " + exception.getMessage()));
+        }
+
+        @Test
+        @DisplayName("A caller-supplied sslContext still builds with verification enabled")
+        void shouldAcceptCallerSuppliedContextWithVerification() throws Exception {
+            SSLContext callerContext = SSLContext.getDefault();
+
+            HttpHandler explicit = HttpHandler.builder()
+                    .uri(VALID_URL)
+                    .sslContext(callerContext)
+                    .verifyHostname(true)
+                    .build();
+            HttpHandler implicit = HttpHandler.builder()
+                    .uri(VALID_URL)
+                    .sslContext(callerContext)
+                    .build();
+
+            assertAll("caller-supplied context with verification",
+                    () -> assertSame(callerContext, explicit.getSslContext(),
+                            "The caller-supplied context must be preserved"),
+                    () -> assertSame(callerContext, implicit.getSslContext(),
+                            "The knob-absent form must behave like verifyHostname(true)"),
+                    () -> assertTrue(implicit.isVerifyHostname(),
+                            "The knob-absent form must keep verification enabled"));
+        }
+
+        @Test
+        @DisplayName("asBuilder round-trips a relaxed handler without tripping the rejection")
+        void shouldRoundTripRelaxedHandler() {
+            HttpHandler handler = HttpHandler.builder()
+                    .uri(VALID_URL)
+                    .verifyHostname(false)
+                    .build();
+
+            HttpHandler rebuilt = assertDoesNotThrow(() -> handler.asBuilder().uri(VALID_URL).build(),
+                    "A derived context must not be treated as caller-supplied");
+
+            assertAll("round-tripped relaxed handler",
+                    () -> assertFalse(rebuilt.isVerifyHostname(),
+                            "asBuilder() must preserve the verifyHostname opt-in"),
+                    () -> assertNotNull(rebuilt.getSslContext(),
+                            "The rebuilt handler must still carry an SSL context"));
+        }
+
+        @Test
+        @DisplayName("Caller-supplied provenance survives an asBuilder round-trip")
+        void shouldKeepCallerSuppliedProvenanceThroughAsBuilder() throws Exception {
+            HttpHandler handler = HttpHandler.builder()
+                    .uri(VALID_URL)
+                    .sslContext(SSLContext.getDefault())
+                    .build();
+
+            var builder = handler.asBuilder().uri(VALID_URL).verifyHostname(false);
+
+            var exception = assertThrows(IllegalArgumentException.class, builder::build,
+                    "A genuinely caller-supplied context must keep tripping the rejection after cloning");
+            assertTrue(exception.getMessage().contains("verifyHostname(false)"),
+                    "The failure must be the mutual-exclusion rejection: " + exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("toString renders the hostname-verification setting")
+        void shouldRenderVerifyHostnameInToString() {
+            HttpHandler relaxed = HttpHandler.builder()
+                    .uri(VALID_URL)
+                    .verifyHostname(false)
+                    .build();
+
+            assertTrue(relaxed.toString().contains("verifyHostname=false"),
+                    "The opt-in must be visible in toString: " + relaxed);
+        }
+
+        @Test
+        @DisplayName("Handlers differing only in verifyHostname are not equal")
+        void shouldTreatVerifyHostnameAsConfigurationIdentity() {
+            HttpHandler strict = HttpHandler.builder().uri(VALID_URL).build();
+            HttpHandler relaxed = HttpHandler.builder().uri(VALID_URL).verifyHostname(false).build();
+
+            assertNotEquals(strict, relaxed,
+                    "verifyHostname is part of the handler's configuration identity");
+        }
+
+        @Test
+        @DisplayName("Context provenance alone does not change configuration identity")
+        void shouldIgnoreContextProvenanceForEquality() throws Exception {
+            HttpHandler derivedContext = HttpHandler.builder().uri(VALID_URL).build();
+            HttpHandler callerContext = HttpHandler.builder()
+                    .uri(VALID_URL)
+                    .sslContext(SSLContext.getDefault())
+                    .build();
+
+            assertEquals(derivedContext, callerContext,
+                    "sslContext and its provenance are excluded from equals/hashCode");
+        }
+    }
+
+    @Nested
     @DisplayName("equals/hashCode")
     class EqualsHashCode {
 

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/OneShotTlsServer.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/OneShotTlsServer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.http.client.handler;
+
+import okhttp3.tls.HandshakeCertificates;
+import okhttp3.tls.HeldCertificate;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLServerSocket;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * A minimal single-connection TLS server that presents the supplied certificate and answers the
+ * first request with an empty {@code 200 OK}. Runs its accept loop on a background thread.
+ */
+final class OneShotTlsServer implements AutoCloseable {
+
+    private final SSLServerSocket serverSocket;
+    private final ExecutorService executor;
+
+    private OneShotTlsServer(SSLServerSocket serverSocket, ExecutorService executor) {
+        this.serverSocket = serverSocket;
+        this.executor = executor;
+    }
+
+    static OneShotTlsServer start(HeldCertificate cert) throws IOException {
+        SSLContext serverContext = new HandshakeCertificates.Builder()
+                .heldCertificate(cert)
+                .build()
+                .sslContext();
+        SSLServerSocket socket = (SSLServerSocket) serverContext.getServerSocketFactory()
+                .createServerSocket(0);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        OneShotTlsServer server = new OneShotTlsServer(socket, executor);
+        executor.submit(server::serveOnce);
+        return server;
+    }
+
+    private void serveOnce() {
+        try (Socket client = serverSocket.accept();
+             InputStream in = client.getInputStream();
+             OutputStream out = client.getOutputStream()) {
+            // Drain the request line/headers (best effort) so the client can finish sending.
+            byte[] buffer = new byte[1024];
+            if (in.read(buffer) > 0) {
+                // ignore contents; we only need the request to arrive
+            }
+            out.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    .getBytes(StandardCharsets.US_ASCII));
+            out.flush();
+        } catch (IOException e) {
+            // Expected when the handshake is rejected by the client (hostname mismatch).
+        }
+    }
+
+    int port() {
+        return serverSocket.getLocalPort();
+    }
+
+    @Override
+    public void close() throws IOException {
+        executor.shutdownNow();
+        serverSocket.close();
+    }
+}

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/SecureSSLContextProviderTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/SecureSSLContextProviderTest.java
@@ -187,6 +187,37 @@ class SecureSSLContextProviderTest {
     }
 
     @Test
+    @DisplayName("Should create hostname-relaxed SSL context honoring the configured minimum")
+    void shouldCreateHostnameRelaxedSSLContext() {
+        SecureSSLContextProvider provider = new SecureSSLContextProvider(SecureSSLContextProvider.TLS_V1_3);
+
+        SSLContext relaxed = provider.createHostnameRelaxedSSLContext();
+
+        assertAll("hostname-relaxed context",
+                () -> assertNotNull(relaxed, "Hostname-relaxed context should not be null"),
+                () -> assertEquals(SecureSSLContextProvider.TLS_V1_3, relaxed.getProtocol(),
+                        "Hostname-relaxed context must use the configured minimum TLS version"),
+                () -> assertNotNull(relaxed.getSocketFactory(),
+                        "Hostname-relaxed context must be initialized and usable"));
+    }
+
+    @Test
+    @DisplayName("Should create a distinct instance per hostname-relaxed context request")
+    void shouldCreateDistinctHostnameRelaxedContexts() throws Exception {
+        SecureSSLContextProvider provider = new SecureSSLContextProvider();
+
+        SSLContext relaxed = provider.createHostnameRelaxedSSLContext();
+
+        assertAll("hostname-relaxed context identity",
+                () -> assertNotSame(relaxed, provider.createHostnameRelaxedSSLContext(),
+                        "Each call must yield a fresh context"),
+                () -> assertNotSame(relaxed, provider.createSecureSSLContext(),
+                        "The relaxed context must never be the strict context instance"),
+                () -> assertEquals(SecureSSLContextProvider.TLS_V1_2, relaxed.getProtocol(),
+                        "The default minimum TLS version must be honored"));
+    }
+
+    @Test
     @DisplayName("Should throw exception for invalid minimum TLS version")
     void shouldThrowExceptionForInvalidMinimumTlsVersion() {
         assertThrows(IllegalArgumentException.class, () -> new SecureSSLContextProvider("invalid"));

--- a/cui-http-core/src/test/java/de/cuioss/http/client/handler/SecureSSLContextProviderTest.java
+++ b/cui-http-core/src/test/java/de/cuioss/http/client/handler/SecureSSLContextProviderTest.java
@@ -203,7 +203,7 @@ class SecureSSLContextProviderTest {
 
     @Test
     @DisplayName("Should create a distinct instance per hostname-relaxed context request")
-    void shouldCreateDistinctHostnameRelaxedContexts() throws Exception {
+    void shouldCreateDistinctHostnameRelaxedContexts() {
         SecureSSLContextProvider provider = new SecureSSLContextProvider();
 
         SSLContext relaxed = provider.createHostnameRelaxedSSLContext();

--- a/doc/LogMessages.adoc
+++ b/doc/LogMessages.adoc
@@ -13,7 +13,7 @@ Module: `de.cuioss.http`
 
 LogMessages Classes:
 
-- `de.cuioss.http.client.HttpLogMessages` - HTTP client operations (HTTP-106–108, HTTP-110–115, HTTP-200–201)
+- `de.cuioss.http.client.HttpLogMessages` - HTTP client operations (HTTP-106–108, HTTP-110–116, HTTP-200–201)
 - `de.cuioss.http.forwarded.ForwardedLogMessages` - Forwarded / reverse-proxy header resolution (HTTP-120–125) - source: xref:../cui-http-core/src/main/java/de/cuioss/http/forwarded/ForwardedLogMessages.java[ForwardedLogMessages.java]
 
 == HttpLogMessages
@@ -68,6 +68,11 @@ LogMessages Classes:
 |Handler
 |Using cleartext HTTP for %s (allowInsecureHttp=true); data is transmitted unencrypted
 |Logged when a cleartext HTTP handler is built under the allowInsecureHttp opt-in. Parameters: URI.
+
+|HTTP-116
+|Handler
+|TLS hostname verification disabled for %s (verifyHostname=false); certificate chain validation remains enforced
+|Logged when an HTTPS handler is built under the verifyHostname(false) opt-in. Parameters: URI.
 |===
 
 === ERROR Level (200-299)

--- a/doc/adr/0007-TLS_hostname-verification_relaxation_via_a_delegating_trust_manager_not_a_JVM-wide_lever.adoc
+++ b/doc/adr/0007-TLS_hostname-verification_relaxation_via_a_delegating_trust_manager_not_a_JVM-wide_lever.adoc
@@ -1,0 +1,144 @@
+= ADR-0007: TLS hostname-verification relaxation via a delegating trust manager, not a JVM-wide lever
+:toc: left
+:toclevels: 2
+:sectnums:
+
+// adr-metadata
+// summary: Hostname-verification relaxation is scoped per handler via a delegating X509ExtendedTrustManager that forwards to the platform trust manager with a null SSLEngine/Socket, never via a JVM-wide or trust-all mechanism.
+// tags: security, tls, trust-boundary, http-client
+// affects: cui-http-core
+// supersedes:
+// end-adr-metadata
+
+== Status
+
+Proposed
+
+== Context
+
+An HTTP client sometimes needs to trust a server certificate chain while
+skipping *identity* verification — the server's hostname or SAN entries do not
+match the certificate presented (self-signed local endpoints, internal
+service meshes addressed by IP, test doubles). The architectural question is
+where the boundary between "identity checking" and "chain trust" is drawn,
+and how narrowly a caller can be allowed to cross it.
+
+TLS validation bundles several independent checks — certificate chain trust,
+expiry, algorithm constraints, and endpoint identity (hostname/SAN) matching —
+behind a single `SSLContext`. Any mechanism that relaxes one of these checks
+risks silently relaxing the others unless the relaxation is deliberately
+scoped to the one check it names. A relaxation lever that is coarser than the
+problem it solves creates a residual attack surface (an on-path attacker who
+merely holds *any* trusted-CA-signed certificate, rather than the endpoint's
+own) that the caller did not ask for and may not realize they accepted.
+
+A second axis is scope: whether the relaxation is a property of one HTTP
+client configuration, or a property of the JVM process. A process-global
+lever cannot be limited to the one endpoint that needs it — every other TLS
+connection in the same JVM, including ones the caller does not control,
+inherits the relaxation.
+
+== Decision
+
+Hostname-verification relaxation is implemented as an opt-in, per-handler
+setting realized by a package-private `X509ExtendedTrustManager` that
+delegates `checkServerTrusted` / `checkClientTrusted` to the platform trust
+manager, passing a `null` `SSLEngine` / `Socket` argument. This is the
+JSSE-documented contract under which the platform trust manager's endpoint
+identification step is skipped while chain trust, expiry, and algorithm
+constraint enforcement continue to run unchanged. Revocation posture is
+unaffected — it remains whatever the JVM's default PKIX configuration
+provides.
+
+The relaxation is scoped to the `SSLContext` the client's own provider builds
+from the default JVM trust store. A caller-supplied `SSLContext` combined
+with the relaxation setting is rejected at build time, keyed off an explicit
+provenance flag recorded when the context was supplied by the caller —
+`sslContextCallerSupplied` — rather than off a null-check on the context
+field. The context field is not a reliable discriminator: the client also
+stores its own internally-derived context in that same field, and the
+builder's copy-constructor path re-injects that derived context when a
+configuration is round-tripped. A null-check would misclassify that
+round-trip as caller-supplied and reject a request that never set a caller
+context. Because a relaxed context is itself a *derived* context, the
+provenance tracking is not limited to the caller-supplied case: the DERIVED
+relaxed context must also be tracked, so that re-deriving a configuration
+with hostname verification switched back on discards the stale relaxed
+context rather than silently returning a configuration that reports
+verification as enabled while an already-built relaxed context underneath it
+still skips it.
+
+== Consequences
+
+=== Positive
+
+* The relaxation is provably scoped to identity checking alone — chain
+  trust, expiry, and algorithm constraints stay enforced by the platform
+  trust manager on every call, because the delegating trust manager performs
+  no logic of its own beyond substituting the engine/socket argument.
+* The relaxation is opt-in per client configuration; unrelated TLS
+  connections in the same process are unaffected.
+* The mutual-exclusion rule between a caller-supplied context and the
+  relaxation setting is enforced at build time rather than left as a
+  documentation-only caveat, closing the path where a caller unknowingly
+  gets a context that is both externally managed and identity-relaxed.
+
+=== Negative
+
+* The provenance flag is additional state a maintainer must keep consistent
+  with the context field across every path that sets, re-derives, or copies
+  the context (initial build, `asBuilder()`, and any future context-mutating
+  operation). A path that sets the context field without updating the
+  provenance flag reintroduces the misclassification this decision exists to
+  prevent.
+
+=== Risks
+
+* Revocation checking is inherited from the JVM default PKIX behavior and is
+  not independently hardened by this mechanism; a deployment relying on
+  strict revocation enforcement must configure that separately from this
+  relaxation.
+* A caller who opts into the relaxation still accepts any certificate chain
+  trusted by the default JVM trust store, presented by any host — the
+  narrowing this decision provides is to identity checking only, not to
+  which chains are trusted overall.
+
+== Alternatives Considered
+
+A trust-all `X509TrustManager` that accepts every certificate chain
+unconditionally would also skip hostname verification, but it additionally
+disables chain trust validation — a strictly larger relaxation than the
+problem calls for. It was rejected because it removes protection the caller
+never asked to give up.
+
+The JVM-wide system property
+`jdk.internal.httpclient.disableHostnameVerification` relaxes hostname
+verification for the entire process rather than for one client
+configuration. It was rejected because it cannot be scoped per handler or
+per endpoint, and because it is documented by the JDK as intended for
+testing rather than as a supported production lever — a plan-scoped opt-in
+setting has no way to bound the property's process-wide reach.
+
+Setting `SSLParameters.setEndpointIdentificationAlgorithm(null)` on the
+client's SSL parameters was considered as the standard JSSE-documented way to
+disable endpoint identification. It was rejected because it is provably
+ineffective against the JDK's built-in HTTP client: the client's internal
+async SSL connection setup unconditionally overwrites the endpoint
+identification algorithm with `"HTTPS"` after copying the caller-supplied
+parameters, so a caller-set `null` value is silently discarded before the
+handshake runs.
+
+These three alternatives fail in the same class of way: each either
+over-relaxes the trust boundary beyond identity checking, or fails to
+confine the relaxation to the one client configuration that requested it, or
+is silently overridden by the platform before it can take effect. The
+delegating-trust-manager mechanism avoids all three failure modes by
+operating entirely within the one JSSE-documented seam — the trust manager's
+`checkServerTrusted` engine/socket argument — that both scopes the
+relaxation to identity checking and survives the platform's own parameter
+handling.
+
+== References
+
+* `README.adoc` and `doc/client-handlers-readme.adoc` — client configuration
+  documentation for `HttpHandler` and `SecureSSLContextProvider`.

--- a/doc/adr/0008-Extend_a_Maven-Central-published_provider_surface_additively_even_under_a_plan-level_breaking-compatibility_setting.adoc
+++ b/doc/adr/0008-Extend_a_Maven-Central-published_provider_surface_additively_even_under_a_plan-level_breaking-compatibility_setting.adoc
@@ -1,0 +1,115 @@
+= ADR-0008: Extend a Maven-Central-published provider surface additively, even under a plan-level breaking-compatibility setting
+:toc: left
+:toclevels: 2
+:sectnums:
+
+// adr-metadata
+// summary: A published, externally-consumed provider (SecureSSLContextProvider) gains new capability via an additional method rather than a changed existing signature, regardless of the authoring plan's own breaking-compatibility posture.
+// tags: api-design, compatibility, ssl, provider-surface
+// affects: cui-http-core
+// supersedes:
+// end-adr-metadata
+
+== Status
+
+Proposed
+
+== Context
+
+A plan's `compatibility` setting (e.g. "breaking — clean-slate approach, no
+deprecation nor transitionary comments") governs how that plan's *own*
+internal invariants and shapes may change without preserving backward
+compatibility inside the change it is making. It answers "how freely may this
+plan restructure the surfaces it is actively reworking", not "how freely may
+this plan restructure every published surface it happens to touch".
+
+A provider class published to Maven Central and consumed by external,
+independently-versioned projects sits outside that plan-local scope: its
+existing method signatures are contract, already relied upon by call sites
+this repository does not control and cannot audit before release. Widening a
+plan's breaking-compatibility posture into an already-published, already-
+satisfied method signature imposes an unforced migration cost on every
+external consumer of that signature, for a benefit — internal shape
+uniformity — that a plan-scoped breaking setting was never meant to reach.
+
+The general architectural question this raises: when new capability is
+needed on a published provider type, does the new capability get folded into
+an existing published method's signature, or does it arrive as an additional
+method alongside the existing one?
+
+== Decision
+
+A published provider gains new capability through an additional method,
+never through an added or changed parameter on an existing published method
+signature — regardless of the authoring plan's own compatibility posture.
+`SecureSSLContextProvider` gains `createHostnameRelaxedSSLContext()` as a new
+method alongside the existing `getOrCreateSecureSSLContext(...)`, rather than
+an added parameter on that existing method.
+
+A plan's `compatibility: breaking` setting is scoped to the invariants and
+shapes the plan is actively reworking inside its own change — it is not a
+blanket license to make gratuitous, non-required changes to a call site that
+is already published and already fully served by its existing signature. The
+determining question for any published provider method is not "is this
+plan's compatibility posture permissive enough to change this", but "does
+the existing signature already serve every call site, including this plan's
+own new one, without modification" — when the answer is yes, the additive
+method is the only justified shape.
+
+== Consequences
+
+=== Positive
+
+* Every existing external consumer of `SecureSSLContextProvider`'s published
+  methods continues to compile and behave identically after this change —
+  no signature they depend on was touched.
+* The new capability is discoverable and self-describing at its own call
+  sites (`createHostnameRelaxedSSLContext()` names exactly what it returns),
+  rather than being an overload disambiguated only by a boolean or enum
+  parameter added to an existing, more general method.
+
+=== Negative
+
+* The provider type accumulates one additional public method per new
+  capability rather than folding capabilities into fewer, more parameterized
+  methods — a design that trades signature-surface breadth for consumer
+  stability.
+
+=== Risks
+
+* A future capability that is a small variation on an already-published
+  method could still be tempted toward parameter-widening instead of a new
+  method if this decision's rationale is not consulted; the risk is
+  reintroducing the exact breaking-signature pressure this decision exists
+  to close off.
+
+== Alternatives Considered
+
+Adding a boolean or enum parameter to the existing
+`getOrCreateSecureSSLContext(...)` signature was considered, since it keeps
+the provider's public method count from growing. It was rejected because it
+breaks the compiled signature every existing external consumer already
+depends on, for a change that a review of in-repository call sites found no
+call site requiring — the existing signature already fully serves every
+caller that does not need the new relaxed-context behavior.
+
+Treating the plan's `compatibility: breaking` setting as authorization to
+change the existing signature was considered, on the reasoning that the plan
+had already declared it was not preserving backward compatibility for this
+change. It was rejected because that setting governs the plan's own internal
+invariants and shapes, not the compiled contract of a type this repository
+publishes to Maven Central for consumption by independently-versioned
+external projects; a plan-local compatibility posture cannot retroactively
+authorize breaking a contract those external consumers already rely on.
+
+Both alternatives share the same underlying failure: each reaches for
+in-place modification of an already-satisfied, externally-consumed
+signature when an additive method fully solves the same problem without
+that cost. The unifying principle is that a published provider's
+compatibility posture is governed by its own consumers, not by the
+compatibility setting of whichever plan happens to be extending it next.
+
+== References
+
+* `README.adoc` and `doc/client-handlers-readme.adoc` — client configuration
+  documentation for `SecureSSLContextProvider`.

--- a/doc/client-handlers-readme.adoc
+++ b/doc/client-handlers-readme.adoc
@@ -53,6 +53,44 @@ HttpHandler.builder().uri("http://localhost:8080").allowInsecureHttp(true).build
 minimum and the generic `TLS` context both enforce `[TLSv1.2, TLSv1.3]` (deliberate); a caller
 cannot express "TLS 1.3-only" via the generic `TLS` string.
 
+*Hostname verification (opt-in relaxation):* the default is `verifyHostname(true)`. Setting
+`verifyHostname(false)` skips the TLS hostname/endpoint-identification check *only* - the match
+between the peer certificate's SAN/CN and the connected host. Certificate-chain trust, validity
+period (expiry), revocation posture, and algorithm constraints all remain fully enforced. The
+mechanism is a delegating `X509ExtendedTrustManager` that forwards `checkServerTrusted` to the
+platform trust manager with a `null` `SSLEngine`, the JSSE-documented contract under which the
+chain is still validated but no peer identity is available to match. The relaxation applies only
+to the SSL context the handler builds itself, so combining it with a caller-supplied
+`.sslContext(...)` is rejected at `build()` time with `IllegalArgumentException`. A WARN
+(`HTTP-116`) is logged for every handler built this way.
+
+The rejection keys off whether the *caller* supplied the context, not off the handler's own
+derived one, so `asBuilder()` round-trips a relaxed handler without tripping it.
+
+[source,java]
+----
+// Accepted: opt in to hostname relaxation on the handler's own derived context
+HttpHandler relaxed = HttpHandler.builder()
+        .uri("https://10.0.0.7/api")
+        .verifyHostname(false)
+        .build();
+
+// Round-trips cleanly - the derived context is not "caller-supplied"
+HttpHandler cloned = relaxed.asBuilder().uri("https://10.0.0.8/api").build();
+
+// Rejected: the relaxation cannot be applied to caller-owned trust material
+HttpHandler.builder()
+        .uri("https://10.0.0.7/api")
+        .sslContext(myCustomContext)
+        .verifyHostname(false)
+        .build(); // throws IllegalArgumentException
+----
+
+Two commonly reached-for alternatives are deliberately *not* supported and must not be used:
+the JVM-wide `jdk.internal.httpclient.disableHostnameVerification` system property (it is
+process-global and affects every client in the JVM), and a trust-all `X509TrustManager` (it
+discards chain validation entirely, which this opt-in specifically preserves).
+
 ==== xref:../cui-http-core/src/main/java/de/cuioss/http/client/adapter/package-info.java[HTTP Adapters (New Architecture)]
 
 Async-first HTTP client adapters with composable retry and caching.
@@ -70,7 +108,9 @@ See xref:../cui-http-core/src/main/java/de/cuioss/http/client/adapter/package-in
 
 ==== xref:../cui-http-core/src/main/java/de/cuioss/http/client/handler/SecureSSLContextProvider.java[SecureSSLContextProvider]
 
-Utility for creating TLS 1.2+ SSL contexts.
+Utility for creating TLS 1.2+ SSL contexts, including `createHostnameRelaxedSSLContext()` - the
+opt-in context backing `HttpHandlerBuilder.verifyHostname(false)`, which relaxes hostname
+matching only and keeps certificate-chain validation intact.
 
 === HTTP Status Classification
 

--- a/doc/client-handlers-readme.adoc
+++ b/doc/client-handlers-readme.adoc
@@ -56,13 +56,15 @@ cannot express "TLS 1.3-only" via the generic `TLS` string.
 *Hostname verification (opt-in relaxation):* the default is `verifyHostname(true)`. Setting
 `verifyHostname(false)` skips the TLS hostname/endpoint-identification check *only* - the match
 between the peer certificate's SAN/CN and the connected host. Certificate-chain trust, validity
-period (expiry), revocation posture, and algorithm constraints all remain fully enforced. The
-mechanism is a delegating `X509ExtendedTrustManager` that forwards `checkServerTrusted` to the
-platform trust manager with a `null` `SSLEngine`, the JSSE-documented contract under which the
-chain is still validated but no peer identity is available to match. The relaxation applies only
-to the SSL context the handler builds itself, so combining it with a caller-supplied
-`.sslContext(...)` is rejected at `build()` time with `IllegalArgumentException`. A WARN
-(`HTTP-116`) is logged for every handler built this way.
+period (expiry), and algorithm constraints all remain fully enforced; revocation posture is
+*unchanged* from whatever the JVM's default PKIX trust manager already applies - the JDK's default
+PKIX configuration does not itself enable revocation checking. The mechanism is a delegating
+`X509ExtendedTrustManager` that forwards `checkServerTrusted` to the platform trust manager with a
+`null` `SSLEngine`, the JSSE-documented contract under which the chain is still validated but no
+peer identity is available to match. The relaxation applies only to the SSL context the handler
+builds itself, so combining it with a caller-supplied `.sslContext(...)` is rejected at `build()`
+time with `IllegalArgumentException`. A WARN (`HTTP-116`) is logged for every handler built this
+way.
 
 The rejection keys off whether the *caller* supplied the context, not off the handler's own
 derived one, so `asBuilder()` round-trips a relaxed handler without tripping it.


### PR DESCRIPTION
## Summary

Adds an opt-in `HttpHandlerBuilder.verifyHostname(boolean)` knob (default `true`) that relaxes TLS
hostname verification only, while leaving certificate-chain validation, expiry, and algorithm-constraint
checks fully intact. This gives consumers connecting to internal DNS names, container service names, or
SAN-mismatched internal CAs a supported, first-class lever instead of a hand-rolled trust-all workaround.

## Changes

- `HttpHandlerBuilder.verifyHostname(boolean)` — new builder method, default `true` (verification on).
- `HostnameVerificationRelaxingTrustManager` — a delegating `X509ExtendedTrustManager` that forwards
  `checkServerTrusted` / `checkClientTrusted` to the platform trust manager with a `null` `SSLEngine`,
  per the documented null-engine contract (skips hostname/endpoint-identification checks only; chain
  trust, expiry, and algorithm constraints remain enforced).
- `verifyHostname(false)` applies only to the default JVM-trust-store `SSLContext` that `HttpHandler` /
  `SecureSSLContextProvider` builds itself when no caller-supplied `SSLContext` is set.
- `build()` throws `IllegalArgumentException` when both `.sslContext(...)` and `.verifyHostname(false)`
  are set on the same builder — the combination is rejected outright.
- New `HttpLogMessages` entry documenting the relaxation at build time.
- Documentation: README.adoc and doc/client-handlers-readme.adoc updated with the exact relaxation
  semantics (hostname-only, chain validation unaffected) and the `.sslContext(...)` +
  `.verifyHostname(false)` rejection; Javadoc added on the new builder method and the delegating
  trust-manager class.
- Tests: `HostnameVerificationRelaxingTrustManagerTest`, `HttpHandlerHostnameVerificationTest`, plus
  updates to `HttpHandlerTest` and `SecureSSLContextProviderTest`, using a new `OneShotTlsServer` test
  helper.

## Test Plan

- [ ] Verification command passed (`mvn verify -Ppre-commit`)
- [ ] Manual testing completed (if applicable)

## Related Issues

Closes #165

---
Generated by plan-finalize skill

## Intent

**Problem**: Consumers connecting to internal DNS names, container service names, or SAN-mismatched
internal CAs have no supported way to relax only hostname verification — the only workaround available
was a hand-rolled trust-all `SSLContext`, which also disables chain validation, expiry, and
algorithm-constraint checks. The JDK's own hostname-disabling lever
(`jdk.internal.httpclient.disableHostnameVerification`) is documented as test-only and process-global,
and `SSLParameters.setEndpointIdentificationAlgorithm(null)` is provably ineffective because the JDK
`HttpClient` unconditionally overwrites that field per connection.

**Chosen approach**: A new opt-in `HttpHandlerBuilder.verifyHostname(boolean)` knob, default `true`,
implemented via a delegating `X509ExtendedTrustManager` (`HostnameVerificationRelaxingTrustManager`)
that forwards `checkServerTrusted`/`checkClientTrusted` to the platform trust manager with a `null`
`SSLEngine` — the documented mechanism for skipping only hostname/endpoint-identification checks while
chain trust, expiry, and algorithm constraints stay enforced. The relaxation applies only to the
default JVM-trust-store `SSLContext` that `HttpHandler`/`SecureSSLContextProvider` builds itself; when
a caller supplies its own `SSLContext`, combining it with `verifyHostname(false)` is a build-time
`IllegalArgumentException` rather than a silently-ignored

_[Intent truncated — 1395 of 1817 characters shown; full outline in the plan workspace]_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `verifyHostname(false)` setting for HTTPS handlers.
  * Hostname checks can be relaxed while certificate-chain, validity, revocation, and algorithm validation remain enforced.
  * A warning is logged whenever hostname verification is disabled.
  * Incompatible combinations with a caller-provided SSL context are rejected.

* **Documentation**
  * Added guidance and examples for hostname-verification relaxation, including its security limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->